### PR TITLE
boolean is not a valid format.

### DIFF
--- a/specification/resources/apps/models/app_database_spec.yml
+++ b/specification/resources/apps/models/app_database_spec.yml
@@ -41,7 +41,6 @@ properties:
 
   production:
     description: Whether this is a production or dev database.
-    format: boolean
     type: boolean
     example: true
 

--- a/specification/resources/apps/models/apps_create_deployment_request.yml
+++ b/specification/resources/apps/models/apps_create_deployment_request.yml
@@ -4,7 +4,6 @@ properties:
     type: string
     example: 4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf
   force_build:
-    format: boolean
     title: Indicates whether to force a build of app from source even if an existing
       cached build is suitable for re-use
     type: boolean

--- a/specification/resources/apps/models/apps_detect_response.yml
+++ b/specification/resources/apps/models/apps_detect_response.yml
@@ -11,12 +11,10 @@ properties:
     type: string
     example: Error
   template_found:
-    format: boolean
     title: Whether or not a deploy template was found
     type: boolean
     example: true
   template_valid:
-    format: boolean
     title: Whether or not the deploy template is valid
     type: boolean
     example: true

--- a/specification/resources/apps/models/apps_propose_app_response.yml
+++ b/specification/resources/apps/models/apps_propose_app_response.yml
@@ -4,11 +4,9 @@ properties:
     type: number
     example: 23.23
   app_is_static:
-    format: boolean
     type: boolean
     example: true
   app_name_available:
-    format: boolean
     type: boolean
     example: true
   app_name_suggestion:

--- a/specification/resources/apps/models/apps_region.yml
+++ b/specification/resources/apps/models/apps_region.yml
@@ -15,12 +15,10 @@ properties:
       - ams
   default:
     description: Whether or not the region is presented as the default.
-    format: boolean
     readOnly: true
     type: boolean
     example: true
   disabled:
-    format: boolean
     readOnly: true
     title: Whether or not the region is open for new apps
     type: boolean

--- a/specification/resources/apps/parameters.yml
+++ b/specification/resources/apps/parameters.yml
@@ -23,7 +23,7 @@ app_name:
   schema:
     type: string
   example: myApp
-    
+
 id_app:
   description: The ID of the app
   in: path
@@ -51,13 +51,12 @@ component:
   schema:
     type: string
   example: component
-    
+
 live_updates:
   description: Whether the logs should follow live updates.
   in: query
   name: follow
   schema:
-    format: boolean
     type: boolean
   example: true
 


### PR DESCRIPTION
When experimenting with some code generators, I've notice that some warn or error on the usage of `format: boolean`. 

`format` extends `type` which is already `boolean` in these cases.

https://swagger.io/specification/#data-types