### PR TITLE
Resolve openapi-generator 5.0.0 errors - new_volume_ext4 errors.

### DIFF
--- a/specification/resources/floating_ips/models/floating_ip_actions.yml
+++ b/specification/resources/floating_ips/models/floating_ip_actions.yml
@@ -1,31 +1,34 @@
 floating_ip_action_type:
-  type: string
-  enum:
-  - assign
-  - unassign
-  example: assign
-  description: The type of action to initiate for the floating IP.
+  type: object
+  required:
+    - type
+  discriminator:
+    propertyName: type
+    mapping:
+      ASSIGN: '#/floating_ip_action_unassign'
+      UNASSIGN: '#/floating_ip_action_assign'
 
 floating_ip_action_unassign:
-  type: object
-  properties:
-    type:
-      $ref: '#/floating_ip_action_type'
-  additionalProperties: false
-  required:
-  - type
+  allOf:
+    - $ref: '#/floating_ip_action_type'
+    - type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
 
 floating_ip_action_assign:
-  type: object
-  properties:
-    type:
-      $ref: '#/floating_ip_action_type'
-
-    droplet_id:
-      type: integer
-      example: 758604968
-      description: The ID of the Droplet that the floating IP will be assigned to.
-
-  required:
-  - type
-  - droplet_id
+  allOf:
+    - $ref: '#/floating_ip_action_type'
+    - type: object
+      required:
+        - type
+        - droplet_id
+      properties:
+        type:
+          type: string
+        droplet_id:
+          type: integer
+          example: 758604968
+          description: The ID of the Droplet that the floating IP will be assigned to.

--- a/specification/resources/floating_ips/models/floating_ip_actions.yml
+++ b/specification/resources/floating_ips/models/floating_ip_actions.yml
@@ -2,6 +2,10 @@ floating_ip_action_type:
   type: object
   required:
     - type
+  properties:
+    type:
+      type: string
+      description: The type of action to initiate for the floating IP.
   discriminator:
     propertyName: type
     mapping:
@@ -14,9 +18,6 @@ floating_ip_action_unassign:
     - type: object
       required:
         - type
-      properties:
-        type:
-          type: string
 
 floating_ip_action_assign:
   allOf:
@@ -26,8 +27,6 @@ floating_ip_action_assign:
         - type
         - droplet_id
       properties:
-        type:
-          type: string
         droplet_id:
           type: integer
           example: 758604968

--- a/specification/resources/volumes/models/attributes.yml
+++ b/specification/resources/volumes/models/attributes.yml
@@ -1,18 +1,26 @@
 volume_write_file_system_type:
-  type: string
-  description: >-
-    The name of the filesystem type to be used on the volume.
-    When provided, the volume will automatically be formatted to the
-    specified filesystem type. Currently, the available options are `ext4`
-    and `xfs`.
-    Pre-formatted volumes are automatically mounted when attached to
-    Ubuntu, Debian, Fedora, Fedora Atomic, and CentOS Droplets created on
-    or after April 26, 2018.
-    Attaching pre-formatted volumes to other Droplets is not recommended.
-  enum:
-    - ext4
-    - xfs
-  example: ext4
+  type: object
+  required: 
+    - filesystem_type
+  properties:
+    filesystem_type:
+      type: string
+      description: >-
+        The name of the filesystem type to be used on the volume.
+        When provided, the volume will automatically be formatted to the
+        specified filesystem type. Currently, the available options are `ext4`
+        and `xfs`.
+        Pre-formatted volumes are automatically mounted when attached to
+        Ubuntu, Debian, Fedora, Fedora Atomic, and CentOS Droplets created on
+        or after April 26, 2018.
+        Attaching pre-formatted volumes to other Droplets is not recommended.
+      example: ext4
+  discriminator:
+    propertyName: filesystem_type
+    mapping:
+      EXT4: './new_volume_ext4.yml'
+      XFS: './new_volume_xfs.yml'
+
 
 volume_write_file_system_label:
   type: string

--- a/specification/resources/volumes/models/new_volume_ext4.yml
+++ b/specification/resources/volumes/models/new_volume_ext4.yml
@@ -1,18 +1,13 @@
 type: object
-
 allOf:
-
   - $ref: 'volume_base.yml'
-
+  - $ref: 'attributes.yml#/volume_write_file_system_type'
   - properties:
-
       region:
         $ref: '../../../shared/attributes/region_slug.yml'
-
-      filesystem_type:
-        $ref: 'attributes.yml#/volume_write_file_system_type'
-
       filesystem_label:
         allOf:
           - $ref: 'attributes.yml#/volume_write_file_system_label'
           - maxLength: 16
+    required:
+      - filesystem_type

--- a/specification/resources/volumes/models/new_volume_xfs.yml
+++ b/specification/resources/volumes/models/new_volume_xfs.yml
@@ -1,17 +1,10 @@
 type: object
-
 allOf:
-
   - $ref: 'volume_base.yml'
-
+  - $ref: 'attributes.yml#/volume_write_file_system_type'
   - properties:
-
       region:
         $ref: '../../../shared/attributes/region_slug.yml'
-
-      filesystem_type:
-        $ref: 'attributes.yml#/volume_write_file_system_type'
-
       filesystem_label:
         allOf:
           - $ref: 'attributes.yml#/volume_write_file_system_label'


### PR DESCRIPTION
Resolving errors with openapi-generator 5.0.0

When inputting the DO openapi spec into the latest release of openapi-generator, I would get an exception with new_volume_ext4 and new_volume_xfs (a "filesystem_type" needs to be required and a type of string")
    
Solution: include discriminator in the base schema (volume_write_file_system_type).
    
This resolved the exceptions.
    
With this PR, the DO spec is accepted into the latest version of openapi-generator (5.0.0) exception/error free and is able to generate a python client.