### PR TITLE
images: Add 'retired' as a valid status.

### DIFF
--- a/specification/resources/images/models/image.yml
+++ b/specification/resources/images/models/image.yml
@@ -84,8 +84,8 @@ properties:
   status:
     type: string
     description: >-
-      A status string indicating the state of a custom image. This may be "NEW",
-       "available", "pending", "deleted", or "retired".
+      A status string indicating the state of a custom image. This may be `NEW`,
+       `available`, `pending`, `deleted`, or `retired`.
     enum:
       - NEW
       - available


### PR DESCRIPTION
Came across a missing image status doing some validation with Prism. Verified it in the imageinfo service's proto file.