### PR TITLE
Use ensurePropertiesExample function for header check.

### DIFF
--- a/spectral/ruleset.yml
+++ b/spectral/ruleset.yml
@@ -38,8 +38,7 @@ rules:
     severity: error
     message: "{{description}}; missing {{property}}"
     then:
-      field: example
-      function: truthy
+      function: ensurePropertiesExample
 
   endpoint-must-be-ref:
     description: Endpoint must be a $ref


### PR DESCRIPTION
* Removing an example from a header in `specification/shared/headers.yml` produces an error as expected.
* Unexpected errors are not produced in branches like https://github.com/digitalocean/apiv2-openapi/pull/381