### PR TITLE
Fix domain responses and some examples.

### DIFF
--- a/specification/resources/domains/responses/all_domain_records_response.yml
+++ b/specification/resources/domains/responses/all_domain_records_response.yml
@@ -3,7 +3,7 @@ description: >-
   value of this will be an array of domain record objects, each of which
   contains the standard domain record attributes. For attributes that are not
   used by a specific record type, a value of `null` will be returned. For
-  instance, all records other than SRV will have `null` for the `weight` and 
+  instance, all records other than SRV will have `null` for the `weight` and
   `port` attributes.
 
 headers:

--- a/specification/resources/domains/responses/all_domains_response.yml
+++ b/specification/resources/domains/responses/all_domains_response.yml
@@ -28,18 +28,18 @@ content:
         - $ref: '../../../shared/pages.yml#/pagination'
         - $ref: '../../../shared/meta.yml'
 
-    example:
-      domains:
-        - name: example.com
-          ttl: 1800
-          zone_file: |
-            $ORIGIN example.com.
-            $TTL 1800
-            example.com. IN SOA ns1.digitalocean.com. hostmaster.example.com. 1415982609 10800 3600 604800 1800
-            example.com. 1800 IN NS ns1.digitalocean.com.
-            example.com. 1800 IN NS ns2.digitalocean.com.
-            example.com. 1800 IN NS ns3.digitalocean.com.
-            example.com. 1800 IN A 1.2.3.4
-      links: {}
-      meta:
-        total: 1
+      example:
+        domains:
+          - name: example.com
+            ttl: 1800
+            zone_file: |
+              $ORIGIN example.com.
+              $TTL 1800
+              example.com. IN SOA ns1.digitalocean.com. hostmaster.example.com. 1415982609 10800 3600 604800 1800
+              example.com. 1800 IN NS ns1.digitalocean.com.
+              example.com. 1800 IN NS ns2.digitalocean.com.
+              example.com. 1800 IN NS ns3.digitalocean.com.
+              example.com. 1800 IN A 1.2.3.4
+        links: {}
+        meta:
+          total: 1

--- a/specification/resources/domains/responses/create_domain_response.yml
+++ b/specification/resources/domains/responses/create_domain_response.yml
@@ -14,10 +14,12 @@ headers:
 content:
   application/json:
     schema:
-      $ref: '../models/domain.yml'
+      properties:
+        domain:
+          $ref: '../models/domain.yml'
 
-    example:
-      domain:
-        name: example.com
-        ttl: 1800
-        zone_file: null
+      example:
+        domain:
+          name: example.com
+          ttl: 1800
+          zone_file: null

--- a/specification/resources/domains/responses/created_domain_record.yml
+++ b/specification/resources/domains/responses/created_domain_record.yml
@@ -15,17 +15,19 @@ headers:
 content:
   application/json:
     schema:
-      $ref: '../models/domain_record.yml'
+      properties:
+        domain_record:
+          $ref: '../models/domain_record.yml'
 
-    example:
-      domain_record:
-        id: 28448433
-        type: A
-        name: www
-        data: 162.10.66.0
-        priority: null
-        port: null
-        ttl: 1800
-        weight: null
-        flags: null
-        tag: null
+      example:
+        domain_record:
+          id: 28448433
+          type: A
+          name: www
+          data: 162.10.66.0
+          priority: null
+          port: null
+          ttl: 1800
+          weight: null
+          flags: null
+          tag: null

--- a/specification/resources/domains/responses/existing_domain.yml
+++ b/specification/resources/domains/responses/existing_domain.yml
@@ -14,17 +14,19 @@ headers:
 content:
   application/json:
     schema:
-      $ref: '../models/domain.yml'
+      properties:
+        domain:
+          $ref: '../models/domain.yml'
 
-    example:
-      domain:
-        name: example.com
-        ttl: 1800
-        zone_file: |
-          $ORIGIN example.com.
-          $TTL 1800
-          example.com. IN SOA ns1.digitalocean.com. hostmaster.example.com. 1415982611 10800 3600 604800 1800
-          example.com. 1800 IN NS ns1.digitalocean.com.
-          example.com. 1800 IN NS ns2.digitalocean.com.
-          example.com. 1800 IN NS ns3.digitalocean.com.
-          example.com. 1800 IN A 1.2.3.4
+      example:
+        domain:
+          name: example.com
+          ttl: 1800
+          zone_file: |
+            $ORIGIN example.com.
+            $TTL 1800
+            example.com. IN SOA ns1.digitalocean.com. hostmaster.example.com. 1415982611 10800 3600 604800 1800
+            example.com. 1800 IN NS ns1.digitalocean.com.
+            example.com. 1800 IN NS ns2.digitalocean.com.
+            example.com. 1800 IN NS ns3.digitalocean.com.
+            example.com. 1800 IN A 1.2.3.4

--- a/specification/resources/domains/responses/updated_domain_record.yml
+++ b/specification/resources/domains/responses/updated_domain_record.yml
@@ -14,17 +14,19 @@ headers:
 content:
   application/json:
     schema:
-      $ref: '../models/domain_record.yml'
+      properties:
+        domain_record:
+          $ref: '../models/domain_record.yml'
 
-    example:
-      domain_record:
-        id: 3352896
-        type: A
-        name: blog
-        data: 162.10.66.0
-        priority: 
-        port: 
-        ttl: 1800
-        weight: 
-        flags: 
-        tag: 
+      example:
+        domain_record:
+          id: 3352896
+          type: A
+          name: blog
+          data: 162.10.66.0
+          priority:
+          port:
+          ttl: 1800
+          weight:
+          flags:
+          tag:


### PR DESCRIPTION
This does not fix all warnings for domains as some are coming from ref-ed `examples, but it's an important one to get in as it includes fixes to the actual response schemas.