### PR TITLE
Add Spectral rules to ensure arrays have item types.

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -4,6 +4,7 @@ functionsDir: ./spectral/
 
 functions:
   - ensurePropertiesExample
+  - ensureAllArraysHaveItemTypes
 
 rules:
   contact-properties: off
@@ -38,8 +39,8 @@ rules:
     message: "{{description}}; missing {{property}}"
     then:
       function: xor
-      functionOptions: 
-        properties: 
+      functionOptions:
+        properties:
           - example
           - examples
 
@@ -90,3 +91,19 @@ rules:
     then:
       - field: '500'
         function: truthy
+
+  array-properties-must-have-items-with-type:
+    description: Array properties must have an items attribute with a type
+    given: '$..*.properties[*]'
+    severity: error
+    message: "{{error}}"
+    then:
+      function: ensureAllArraysHaveItemTypes
+
+  array-params-must-have-items-with-type:
+    description: Array parameters must have an items attribute with a type
+    given: '$..*.parameters[*]'
+    severity: error
+    message: "{{error}}"
+    then:
+      function: ensureAllArraysHaveItemTypes

--- a/specification/resources/kubernetes/models/clusterlint_request.yml
+++ b/specification/resources/kubernetes/models/clusterlint_request.yml
@@ -14,6 +14,8 @@ properties:
 
   include_checks:
     type: array
+    items:
+      type: string
     example:
     - bare-pods
     - resource-requirements
@@ -22,6 +24,8 @@ properties:
 
   exclude_groups:
     type: array
+    items:
+      type: string
     example:
     - workload-health
     description: An array of check groups that will be omitted when clusterlint
@@ -29,6 +33,8 @@ properties:
 
   exclude_checks:
     type: array
+    items:
+      type: string
     example:
     - default-namespace
     description: An array of checks that will be run when clusterlint executes

--- a/specification/resources/volumes/models/volume_base.yml
+++ b/specification/resources/volumes/models/volume_base.yml
@@ -7,15 +7,17 @@ properties:
     description: The unique identifier for the block storage volume.
     example: 506f78a4-e098-11e5-ad9f-000f53306ae1
     readOnly: true
-  
+
   droplet_ids:
     type: array
+    items:
+      type: integer
     description: >-
       An array containing the IDs of the Droplets the volume is attached to.
       Note that at this time, a volume can only be attached to a single Droplet.
     example: []
     readOnly: true
-  
+
   name:
     type: string
     description: >-
@@ -23,18 +25,18 @@ properties:
       be composed only of numbers, letters and "-", up to a limit of 64
       characters. The name must begin with a letter.
     example: example
-  
+
   description:
     type: string
     description: >-
       An optional free-form text field to describe a block storage volume.
     example: Block store for examples
-  
+
   size_gigabytes:
     type: integer
     description: The size of the block storage volume in GiB (1024^3).
     example: 10
-  
+
   created_at:
     type: string
     description: >-
@@ -42,6 +44,6 @@ properties:
       represents when the block storage volume was created.
     example: 2020-03-02T17:00:49Z
     readOnly: true
-  
+
   tags:
     $ref: '../../../shared/attributes/tags_array.yml'

--- a/specification/shared/attributes/tags_array.yml
+++ b/specification/shared/attributes/tags_array.yml
@@ -1,7 +1,9 @@
 type: array
+items:
+  type: string
 description: >-
-  A flat array of tag names as strings to be applied to the resource. 
+  A flat array of tag names as strings to be applied to the resource.
   Tag names may be for either existing or new tags.
-example: 
+example:
   - base-image
   - prod

--- a/spectral/ensureAllArraysHaveItemTypes.js
+++ b/spectral/ensureAllArraysHaveItemTypes.js
@@ -1,0 +1,26 @@
+/**
+ * Ensures all arrays have item types
+ *
+ * Based on:
+ * https://github.com/box/box-openapi/blob/main/src/spectral/ensureAllArraysHaveItemTypes.js
+ */
+module.exports = (param, _, paths) => {
+  // if this is actually a property called properties, ignore
+  if (paths.target.join('.').includes('properties.properties')) { return }
+
+  // if this is a list, check if the first item matches instead
+  if (param.items && param.items.oneOf) { return }
+
+  // check if the param is an array
+  if (param.type === 'array' &&
+    // if the param has items, ensure it has a type, $ref, or properties
+    !(param.items && (param.items.type || param.items['$ref']
+    || param.items['anyOf'] || param.items['allOf']
+    || param.items['properties']))) {
+    return [
+      {
+        message: `${paths.target ? paths.target.join('.') : 'property'}; type array need an item type, $ref, or properties`
+      }
+    ]
+  }
+}


### PR DESCRIPTION
When running https://github.com/OpenAPITools/openapi-generator against our spec, I noticed a number of errors relating to arrays not specifying the type of their items.

Of course again, Box already has a custom Spectral rule for this usecase. I made a small change allowing the check to pass when specifying `anyOf`, `allOf`, or `properties` in addition to a`$ref`.