### PR TITLE
droplet: vpc_uuid not included in create response.

### DIFF
--- a/specification/resources/droplets/models/droplet.yml
+++ b/specification/resources/droplets/models/droplet.yml
@@ -181,4 +181,3 @@ required:
 - networks
 - region
 - tags
-- vpc_uuid

--- a/specification/resources/droplets/responses/examples.yml
+++ b/specification/resources/droplets/responses/examples.yml
@@ -818,7 +818,6 @@ droplet_create_response:
       tags:
       - web
       - env:prod
-      vpc_uuid: 760e09ef-dc84-11e8-981e-3cfdfeaae000
     links:
       actions:
       - id: 7515
@@ -931,7 +930,6 @@ droplet_multi_create_response:
       tags:
       - web
       - env:prod
-      vpc_uuid: 760e09ef-dc84-11e8-981e-3cfdfeaae000
     - id: 3164445
       name: sub-02.example.com
       memory: 1024
@@ -1035,7 +1033,6 @@ droplet_multi_create_response:
       tags:
       - web
       - env:prod
-      vpc_uuid: 760e09ef-dc84-11e8-981e-3cfdfeaae000
     links:
       actions:
       - id: 7515


### PR DESCRIPTION
The `vpc_uuid` is not returned in response to POSTs to `/v2/droplets`. It is only returned in subsequent GET requests. This removes it from the `required` list for the droplet model.

Fixing this also resolves the other validation errors shown as they stem from the response not matching `oneOf` since the "require" attribute is missing.

Request:

```
$ curl -v -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $DO_TOKEN" -d '{"name":"web.example.com","region":"nyc3","size":"s-2vcpu-2gb","image":"ubuntu-20-04-x64"}' "http://0.0.0.0:8080/v2/droplets"
```

Header:

```
< sl-violations: [{"location":["response","body","droplet"],"severity":"Error","code":"required","message":"should have required property 'vpc_uuid'"},{"location":["response","body"],"severity":"Error","code":"required","message":"should have required property 'droplets'"},{"location":["response","body"],"severity":"Error","code":"oneOf","message":"should match exactly one schema in oneOf"}]
```

Response:

```
{"droplet":{"id":220685719,"name":"web.example.com","memory":2048,"vcpus":2,"disk":60,"locked":false,"status":"new","kernel":null,"created_at":"2020-12-09T22:05:58Z","features":[],"backup_ids":[],"next_backup_window":null,"snapshot_ids":[],"image":{"id":72067660,"name":"20.04 (LTS) x64","distribution":"Ubuntu","slug":"ubuntu-20-04-x64","public":true,"regions":["nyc3","nyc1","sfo1","nyc2","ams2","sgp1","lon1","ams3","fra1","tor1","sfo2","blr1","sfo3"],"created_at":"2020-10-20T16:34:30Z","min_disk_size":15,"type":"base","size_gigabytes":0.52,"description":"Ubuntu 20.04 x86","tags":[],"status":"available"},"volume_ids":[],"size":{"slug":"s-2vcpu-2gb","memory":2048,"vcpus":2,"disk":60,"transfer":3,"price_monthly":15,"price_hourly":0.02232,"regions":["ams2","ams3","blr1","fra1","lon1","nyc1","nyc2","nyc3","sfo1","sfo2","sfo3","sgp1","tor1"],"available":true},"size_slug":"s-2vcpu-2gb","networks":{"v4":[],"v6":[]},"region":{"name":"New York 3","slug":"nyc3","features":["backups","ipv6","metadata","install_agent","storage","image_transfer","server_id","management_networking"],"available":true,"sizes":["s-1vcpu-1gb","512mb","s-1vcpu-2gb","1gb","s-3vcpu-1gb","s-2vcpu-2gb","s-1vcpu-3gb","s-2vcpu-4gb","2gb","s-4vcpu-8gb","m-1vcpu-8gb","c-2","4gb","c2-2vcpu-4gb","g-2vcpu-8gb","gd-2vcpu-8gb","m-16gb","s-8vcpu-16gb","m-2vcpu-16gb","s-6vcpu-16gb","c-4","8gb","c2-4vpcu-8gb","m3-2vcpu-16gb","g-4vcpu-16gb","m6-2vcpu-16gb","gd-4vcpu-16gb","m-32gb","m-4vcpu-32gb","s-8vcpu-32gb","c-8","16gb","c2-8vpcu-16gb","m3-4vcpu-32gb","g-8vcpu-32gb","s-12vcpu-48gb","m6-4vcpu-32gb","gd-8vcpu-32gb","m-64gb","m-8vcpu-64gb","s-16vcpu-64gb","c-16","32gb","c2-16vcpu-32gb","m3-8vcpu-64gb","g-16vcpu-64gb","s-20vcpu-96gb","48gb","m6-8vcpu-64gb","gd-16vcpu-64gb","m-128gb","m-16vcpu-128gb","s-24vcpu-128gb","64gb","c2-32vpcu-64gb","m3-16vcpu-128gb","m-24vcpu-192gb","g-32vcpu-128gb","s-32vcpu-192gb","m6-16vcpu-128gb","m-224gb","m3-24vcpu-192gb","m6-24vcpu-192gb","m3-32vcpu-256gb","m6-32vcpu-256gb"]},"tags":[]},"links":{"actions":[{"id":1087353574,"rel":"create","href":"https://api.digitalocean.com/v2/actions/1087353574"}]}}
```