### PR TITLE
Update spectral to 5.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,28 +14,28 @@
       }
     },
     "@nodelib/fs.scandir": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.stat": "2.0.3",
+        "@nodelib/fs.stat": "2.0.4",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
       "dev": true
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.scandir": "2.1.3",
+        "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
       }
     },
@@ -184,9 +184,9 @@
       "dev": true
     },
     "@stoplight/spectral": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral/-/spectral-5.7.1.tgz",
-      "integrity": "sha512-YsoSzKX2F07cEm8xTGKUo8CEvK0mO+3laVpJfP6QnBTNPz4Ym7GoRarbCbRJXkd6scoVGANlFDKQnnD1GvdEuw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral/-/spectral-5.8.0.tgz",
+      "integrity": "sha512-KzcdC3qhxK9rKIipMJeviR+vlbVHBofCKqOnGEa73ZyYOpgn7YL5i9YEkVOMLO2vBfnLVGsRroTfa4KnRodjoA==",
       "dev": true,
       "requires": {
         "@stoplight/better-ajv-errors": "0.0.3",
@@ -389,9 +389,9 @@
       }
     },
     "astring": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/astring/-/astring-1.4.3.tgz",
-      "integrity": "sha512-yJlJU/bmN820vL+cbWShu2YQU87dBP5V7BH2N4wODapRv27A2dZtUD0LgjP9lZENvPe9XRoSyWx+pZR6qKqNBw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.6.0.tgz",
+      "integrity": "sha512-8Rhu9cQMu4CSie4IOTAgQl75kZ8dp+gmOipjCAkV1ZVSwuDXRKXDbi8YAlCOKzIh3mws/hNoXJu8EkZwfCakLQ==",
       "dev": true
     },
     "async": {
@@ -984,9 +984,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
-      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
+      "integrity": "sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -1325,9 +1325,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@digitalocean/apiv2-openapi",
+  "name": "@digitalocean/openapi",
   "version": "2.0.0",
   "description": "OpenAPI v3 specification for DigitalOcean's public API v2.",
   "dependencies": {},
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/digitalocean/apiv2-openapi.git"
+    "url": "git+https://github.com/digitalocean/openapi.git"
   },
   "keywords": [
     "openapi",
@@ -30,7 +30,7 @@
   "author": "DigitalOcean API Engineering",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/digitalocean/apiv2-openapi/issues"
+    "url": "https://github.com/digitalocean/openapi/issues"
   },
-  "homepage": "https://github.com/digitalocean/apiv2-openapi#readme"
+  "homepage": "https://github.com/digitalocean/openapi#readme"
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {},
   "devDependencies": {
     "@redocly/openapi-cli": "^1.0.0-beta.8",
-    "@stoplight/spectral": "^5.7.1",
+    "@stoplight/spectral": "^5.8.0",
     "newman": "^5.1.2",
     "openapi-to-postmanv2": "^1.2.6"
   },

--- a/specification/resources/databases/models/database_connection.yml
+++ b/specification/resources/databases/models/database_connection.yml
@@ -11,7 +11,7 @@ properties:
   database:
     type: string
     description: The name of the default database.
-    example:
+    example: defaultdb
     readOnly: true
   host:
     type: string

--- a/specification/resources/databases/models/firewall_rule.yml
+++ b/specification/resources/databases/models/firewall_rule.yml
@@ -32,7 +32,7 @@ properties:
   created_at:
     type: string
     format: date-time
-    example:
+    example: 2019-01-11T18:37:36Z
     description: >-
       A time value given in ISO8601 combined date and time format that
       represents when the firewall rule was created.


### PR DESCRIPTION
New upstream release with some validation improvements that picked up a few missing examples.