### PR TITLE
Adds POST/DELETE tags/{tag}/resources

### DIFF
--- a/DigitalOcean-public.v2.yaml
+++ b/DigitalOcean-public.v2.yaml
@@ -213,6 +213,12 @@ paths:
     delete:
       $ref: 'resources/tags/delete_tag.yml'
 
+  /tags/{tag_id}/resources:
+    post:
+      $ref: 'resources/tags/tag_resource.yml'
+    delete:
+      $ref: 'resources/tags/untag_resource.yml'
+
 components:
   securitySchemes:
     bearerAuth:

--- a/resources/tags/models/tag_resource.yml
+++ b/resources/tags/models/tag_resource.yml
@@ -1,0 +1,37 @@
+type: object
+
+properties:
+  resources:
+    description: >-
+      An array of objects containing resource_id and resource_type 
+      attributes.
+    
+    type: array
+    
+    items:
+      properties:
+        resource_id:
+          type: string
+          description: The identifier of a resource.
+          example: 3d80cb72-342b-4aaa-b92e-4e4abb24a933
+        
+        resource_type:
+          type: string
+          description: The type of the resource.
+          example: volume
+          enum:
+            - droplet
+            - image
+            - volume
+            - volume_snapshot
+    
+    example:
+      - resource_id: '9569411'
+        resource_type: droplet
+      - resource_id: '7555620'
+        resource_type: image
+      - resource_id: 3d80cb72-342b-4aaa-b92e-4e4abb24a933
+        resource_type: volume
+
+required:
+  - resources

--- a/resources/tags/tag_resource.yml
+++ b/resources/tags/tag_resource.yml
@@ -1,0 +1,44 @@
+operationId: tag_resource
+
+summary: Tag a Resource
+
+description: >-
+  Resources can be tagged by sending a POST request to 
+  `/v2/tags/$TAG_NAME/resources` with an array of json objects containing 
+  `resource_id` and `resource_type` attributes.
+
+  Currently only tagging of Droplets, Images, Volumes, and Volume Snapshots is 
+  supported. `resource_id` is expected to be the Droplet's id, Image's id, or 
+  Volume/Volume Snapshot's UUID attribute as a string, and `resource_type` is 
+  expected to be the string `droplet`, `image`, `volume` or `volume_snapshot`.
+
+tags:
+  - Tags
+
+parameters:
+  - $ref: 'parameters.yml#/TagId'
+
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: 'models/tag_resource.yml'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+  

--- a/resources/tags/untag_resource.yml
+++ b/resources/tags/untag_resource.yml
@@ -1,0 +1,44 @@
+operationId: untag_resource
+
+summary: Untag a Resource
+
+description: >-
+  Resources can be tagged by sending a DELETE request to 
+  `/v2/tags/$TAG_NAME/resources` with an array of json objects containing 
+  `resource_id` and `resource_type` attributes.
+
+  Currently only untagging of Droplets, Images, Volumes, and Volume Snapshots 
+  is supported. `resource_id` is expected to be the Droplet's id, Image's id, 
+  or Volume/Volume Snapshot's UUID attribute as a string, and `resource_type` is 
+  expected to be the string `droplet`, `image`, `volume` or `volume_snapshot`.
+
+tags:
+  - Tags
+
+parameters:
+  - $ref: 'parameters.yml#/TagId'
+
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: 'models/tag_resource.yml'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+  


### PR DESCRIPTION
The current docs have a discrepancy in the description for DELETE in that it states the POST supports tagging of Droplets, Images, Volumes, and Volume Snapshots where DELETE supports Droplets, Images, and Volumes.

I verified DELETE also supports Volume Snapshots and created a shared request schema between the two endpoints