### PR TITLE
Trigger preview deployment from PR with comment.

### DIFF
--- a/.github/workflows/spec.pr-comment-trigger.yml
+++ b/.github/workflows/spec.pr-comment-trigger.yml
@@ -1,0 +1,80 @@
+name: Spec Comment Trigger
+# This workflow uploads a copy of the spec with the respective changes in the PR
+# to the team Space when triggered by commenting "!deploy" on the PR.
+#
+# The name of the uploaded file will be prefixed with the PR number.
+# e.g. `spec-ci/previews/123-spec.yaml
+
+on:
+  issue_comment:
+
+jobs:
+  generate-preview-on-trigger:
+    # Check that the issue is a PR and that the comment starts with "!deploy"
+    # Also ensure that the comments is made by someone with commit access to the repo
+    if: |
+      github.event.issue.pull_request && startsWith(github.event.comment.body, '!deploy') && (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    name: Generate Preview on Comment Trigger
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+
+    - name: Get PR Branch
+      id: get-pr-branch
+      uses: actions/github-script@v3
+      with:
+        script: |
+          repository = '${{ github.repository }}'
+          result = await github.pulls.get({
+              owner: repository.split('/')[0],
+              repo: repository.split('/')[1],
+              pull_number: ${{ github.event.issue.number }},
+          });
+
+          return result.data.head
+
+    - name: Checkout PR Branch
+      uses: actions/checkout@@v2
+      with:
+        repository: ${{ fromJSON(steps.get-pr-branch.outputs.result).repo.full_name }}
+        ref: ${{ fromJSON(steps.get-pr-branch.outputs.result).ref }}
+
+    - name: Bundle
+      run: make bundle
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: openapi-bundled
+        path: tests/openapi-bundled.yaml
+
+    - name: Upload PR spec
+      run: >-
+        aws s3 cp tests/openapi-bundled.yaml
+        ${{ env.SPACES_PATH }}/previews/${{ github.event.number }}-spec.yaml
+        --endpoint=${{ env.SPACES_ENDPOINT }}
+        --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.SPACES_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SPACES_ACCESS_SECRET }}
+        AWS_DEFAULT_OUTPUT: json
+        SPACES_PATH: ${{ secrets.SPACES_PATH || 's3://api-engineering/spec-ci' }}
+        SPACES_ENDPOINT: ${{ secrets.SPACES_ENDPOINT || 'https://nyc3.digitaloceanspaces.com'}}
+
+    - name: Comment on PR
+      if: ${{ success() }}
+      uses: actions/github-script@v3
+      with:
+        script: |
+          var previewComment = '🔎 API documentation preview: https://api-engineering.nyc3.digitaloceanspaces.com/spec-ci/redoc-index.html?pr=' + context.issue.number;
+          github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: previewComment
+          });

--- a/.github/workflows/spec.pr.yml
+++ b/.github/workflows/spec.pr.yml
@@ -1,11 +1,12 @@
 name: Spec PR
 # This workflow uploads a copy of the spec with the respective changes in the PR
-# to the team spaces.
-# The name of the uplaoded file will be prefixed with the PR number.
+# to the team Space.
+#
+# The name of the uploaded file will be prefixed with the PR number.
 # e.g. `spec-ci/previews/123-spec.yaml
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'specification/**'
       - 'spectral/**'
@@ -21,6 +22,8 @@ jobs:
         run: make lint
 
   generate-preview:
+    # As this job needs access to secrets, skip it if the PR comes from a fork.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: Generate Preview
     runs-on: ubuntu-latest
     needs: lint
@@ -41,7 +44,7 @@ jobs:
 
       - name: Upload PR spec
         run: >-
-          aws s3 cp tests/openapi-bundled.yaml 
+          aws s3 cp tests/openapi-bundled.yaml
           ${{ env.SPACES_PATH }}/previews/${{ github.event.number }}-spec.yaml
           --endpoint=${{ env.SPACES_ENDPOINT }}
           --acl public-read


### PR DESCRIPTION
In order to work around the issues imposed by secrets not being available in a fork, this adds a new workflow that allows for people with commit access to this repo to trigger a preview deployment by commenting `!deploy` on a PR. On success, a comment is posted with the link.

The "Spec PR" workflow has been changed back to being triggered on `pull_request` rather than `pull_request_target`. Additionally, the `generate-preview` job is now only triggered if the PR is a branch as this job would fail if run from a fork.