### PR TITLE
Add license header to ensureAllArraysHaveItemTypes.js

### DIFF
--- a/spectral/functions/ensureAllArraysHaveItemTypes.js
+++ b/spectral/functions/ensureAllArraysHaveItemTypes.js
@@ -1,9 +1,25 @@
 /**
- * Ensures all arrays have item types
- *
- * Based on:
- * https://github.com/box/box-openapi/blob/184889a4b5b6156e0e2719bd513d93f994c6c50e/src/spectral/ensureAllArraysHaveItemTypes.js
- */
+  * Copyright 2020 Box, Inc. All rights reserved.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  * use this file except in compliance with the License. You may obtain a copy
+  * of the License at http://www.apache.org/licenses/LICENSE-2.0.
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  * License for the specific language governing permissions and limitations
+  * under the License.
+  *
+  * Ensure that examples exist for paramters/properties of
+  * basic values
+  *
+  *
+  * Ensures all arrays have item types
+  *
+  * Based on:
+  * https://github.com/box/box-openapi/blob/184889a4b5b6156e0e2719bd513d93f994c6c50e/src/spectral/ensureAllArraysHaveItemTypes.js
+  */
 module.exports = (param, _, paths) => {
   // if this is actually a property called properties, ignore
   if (paths.target.join('.').includes('properties.properties')) { return }


### PR DESCRIPTION
I swore I did this in https://github.com/digitalocean/apiv2-openapi/pull/377, but it looks like I only added it to one of the files.