### PR TITLE
DELETE existing volume (multiple paths)

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -385,6 +385,12 @@ paths:
       $ref: 'resources/volumes/list_all_volumes.yml'
     post:
       $ref: 'resources/volumes/create_new_volume.yml'
+    delete:
+      $ref: 'resources/volumes/delete_volume_by_name.yml'
+
+  /volumes/{volume_id}:
+    delete:
+      $ref: 'resources/volumes/delete_volume.yml'
 
 components:
   securitySchemes:

--- a/specification/resources/volumes/delete_volume.yml
+++ b/specification/resources/volumes/delete_volume.yml
@@ -1,0 +1,33 @@
+operationId: delete_volume
+
+summary: Delete a Block Storage Volume
+
+description: >+
+  To delete a block storage volume, destroying all data and removing it from
+  your account, send a DELETE request to `/v2/volumes/$VOLUME_ID`.
+
+  No response body will be sent back, but the response code will indicate
+  success. Specifically, the response code will be a 204, which means that the
+  action was successful with no returned body data.
+
+tags:
+  - Block Storage
+
+parameters:
+  - $ref: 'parameters.yml#/VolumeId'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'

--- a/specification/resources/volumes/delete_volume_by_name.yml
+++ b/specification/resources/volumes/delete_volume_by_name.yml
@@ -1,0 +1,35 @@
+operationId: delete_volume_by_name
+
+summary: Delete a Block Storage Volume by Name
+
+description: >+
+  Block storage volumes may also be deleted by name by sending a DELETE request
+  with the volume's **name** and the **region slug** for the region it is
+  located in as query parameters to `/v2/volumes?name=$VOLUME_NAME&region=nyc1`.
+
+  No response body will be sent back, but the response code will indicate
+  success. Specifically, the response code will be a 204, which means that the
+  action was successful with no returned body data.
+
+tags:
+  - Block Storage
+
+parameters:
+  - $ref: 'parameters.yml#/VolumeName'
+  - $ref: '../../shared/parameters.yml#/Region'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'

--- a/specification/resources/volumes/get_volume_by_id.yml
+++ b/specification/resources/volumes/get_volume_by_id.yml
@@ -1,0 +1,33 @@
+operationId: 
+
+summary: Delete a Block Storage Volume
+
+description: >+
+  To delete a block storage volume, destroying all data and removing it from
+  your account, send a DELETE request to `/v2/volumes/$VOLUME_ID`.
+
+  No response body will be sent back, but the response code will indicate
+  success. Specifically, the response code will be a 204, which means that the
+  action was successful with no returned body data.
+
+tags:
+  - Block Storage
+
+parameters:
+  - $ref: 'parameters.yml#/VolumeId'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'

--- a/specification/resources/volumes/list_all_volumes.yml
+++ b/specification/resources/volumes/list_all_volumes.yml
@@ -22,6 +22,14 @@ description: >+
 
   **Note:** You can only create one volume per region with the same name.
 
+  ### By Name and Region
+
+  It is also possible to retrieve information about a block storage volume by
+  name. To do so, send a GET request with the volume's name and the region slug
+  for the region it is located in as query parameters to
+  `/v2/volumes?name=$VOLUME_NAME&region=nyc1`.
+
+  
 tags:
   - Block Storage
 

--- a/specification/resources/volumes/parameters.yml
+++ b/specification/resources/volumes/parameters.yml
@@ -1,3 +1,12 @@
+VolumeId:
+  name: volume_id
+  in: path
+  required: true
+  schema:
+    type: string
+    format: uuid
+    example: 7724db7c-e098-11e5-b522-000f53304e51
+
 VolumeName:
   name: name
   in: query


### PR DESCRIPTION
I realized the method/route to ["Retrieve and Existing Volume"](https://developers.digitalocean.com/documentation/v2/#retrieve-an-existing-block-storage-volume) just describes using query parameters on the `GET /volumes` route so I just updated the list_all_volumes.yml description.

closes #53 
closes #58 