### PR TITLE
VPC: Change default network for a region.

### DIFF
--- a/specification/resources/vpcs/models/vpc.yml
+++ b/specification/resources/vpcs/models/vpc.yml
@@ -3,6 +3,7 @@ vpc:
   allOf:
   - $ref: '#/vpc_updatable'
   - $ref: '#/vpc_create'
+  - $ref: '#/vpc_default'
   - $ref: '#/vpc_base'
 
 vpc_base:
@@ -17,13 +18,6 @@ vpc_base:
 
     urn:
       $ref: '../../../shared/attributes/urn.yml'
-
-    default:
-      type: boolean
-      readOnly: true
-      example: false
-      description: A boolean value indicating whether or not the VPC is the
-        default one for the region.
 
     created_at:
       type: string
@@ -48,6 +42,20 @@ vpc_updatable:
       example: VPC for production environment
       description: A free-form text field for describing the VPC's purpose. It
         may be a maximum of 255 characters.
+
+vpc_default:
+  type: object
+  properties:
+    default:
+      type: boolean
+      example: true
+      description: A boolean value indicating whether or not the VPC is the
+        default network for the region. All applicable resources are placed
+        into the default VPC network unless otherwise specified during their
+        creation. The `default` field cannot be unset from `true`. If you want
+        to set a new default VPC network, update the `default` field of another
+        VPC network in the same region. The previous network's `default` field
+        will be set to `false` when a new default VPC has been defined.
 
 vpc_create:
   type: object

--- a/specification/resources/vpcs/patch_vpc.yml
+++ b/specification/resources/vpcs/patch_vpc.yml
@@ -4,8 +4,7 @@ summary: Partially Update a VPC
 
 description: |
   To update a subset of information about a VPC, send a PATCH request to
-  `/v2/vpcs/$VPC_ID`. Currently, only the `name` and `description` attributes
-  can be updated.
+  `/v2/vpcs/$VPC_ID`.
 
 tags:
   - VPCs
@@ -19,7 +18,9 @@ requestBody:
   content:
     application/json:
       schema:
-        $ref: 'models/vpc.yml#/vpc_updatable'
+        allOf:
+        - $ref: 'models/vpc.yml#/vpc_updatable'
+        - $ref: 'models/vpc.yml#/vpc_default'
 
 responses:
   '200':

--- a/specification/resources/vpcs/update_vpc.yml
+++ b/specification/resources/vpcs/update_vpc.yml
@@ -4,8 +4,6 @@ summary: Update a VPC
 
 description: |
   To update information about a VPC, send a PUT request to `/v2/vpcs/$VPC_ID`.
-  Currently, only the `name` and `description` attributes can be updated.
-  Excluding an attribute will reset it to its default.
 
 tags:
   - VPCs
@@ -22,6 +20,7 @@ requestBody:
         type: object
         allOf:
         - $ref: 'models/vpc.yml#/vpc_updatable'
+        - $ref: 'models/vpc.yml#/vpc_default'
 
         required:
         - name


### PR DESCRIPTION
`default` can be set for a VPC on PUT and PATCH, but *not* on POST.

https://developers.digitalocean.com/documentation/changelog/api-v2/vpc-default/