### PR TITLE
tags: Fix response code for POST.

### DIFF
--- a/specification/resources/tags/create_new_tag.yml
+++ b/specification/resources/tags/create_new_tag.yml
@@ -17,7 +17,7 @@ requestBody:
         $ref: 'models/tag.yml'
 
 responses:
-  '200':
+  '201':
     $ref: 'responses/new_tag.yml'
 
   '400':


### PR DESCRIPTION
https://developers.digitalocean.com/documentation/v2/#create-a-new-tag

Request:

```
curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $DO_TOKEN" -d '{"name":"foobarbaz"}' "http://0.0.0.0:8080/v2/tags"
```

Prism before:

```
proxy_1  | [9:08:28 PM] › [HTTP SERVER] post /v2/tags ℹ  info      Request received
proxy_1  | [9:08:28 PM] ›     [PROXY] ℹ  info      Forwarding "post" request to https://api.digitalocean.com/v2/tags...
proxy_1  | [9:08:29 PM] ›     [PROXY] ℹ  info      The upstream call to /v2/tags has returned 201
proxy_1  | [9:08:29 PM] ›     [VALIDATOR] ✖  error     Violation: response.body should have required property 'id'
proxy_1  | [9:08:29 PM] ›     [VALIDATOR] ✖  error     Violation: response.body should have required property 'message'
```

Prism after:

```
proxy_1  | [9:10:46 PM] › [HTTP SERVER] post /v2/tags ℹ  info      Request received
proxy_1  | [9:10:46 PM] ›     [PROXY] ℹ  info      Forwarding "post" request to https://api.digitalocean.com/v2/tags...
proxy_1  | [9:10:47 PM] ›     [PROXY] ℹ  info      The upstream call to /v2/tags has returned 201
```