### PR TITLE
ssh keys: Rework to match current practices and address Prism issues

### DIFF
--- a/specification/resources/ssh_keys/create_ssh_key.yml
+++ b/specification/resources/ssh_keys/create_ssh_key.yml
@@ -11,10 +11,6 @@ tags:
   - SSH Keys
 
 requestBody:
-  description: >-
-    Set the `name` attribute to the name you wish to use and the `public_key` attribute
-    to the full public key you are adding.
-
   required: true
 
   content:
@@ -24,33 +20,7 @@ requestBody:
 
 responses:
   '201':
-    description: Created
-
-    headers:
-      ratelimit-limit:
-        $ref: '../../shared/headers.yml#/ratelimit-limit'
-      ratelimit-remaining:
-        $ref: '../../shared/headers.yml#/ratelimit-remaining'
-      ratelimit-reset:
-        $ref: '../../shared/headers.yml#/ratelimit-reset'
-
-    content:
-      application/json:
-        schema:
-          $ref: 'models/wrapped_ssh_key.yml'
-
-    links:
-      GetSSHKeyById:
-        $ref: 'links/get_ssh_key_by_id.yml'
-
-      GetSSHKeyByFingerprint:
-        $ref: 'links/get_ssh_key_by_fingerprint.yml'
-
-      DeleteSSHKeyById:
-        $ref: 'links/delete_ssh_key_by_id.yml'
-
-      DeleteSSHKeyByFingerprint:
-        $ref: 'links/delete_ssh_key_by_fingerprint.yml'
+    $ref: 'responses/key_created.yml'
 
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
@@ -60,5 +30,3 @@ responses:
 
   default:
     $ref: '../../shared/responses/unexpected_error.yml'
-
-

--- a/specification/resources/ssh_keys/models/ssh_key.yml
+++ b/specification/resources/ssh_keys/models/ssh_key.yml
@@ -9,8 +9,8 @@ properties:
 
   public_key:
     description: >-
-      The entire public key string that was uploaded. Embedded into the root user's authorized_keys file 
-      if you include this key during Droplet creation.
+      The entire public key string that was uploaded. Embedded into the root
+      user's `authorized_keys` file if you include this key during Droplet creation.
     type: string
     example: "ssh-rsa AEXAMPLEaC1yc2EAAAADAQABAAAAQQDDHr/jh2Jy4yALcK4JyWbVkPRaWmhck3IgCoeOO3z1e2dBowLh64QAM+Qb72pxekALga2oi4GvT+TlWNhzPH4V example"
 

--- a/specification/resources/ssh_keys/models/ssh_key.yml
+++ b/specification/resources/ssh_keys/models/ssh_key.yml
@@ -18,7 +18,5 @@ properties:
     $ref: '../attributes/ssh_key_name.yml'
 
 required:
-  - id
-  - fingerprint
   - public_key
   - name

--- a/specification/resources/ssh_keys/models/wrapped_ssh_key.yml
+++ b/specification/resources/ssh_keys/models/wrapped_ssh_key.yml
@@ -1,8 +1,0 @@
-type: object
-
-properties:
-  ssh_key:
-    $ref: 'ssh_key.yml'
-
-required:
-  - ssh_key

--- a/specification/resources/ssh_keys/parameters/ssh_key_identifier.yml
+++ b/specification/resources/ssh_keys/parameters/ssh_key_identifier.yml
@@ -1,9 +1,9 @@
 in: path
 name: ssh_key_identifier
 required: true
-description: Either the id or the fingerprint of an existing ssh key.
+description: Either the ID or the fingerprint of an existing SSH key.
 schema:
-  oneOf:
+  anyOf:
     - $ref: '../attributes/ssh_key_id.yml'
     - $ref: '../attributes/ssh_key_fingerprint.yml'
 example: 512189

