### PR TITLE
k8s: Update response code for PUT /v2/kubernetes/clusters/{uuid}

### DIFF
--- a/specification/resources/kubernetes/update_cluster.yml
+++ b/specification/resources/kubernetes/update_cluster.yml
@@ -22,7 +22,7 @@ requestBody:
         $ref: 'models/cluster_update.yml'
 
 responses:
-  '200':
+  '202':
     $ref: 'responses/updated_cluster.yml'
 
   '401':


### PR DESCRIPTION
Writing contract tests, I found that the spec does not match current docs or reality.

https://developers.digitalocean.com/documentation/v2/#update-a-kubernetes-cluster