### PR TITLE
tags: Fix regex for tag name in path.

### DIFF
--- a/specification/resources/tags/models/tag.yml
+++ b/specification/resources/tags/models/tag.yml
@@ -1,31 +1,32 @@
 type: object
 
-description: >- 
-  A tag is a label that can be applied to a resource (currently Droplets, Images, Volumes, Volume Snapshots, and Database clusters) 
+description: >-
+  A tag is a label that can be applied to a resource (currently Droplets, Images, Volumes, Volume Snapshots, and Database clusters)
   in order to better organize or facilitate the lookups and actions on it.
 
   Tags have two attributes: a user defined `name` attribute and an embedded `resources` attribute with information about resources that have been tagged.
 
 properties:
-  
+
   name:
     type: string
     description: |
-      The name of the tag. Tags may contain letters, numbers, colons, dashes, and underscores. 
-      There is a limit of 255 characters per tag.  
+      The name of the tag. Tags may contain letters, numbers, colons, dashes, and underscores.
+      There is a limit of 255 characters per tag.
 
       **Note:** Tag names are case stable, which means the capitalization you use when you first create a tag is canonical.
 
       When working with tags in the API, you must use the tag's canonical capitalization. For example, if you create a tag named "PROD", the URL to add that tag to a resource would be `https://api.digitalocean.com/v2/tags/PROD/resources` (not `/v2/tags/prod/resources`).
 
       Tagged resources in the control panel will always display the canonical capitalization. For example, if you create a tag named "PROD", you can tag resources in the control panel by entering "prod". The tag will still display with its canonical capitalization, "PROD".
-    pattern: '^[\w-:]+$'
+    pattern: '^[a-zA-Z0-9_\-\:]+$'
+    maxLength: 255
     example: extra-awesome
 
   resources:
     type: object
-    description: >- 
-      An embedded object containing key value pairs of resource type and resource statistics. 
+    description: >-
+      An embedded object containing key value pairs of resource type and resource statistics.
       It also includes a count of the total number of resources tagged with the current tag as well as a `last_tagged_uri` attribute set to the last resource tagged with the current tag.
     readOnly: true
     allOf:
@@ -43,7 +44,7 @@ properties:
             $ref: 'tag_metadata.yml'
     example:
       count: 5
-      last_tagged_uri: https://api.digitalocean.com/v2/images/7555620 
+      last_tagged_uri: https://api.digitalocean.com/v2/images/7555620
       droplets:
         count: 1
         last_tagged_uri: https://api.digitalocean.com/v2/droplets/3164444

--- a/specification/resources/tags/parameters.yml
+++ b/specification/resources/tags/parameters.yml
@@ -2,11 +2,11 @@ tag_id:
   in: path
   name: tag_id
   description: >-
-    The name of the tag. Tags may contain letters, numbers, colons, dashes, 
+    The name of the tag. Tags may contain letters, numbers, colons, dashes,
     and underscores. There is a limit of 255 characters per tag.
   required: true
   schema:
     type: string
     maxLength: 255
-    pattern: '^[a-zA-Z1-9_\-\:]+$'
+    pattern: '^[a-zA-Z0-9_\-\:]+$'
   example: awesome


### PR DESCRIPTION
The regex for tag name in path is missing `0` as a valid character. This also updates the regex used in the tag model so the two are consistent.

Fixing error found in contract testing:

```
=== RUN   TestTag_CreateShort/get_tag
    round_trippers.go:94: request_id=6c4bd201-ef6a-460b-818d-6ded21e0b8cb method=GET host=localhost:4010 path=/v2/tags/ct-107eb4dffbc62229 status_code=200 err=<nil> took=902.919554ms
    prism_proxy.go:208: [CONTRACT TEST VIOLATION] code=pattern message=should match pattern "^[a-zA-Z1-9_\-\:]+$" severity=Error location=request.path.tag_id
```