### PR TITLE
domains: Fix status code and set ttl nullable & readOnly.

### DIFF
--- a/specification/resources/domains/create_domain.yml
+++ b/specification/resources/domains/create_domain.yml
@@ -22,7 +22,7 @@ requestBody:
           $ref: 'examples.yml#/domain_record_created'
 
 responses:
-  '202':
+  '201':
     $ref: 'responses/create_domain_response.yml'
 
   '401':

--- a/specification/resources/domains/models/domain.yml
+++ b/specification/resources/domains/models/domain.yml
@@ -10,6 +10,8 @@ properties:
 
   ttl:
     type: integer
+    readOnly: true
+    nullable: true
     description: >-
       This value is the time to live for the records on this domain, in seconds.
       This defines the time frame that clients can cache queried information


### PR DESCRIPTION
Building out contract tests in https://github.com/digitalocean/contract/pull/29, I was seeing these errors:

```
=== FAIL: suite TestDomains_Create/create_domain_with_ip_address (0.88s)
    round_trippers.go:94: request_id=0fc64f0b-929e-4d59-b39b-749a608651ab method=POST host=localhost:4010 path=/v2/domains status_code=201 err=<nil> took=880.974368ms
    prism_proxy.go:208: [CONTRACT TEST VIOLATION] code=required message=should have required property 'id' severity=Error location=response.body
    prism_proxy.go:208: [CONTRACT TEST VIOLATION] code=required message=should have required property 'message' severity=Error location=response.body
    --- FAIL: TestDomains_Create/create_domain_with_ip_address (0.88s)
```

That is because the response is a 201 Created, not a 202 Accepted.  As no 201 response is specified, it fails back to the default error response for validation.

https://developers.digitalocean.com/documentation/v2/#create-a-new-domain

`ttl` is also returned as `null` on create. It is only populated on subsequent GETs. It is read only.