--- a/specification/resources/ssh_keys/responses/existing_key.yml
+++ b/specification/resources/ssh_keys/responses/existing_key.yml
@@ -1,5 +1,5 @@
 description: >-
-  A JSON object with the key set to `ssh_key`. The value is an `ssh_key` object 
+  A JSON object with the key set to `ssh_key`. The value is an `ssh_key` object
   containing the standard `ssh_key` attributes.
 
 headers:
@@ -13,7 +13,9 @@ headers:
 content:
   application/json:
     schema:
-      $ref: '../models/wrapped_ssh_key.yml'
+      properties:
+        ssh_key:
+          $ref: '../models/ssh_key.yml'
 
 links:
   GetSSHKeyById:

--- a/specification/resources/ssh_keys/responses/existing_key.yml
+++ b/specification/resources/ssh_keys/responses/existing_key.yml
@@ -18,15 +18,15 @@ content:
           $ref: '../models/ssh_key.yml'
 
 links:
-  GetSSHKeyById:
+  get_ssh_key_by_id:
     $ref: '../links/get_ssh_key_by_id.yml'
 
-  GetSSHKeyByFingerprint:
+  get_ssh_key_by_fingerprint:
     $ref: '../links/get_ssh_key_by_fingerprint.yml'
 
-  DeleteSSHKeyById:
+  delete_ssh_key_by_id:
     $ref: '../links/delete_ssh_key_by_id.yml'
 
-  DeleteSSHKeyByFingerprint:
+  delete_ssh_key_by_fingerprint:
     $ref: '../links/delete_ssh_key_by_fingerprint.yml'
 

--- a/specification/resources/ssh_keys/responses/key_created.yml
+++ b/specification/resources/ssh_keys/responses/key_created.yml
@@ -1,0 +1,29 @@
+description: The response body will be a JSON object with a key set to `ssh_key`.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      properties:
+        ssh_key:
+          $ref: '../models/ssh_key.yml'
+
+links:
+  GetSSHKeyById:
+    $ref: '../links/get_ssh_key_by_id.yml'
+
+  GetSSHKeyByFingerprint:
+    $ref: '../links/get_ssh_key_by_fingerprint.yml'
+
+  DeleteSSHKeyById:
+    $ref: '../links/delete_ssh_key_by_id.yml'
+
+  DeleteSSHKeyByFingerprint:
+    $ref: '../links/delete_ssh_key_by_fingerprint.yml'

--- a/specification/resources/ssh_keys/responses/key_created.yml
+++ b/specification/resources/ssh_keys/responses/key_created.yml
@@ -16,14 +16,14 @@ content:
           $ref: '../models/ssh_key.yml'
 
 links:
-  GetSSHKeyById:
+  get_ssh_key_by_id:
     $ref: '../links/get_ssh_key_by_id.yml'
 
-  GetSSHKeyByFingerprint:
+  get_ssh_key_by_fingerprint:
     $ref: '../links/get_ssh_key_by_fingerprint.yml'
 
-  DeleteSSHKeyById:
+  delete_ssh_key_by_id:
     $ref: '../links/delete_ssh_key_by_id.yml'
 
-  DeleteSSHKeyByFingerprint:
+  delete_ssh_key_by_fingerprint:
     $ref: '../links/delete_ssh_key_by_fingerprint.yml'


### PR DESCRIPTION
Prism currently reports a few "false positive" violations for the SSH key endpoints. This also reworks the layout in a few places to better match our current practices.

POST 
```
[PROXY] ℹ  info      Forwarding "post" request to https://api.digitalocean.com/v2/account/keys...
[PROXY] ℹ  info      The upstream call to /v2/account/keys has returned 201
[VALIDATOR] ✖  error     Violation: request.body should have required property 'id'
[VALIDATOR] ✖  error     Violation: request.body should have required property 'fingerprint'
```

GET
```
[VALIDATOR] ✖  error     Violation: request.path.ssh_key_identifier should match exactly one schema in oneOf
```