### PR TITLE
Fix spectral issues with VolumeId path param.

### DIFF
--- a/specification/resources/volumes/parameters.yml
+++ b/specification/resources/volumes/parameters.yml
@@ -2,15 +2,16 @@ VolumeId:
   name: volume_id
   in: path
   required: true
+  description: The ID of the block storage volume.
   schema:
     type: string
     format: uuid
-    example: 7724db7c-e098-11e5-b522-000f53304e51
+  example: 7724db7c-e098-11e5-b522-000f53304e51
 
 VolumeName:
   name: name
   in: query
-  description: The volume's name.
+  description: The block storage volume's name.
   schema:
     type: string
   example: example


### PR DESCRIPTION
Not entirely sure why this didn't get caught in CI, but Spectral is throwing a couple issues at me locally on this:

```
/home/asb/development/apiv2-openapi/specification/resources/volumes/parameters.yml
 1:10  warning  oas3-parameter-description    Parameter objects should have a `description`.
 1:10    error  params-must-include-examples  Parameters must include examples; missing VolumeId
```