### PR TITLE
Add 'assign' to list of accepted custom verbs.

### DIFF
--- a/spectral/functions/validateOperationIdNaming.js
+++ b/spectral/functions/validateOperationIdNaming.js
@@ -8,7 +8,8 @@
 const DELETE = ["delete", "destroy", "remove", "purge", "untag"];
 const GET = ["get", "list"];
 const PATCH = ["patch"];
-const POST = ["create", "post", "add", "tag", "install", "reset", "upgrade", "recycle", "run", "retry", "validate"];
+const POST = ["create", "post", "add", "tag", "install", "reset", "upgrade",
+              "recycle", "run", "retry", "validate", "assign"];
 const PUT = ["update"];
 
 const articles = ["_a_", "_an_", "_the_"]


### PR DESCRIPTION
The lint job is failing on main as a PR landed that had been submitted before the workflow changed.

https://github.com/digitalocean/apiv2-openapi/runs/1344445665

This adds 'assign' to list of accepted custom verbs for POST operation IDs.