### PR TITLE
Remove v2 from prodproxy PROXY_TARGET.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ stop-services: ## Stop the proxy with mock docker services
 
 .PHONY: start-prodproxy
 start-prodproxy: ## Start a proxy to the production
-	 PROXY_TARGET=https://api.digitalocean.com/v2 docker-compose up proxy
+	 PROXY_TARGET=https://api.digitalocean.com docker-compose up proxy
 
 .PHONY: _sleep
 _sleep:


### PR DESCRIPTION
Follow up on https://github.com/digitalocean/apiv2-openapi/pull/420 