### PR TITLE
Fix spec and GitHub links when view main preview.

### DIFF
--- a/docs-preview/redoc-index.html
+++ b/docs-preview/redoc-index.html
@@ -79,8 +79,8 @@
     <div class="header">
         <label class="logo">DigitalOcean APIv2 OpenAPI Preview</label>
         <div class="header-right">
-            <a id="pr-link" href="#" target="_blank">PR: none</a>
-            <a id="spec-link" href="#" target="_blank">Spec File</a>
+            <a id="gh-link" href="https://github.com/digitalocean/apiv2-openapi" target="_blank">Main</a>
+            <a id="spec-link" href="DigitalOcean-public.v2.yaml" target="_blank">Spec File</a>
         </div>
     </div>
 
@@ -90,17 +90,16 @@
         const queryString = window.location.search;
         const urlParams = new URLSearchParams(queryString);
         const pr = urlParams.get('pr');
-        
+
         let specUrl = "DigitalOcean-public.v2.yaml";
-        
+
         if (pr) {
             specUrl = `previews/${pr}-spec.yaml`
-            document.getElementById('pr-link').setAttribute('href', `https://github.com/digitalocean/apiv2-openapi/pull/${pr}`);
-            document.getElementById('pr-link').textContent = `PR: ${pr}`;
+            document.getElementById('gh-link').setAttribute('href', `https://github.com/digitalocean/apiv2-openapi/pull/${pr}`);
+            document.getElementById('gh-link').textContent = `PR: ${pr}`;
             document.getElementById('spec-link').setAttribute('href', specUrl);
         }
 
-        
         document.querySelector('redoc').setAttribute('spec-url', specUrl);
     </script>
 


### PR DESCRIPTION
This fixes the spec and GitHub links when viewing the preview page without a `pr` query param. 

(This was originally in https://github.com/digitalocean/apiv2-openapi/pull/392 which ended up not landing for unrelated reasons.)