### PR TITLE
Add Droplet action request schemas.

### DIFF
--- a/specification/resources/droplets/initiate_droplet_action.yml
+++ b/specification/resources/droplets/initiate_droplet_action.yml
@@ -43,6 +43,12 @@ requestBody:
       schema:
         oneOf:
           - $ref: 'models/droplet_actions.yml#/DropletActionType'
+          - $ref: 'models/droplet_actions.yml#/DropletActionRestore'
+          - $ref: 'models/droplet_actions.yml#/DropletActionResize'
+          - $ref: 'models/droplet_actions.yml#/DropletActionRebuild'
+          - $ref: 'models/droplet_actions.yml#/DropletActionRename'
+          - $ref: 'models/droplet_actions.yml#/DropletActionChangeKernel'
+          - $ref: 'models/droplet_actions.yml#/DropletActionSnapshot'
         discriminator:
           propertyName: type
           mapping:

--- a/specification/resources/droplets/initiate_droplet_action_by_tag.yml
+++ b/specification/resources/droplets/initiate_droplet_action_by_tag.yml
@@ -36,6 +36,7 @@ requestBody:
       schema:
         oneOf:
           - $ref: 'models/droplet_actions.yml#/DropletActionType'
+          - $ref: 'models/droplet_actions.yml#/DropletActionSnapshot'
         discriminator:
           propertyName: type
           mapping:


### PR DESCRIPTION
Going back to the spec to looks discriminators again, I realized that these models should be included here as well as in the mapping. ReDoc doesn't seem to care, but other tooling might. So adding them now.

https://swagger.io/specification/#discriminator-object