### PR TITLE
Use orgs.checkMembershipForUser instead of orgs.listForUser.

### DIFF
--- a/.github/workflows/spec.pr-comment-trigger.yml
+++ b/.github/workflows/spec.pr-comment-trigger.yml
@@ -25,14 +25,19 @@ jobs:
           const organization = 'digitalocean';
           const user = "${{ github.event.comment.user.login }}";
 
-          orgs = await github.orgs.listForUser({
-              username: user,
-              per_page: 100,
-          });
+          try {
+              org = await github.orgs.checkMembershipForUser({
+                  org: organization,
+                  username: user,
+              });
 
-          const isMember = orgs.data.some(({ login }) => login === organization);
+              console.log(`${org.headers.status}: ${user} found in ${organization}`);
+              return 'true';
 
-          return isMember ? 'true' : 'false';
+          } catch(err) {
+              console.log(`${err.headers.status}: ${user} not found in ${organization}`);
+              return 'false';
+          };
 
     - uses: actions/setup-node@v1
       if: steps.is-digitalocean-member.outputs.result == 'true'


### PR DESCRIPTION
Changes the endpoint we hit to check for membership in the GH org. `orgs.listForUser` only lists publicly displayed orgs for a user.  `orgs.checkMembershipForUser` does what we want explicitly.

> Check if a user is, publicly or privately, a member of the organization.

https://docs.github.com/en/free-pro-team@latest/rest/reference/orgs#check-organization-membership-for-a-user

There's no response body, just 204 for true and 404 for false. So we need to try/catch.