### PR TITLE
use a specific version of spectral-action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: stoplightio/spectral-action@master
+      - uses: stoplightio/spectral-action@v0.6.1
         with:
           file_glob: "./DigitalOcean-public.v2.yaml"


### PR DESCRIPTION
Much as I like Spectral, I'd rather stick with a release rather than master 😄 