### PR TITLE
k8s: maintenance_policy can be null.

### DIFF
--- a/specification/resources/kubernetes/models/maintenance_policy.yml
+++ b/specification/resources/kubernetes/models/maintenance_policy.yml
@@ -1,5 +1,5 @@
 type: object
-
+nullable: true
 description: An object specifying the maintenance window policy for the
   Kubernetes cluster.
 


### PR DESCRIPTION
Building contract tests in https://github.com/digitalocean/contract/pull/25, I was seeing these errors:

```
    prism_proxy.go:208: [CONTRACT TEST VIOLATION] code=type message=should be object severity=Error location=request.body.maintenance_policy
    --- FAIL: TestOneClicks_InstallKubernetes/create_kubernetes_cluster (489.64s)
```

When creating a Kuberenetes cluster,  `maintenance_policy` policy object can be `null`. In fact, any request via godo that does not explicitly specify one sends `null` as we do not use `omitempty` on the struct field: 

https://github.com/digitalocean/godo/blob/c3fc90e15b3337fea6395059d1cb235f81dcabcf/kubernetes.go#L76