### PR TITLE
Fixed missing droplet property in example

### DIFF
--- a/specification/resources/droplets/responses/examples.yml
+++ b/specification/resources/droplets/responses/examples.yml
@@ -591,125 +591,126 @@ droplets_tagged:
 
 droplet_single:
   value:
-    id: 3164444
-    name: example.com
-    memory: 1024
-    vcpus: 1
-    disk: 25
-    locked: false
-    status: active
-    kernel: null
-    created_at: '2020-07-21T18:37:44Z'
-    features:
-    - backups
-    - private_networking
-    - ipv6
-    backup_ids:
-    - 53893572
-    next_backup_window:
-      start: '2020-07-30T00:00:00Z'
-      end: '2020-07-30T23:00:00Z'
-    snapshot_ids:
-    - 67512819
-    image:
-      id: 63663980
-      name: 20.04 (LTS) x64
-      distribution: Ubuntu
-      slug: ubuntu-20-04-x64
-      public: true
-      regions:
-      - ams2
-      - ams3
-      - blr1
-      - fra1
-      - lon1
-      - nyc1
-      - nyc2
-      - nyc3
-      - sfo1
-      - sfo2
-      - sfo3
-      - sgp1
-      - tor1
-      created_at: '2020-05-15T05:47:50Z'
-      type: snapshot
-      min_disk_size: 20
-      size_gigabytes: 2.36
-      description: ''
-      tags: []
-      status: available
-      error_message: ''
-    volume_ids: []
-    size:
-      slug: 's-1vcpu-1gb'
+    droplet:
+      id: 3164444
+      name: example.com
       memory: 1024
       vcpus: 1
       disk: 25
-      transfer: 1.0
-      price_monthly: 5.0
-      price_hourly: 0.00743999984115362
-      regions:
-      - ams2
-      - ams3
-      - blr1
-      - fra1
-      - lon1
-      - nyc1
-      - nyc2
-      - nyc3
-      - sfo1
-      - sfo2
-      - sfo3
-      - sgp1
-      - tor1
-      available: true
-    size_slug: s-1vcpu-1gb
-    networks:
-      v4:
-        - ip_address: '10.128.192.124'
-          netmask: '255.255.0.0'
-          gateway: nil
-          type: private
-        - ip_address: '192.241.165.154'
-          netmask: '255.255.255.0'
-          gateway: '192.241.165.1'
-          type: public
-      v6:
-        - ip_address: '2604:a880:0:1010::18a:a001'
-          netmask: 64
-          gateway: '2604:a880:0:1010::1'
-          type: public
-    region:
-      name: New York 3
-      slug: nyc3
+      locked: false
+      status: active
+      kernel: null
+      created_at: '2020-07-21T18:37:44Z'
       features:
-          - private_networking
-          - backups
-          - ipv6
-          - metadata
-          - install_agent
-          - storage
-          - image_transfer
-      available: true
-      sizes:
-          - s-1vcpu-1gb
-          - s-1vcpu-2gb
-          - s-1vcpu-3gb
-          - s-2vcpu-2gb
-          - s-3vcpu-1gb
-          - s-2vcpu-4gb
-          - s-4vcpu-8gb
-          - s-6vcpu-16gb
-          - s-8vcpu-32gb
-          - s-12vcpu-48gb
-          - s-16vcpu-64gb
-          - s-20vcpu-96gb
-          - s-24vcpu-128gb
-          - s-32vcpu-192g
-    tags:
-    - web
-    - env:prod
-    vpc_uuid: 760e09ef-dc84-11e8-981e-3cfdfeaae000
+      - backups
+      - private_networking
+      - ipv6
+      backup_ids:
+      - 53893572
+      next_backup_window:
+        start: '2020-07-30T00:00:00Z'
+        end: '2020-07-30T23:00:00Z'
+      snapshot_ids:
+      - 67512819
+      image:
+        id: 63663980
+        name: 20.04 (LTS) x64
+        distribution: Ubuntu
+        slug: ubuntu-20-04-x64
+        public: true
+        regions:
+        - ams2
+        - ams3
+        - blr1
+        - fra1
+        - lon1
+        - nyc1
+        - nyc2
+        - nyc3
+        - sfo1
+        - sfo2
+        - sfo3
+        - sgp1
+        - tor1
+        created_at: '2020-05-15T05:47:50Z'
+        type: snapshot
+        min_disk_size: 20
+        size_gigabytes: 2.36
+        description: ''
+        tags: []
+        status: available
+        error_message: ''
+      volume_ids: []
+      size:
+        slug: 's-1vcpu-1gb'
+        memory: 1024
+        vcpus: 1
+        disk: 25
+        transfer: 1.0
+        price_monthly: 5.0
+        price_hourly: 0.00743999984115362
+        regions:
+        - ams2
+        - ams3
+        - blr1
+        - fra1
+        - lon1
+        - nyc1
+        - nyc2
+        - nyc3
+        - sfo1
+        - sfo2
+        - sfo3
+        - sgp1
+        - tor1
+        available: true
+      size_slug: s-1vcpu-1gb
+      networks:
+        v4:
+          - ip_address: '10.128.192.124'
+            netmask: '255.255.0.0'
+            gateway: nil
+            type: private
+          - ip_address: '192.241.165.154'
+            netmask: '255.255.255.0'
+            gateway: '192.241.165.1'
+            type: public
+        v6:
+          - ip_address: '2604:a880:0:1010::18a:a001'
+            netmask: 64
+            gateway: '2604:a880:0:1010::1'
+            type: public
+      region:
+        name: New York 3
+        slug: nyc3
+        features:
+            - private_networking
+            - backups
+            - ipv6
+            - metadata
+            - install_agent
+            - storage
+            - image_transfer
+        available: true
+        sizes:
+            - s-1vcpu-1gb
+            - s-1vcpu-2gb
+            - s-1vcpu-3gb
+            - s-2vcpu-2gb
+            - s-3vcpu-1gb
+            - s-2vcpu-4gb
+            - s-4vcpu-8gb
+            - s-6vcpu-16gb
+            - s-8vcpu-32gb
+            - s-12vcpu-48gb
+            - s-16vcpu-64gb
+            - s-20vcpu-96gb
+            - s-24vcpu-128gb
+            - s-32vcpu-192g
+      tags:
+      - web
+      - env:prod
+      vpc_uuid: 760e09ef-dc84-11e8-981e-3cfdfeaae000
 
 droplet_create_response:
   value:


### PR DESCRIPTION
While working on the contract tests, I found an issue with the GET Droplet response example