### PR TITLE
Resolving openapi-gen 5.0 release error: APICLI-550

### DIFF
--- a/specification/resources/domains/models/domain_record.yml
+++ b/specification/resources/domains/models/domain_record.yml
@@ -1,5 +1,6 @@
 type: object
-
+required:
+  - type
 properties:
   id:
     type: integer

--- a/specification/resources/domains/patch_update_domain_record.yml
+++ b/specification/resources/domains/patch_update_domain_record.yml
@@ -25,6 +25,7 @@ requestBody:
 
       example:
         name: blog
+        type: A
 
 responses:
   '200':

--- a/specification/resources/domains/update_domain_record.yml
+++ b/specification/resources/domains/update_domain_record.yml
@@ -25,6 +25,7 @@ requestBody:
 
       example:
         name: blog
+        type: CNAME
 
 responses:
   '200':

--- a/specification/resources/droplets/models/droplet_actions.yml
+++ b/specification/resources/droplets/models/droplet_actions.yml
@@ -1,4 +1,6 @@
 droplet_action_type:
+  required:
+    - type
   type: object
   description: Specifies the action that will be taken on the Droplet.
   properties:


### PR DESCRIPTION
Resolved the following exception:
  "Exception: 'null' defines discriminator 'type', but the referenced schema 'domain_record_a' is incorrect. invalid optional definition of type, include it in required"

Exception was happening for both domain_record and droplet_action. Basically whenever a discriminator is used to express polymorphism and a choice of object definitions, the objects definitions must have a type property set as required otherwise validation would fail.

after resolving issue, generator found a different error:

Exception: 'null' defines discriminator 'type', but the referenced schema 'floating_ip_action_unassign' is incorrect. invalid type for type, set it to string

will resolve in another jira ticket.