### PR TITLE
Resolving errors pertaining to "floating_ip" clientgen

### DIFF
--- a/specification/resources/floating_ips/models/floating_ip_actions.yml
+++ b/specification/resources/floating_ips/models/floating_ip_actions.yml
@@ -1,31 +1,34 @@
 floating_ip_action_type:
-  type: string
-  enum:
-  - assign
-  - unassign
-  example: assign
-  description: The type of action to initiate for the floating IP.
+  type: object
+  required:
+    - type
+  discriminator:
+    propertyName: type
+    mapping:
+      ASSIGN: '#/floating_ip_action_unassign'
+      UNASSIGN: '#/floating_ip_action_assign'
 
 floating_ip_action_unassign:
-  type: object
-  properties:
-    type:
-      $ref: '#/floating_ip_action_type'
-  additionalProperties: false
-  required:
-  - type
+  allOf:
+    - $ref: '#/floating_ip_action_type'
+    - type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
 
 floating_ip_action_assign:
-  type: object
-  properties:
-    type:
-      $ref: '#/floating_ip_action_type'
-
-    droplet_id:
-      type: integer
-      example: 758604968
-      description: The ID of the Droplet that the floating IP will be assigned to.
-
-  required:
-  - type
-  - droplet_id
+  allOf:
+    - $ref: '#/floating_ip_action_type'
+    - type: object
+      required:
+        - type
+        - droplet_id
+      properties:
+        type:
+          type: string
+        droplet_id:
+          type: integer
+          example: 758604968
+          description: The ID of the Droplet that the floating IP will be assigned to.

--- a/specification/resources/floating_ips/models/floating_ip_actions.yml
+++ b/specification/resources/floating_ips/models/floating_ip_actions.yml
@@ -2,6 +2,10 @@ floating_ip_action_type:
   type: object
   required:
     - type
+  properties:
+    type:
+      type: string
+      description: The type of action to initiate for the floating IP.
   discriminator:
     propertyName: type
     mapping:
@@ -14,9 +18,6 @@ floating_ip_action_unassign:
     - type: object
       required:
         - type
-      properties:
-        type:
-          type: string
 
 floating_ip_action_assign:
   allOf:
@@ -26,8 +27,6 @@ floating_ip_action_assign:
         - type
         - droplet_id
       properties:
-        type:
-          type: string
         droplet_id:
           type: integer
           example: 758604968


### PR DESCRIPTION
Was running openapi generator and ran into the following exception:
Exception: 'null' defines discriminator 'type', but the referenced schema 'floating_ip_action_unassign' is incorrect. invalid type for type, set it to string

Solution: must specify the discriminator mapping in the base schema, which in this case is "floating_ip_action_type"

Was able to move past that exception and on to another, which will be resolved in a different pr.