### PR TITLE
Fix examples: cdn

### DIFF
--- a/specification/resources/cdn/responses/all_cdn_endpoints.yml
+++ b/specification/resources/cdn/responses/all_cdn_endpoints.yml
@@ -24,14 +24,15 @@ content:
         - $ref: '../../../shared/pages.yml#/pagination'
         - $ref: '../../../shared/meta.yml'
 
-    example:
-      endpoints:
-      - id: 19f06b6a-3ace-4315-b086-499a0e521b76
-        origin: static-images.nyc3.digitaloceanspaces.com
-        endpoint: static-images.nyc3.cdn.digitaloceanspaces.com
-        created_at: '2018-07-19T15:04:16Z'
-        certificate_id: 892071a0-bb95-49bc-8021-3afd67a210bf
-        custom_domain: static.example.com
-        ttl: 3600
-      meta:
-        total: 1
+      example:
+        endpoints:
+          - id: 19f06b6a-3ace-4315-b086-499a0e521b76
+            origin: static-images.nyc3.digitaloceanspaces.com
+            endpoint: static-images.nyc3.cdn.digitaloceanspaces.com
+            created_at: '2018-07-19T15:04:16Z'
+            certificate_id: 892071a0-bb95-49bc-8021-3afd67a210bf
+            custom_domain: static.example.com
+            ttl: 3600
+        links: {}
+        meta:
+          total: 1


### PR DESCRIPTION
Looks like the location/indentation of examples is what's causing some of these errors.
I guess ReDoc and spectral do some sort of "inheriting" examples from the property tree but `openapi lint` is a bit more strict.

This fixes the openapi lint errors and passes spectral lint as well as renders in ReDoc. 