### PR TITLE
Only run lint on push to main, not feature branches.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Run Spectral
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+    - main
 
 jobs:
   lint:


### PR DESCRIPTION
When a branch used in a pull request is pushed to, we are currently running the linting GitHub Action twice: for the PR and for the push. The extra check is a bit noisy, and the original intention was to lint on the PR and pushes to main.