### PR TITLE
add shared error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
+![Run Spectral](https://github.com/digitalocean/apiv2-openapi/workflows/Run%20Spectral/badge.svg?branch=main)
+
 # apiv2-openapi
 OpenAPI v3 specification for DigitalOcean's public API v2.
 
 ## What's this?
 
-We're writing an OpenAPI v3 spec for our existing public API (v2). We're planning on publishing each resource's 
-endpoints as we complete them. Stay tuned for further developments.
+We are writing an OpenAPI v3 spec for our existing [APIv2](https://developers.digitalocean.com/documentation/v2/). Due to customer requests for an OpenAPI v3 spec, we decided to share our work as we go and will start releasing release candidates as we complete useful sets of endpoints.
+
+Right now, the repo contains our working files, which you can clone and browse using VS Code or any other editor that has robust support for `$ref`. We will also be providing a single file (bundled) version of the spec in the near future, as well as a Postman collection.
+
+We would love to hear from you how you plan to use the spec as well as any other spec related feedback you might like to provide in the issues.

--- a/resources/account/get_user_information.yml
+++ b/resources/account/get_user_information.yml
@@ -23,3 +23,12 @@ responses:
       application/json:
         schema:
           $ref: 'wrapped_account.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'

--- a/resources/ssh_keys/list_all_keys.yml
+++ b/resources/ssh_keys/list_all_keys.yml
@@ -18,3 +18,12 @@ parameters:
 responses:
   '200':
     $ref: 'responses/all_keys.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'

--- a/shared/models/error.yml
+++ b/shared/models/error.yml
@@ -1,0 +1,28 @@
+type: object
+
+properties:
+  id:
+    description: >-
+      A short identifier corresponding to the HTTP status code returned. For 
+      example, the ID for a response returning a 404 status code would be "not_found."
+    type: string
+    example: not_found
+
+  message:
+    description: >-
+      A message providing additional information about the error, including 
+      details to help resolve it when possible.
+    type: string
+    example: The resource you were accessing could not be found.
+
+  request_id:
+    description: >-
+      Optionally, some endpoints may include a request ID that should be 
+      provided when reporting bugs or opening support tickets to help 
+      identify the issue.
+    type: string
+    example: 4d9d8375-3c56-4925-a3e7-eb137fed17e9
+
+required:
+  - id
+  - message

--- a/shared/responses/not_found.yml
+++ b/shared/responses/not_found.yml
@@ -1,0 +1,17 @@
+description: The resource was not found.
+
+headers:
+  ratelimit-limit:
+    $ref: '../headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/error.yml'
+    example:
+      id: not_found
+      message: The resource you requested could not be found.

--- a/shared/responses/server_error.yml
+++ b/shared/responses/server_error.yml
@@ -1,0 +1,17 @@
+description: Server error.
+
+headers:
+  ratelimit-limit:
+    $ref: '../headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/error.yml'
+    example:
+      id: server_error
+      message: Unexpected server-side error

--- a/shared/responses/unauthorized.yml
+++ b/shared/responses/unauthorized.yml
@@ -1,0 +1,17 @@
+description: Unauthorized
+
+headers:
+  ratelimit-limit:
+    $ref: '../headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/error.yml'
+    example:
+      id: unauthorized
+      message: Unable to authenticate you.

--- a/shared/responses/unexpected_error.yml
+++ b/shared/responses/unexpected_error.yml
@@ -1,0 +1,17 @@
+description: Unexpected error
+
+headers:
+  ratelimit-limit:
+    $ref: '../headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/error.yml'
+    example:
+      id: im_a_teapot
+      message: how do you do?


### PR DESCRIPTION
I'll use the 404's in the next ssh_key endpoint. The 500 is there for @scotchneat . 

I've also added a default response that serves as a catchall for all remaining 4xx and 5xx responses. I punted on the enum for the response code as the API is too chaotic for that at the moment.

I added the examples as @scotchneat suggested. I didn't include `request_id` in examples at the `shared/responses` level, as whether a `request_id` is supplied varies by endpoint. It seemed to make sense to me that an endpoint that provides a `request_id` should provide an example in its path file, perhaps with info as to why? I'm unclear as to why some do and some don't.

Feel free to simply decide where you want to go with this PR, make the changes and merge them while I'm out on PTO (or merge the PR and submit a patch on top of it, or whatever). 
