### PR TITLE
Missing Endpoints

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -498,6 +498,10 @@ paths:
     get:
       $ref: 'resources/apps/get_tier.yml'
 
+  /v2/apps/propose:
+    post:
+      $ref: 'resources/apps/propose_app.yml'
+
   /v2/cdn/endpoints:
     get:
       $ref: 'resources/cdn/list_all_endpoints.yml'
@@ -573,6 +577,10 @@ paths:
   /v2/databases/{database_cluster_uuid}/migrate:
     put:
       $ref: 'resources/databases/migrate_database_cluster.yml'
+
+  /v2/databases/{database_cluster_uuid}/resize:
+    put:
+      $ref: 'resources/databases/resize_database_cluster.yml'
 
   /v2/databases/{database_cluster_uuid}/firewall:
     get:

--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -644,6 +644,10 @@ paths:
     post:
       $ref: 'resources/databases/add_connection_pool.yml'
 
+  /v2/databases/{database_cluster_uuid}/pools/{pool_name}:
+    get:
+      $ref: 'resources/databases/get_connection_pool.yml'
+
   /v2/databases/{database_cluster_uuid}/eviction_policy:
     get:
       $ref: 'resources/databases/get_eviction_policy.yml'

--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -571,7 +571,7 @@ paths:
       $ref: 'resources/databases/create_database_cluster.yml'
     delete:
       $ref: 'resources/databases/destroy_cluster.yml'
-      
+
   /v2/databases/{database_cluster_uuid}:
     get:
       $ref: 'resources/databases/get_database_cluster.yml'
@@ -637,6 +637,10 @@ paths:
       $ref: 'resources/databases/get_database.yml'
     delete:
       $ref: 'resources/databases/delete_database.yml'
+
+  /v2/databases/{database_cluster_uuid}/pools:
+    post:
+      $ref: 'resources/databases/add_connection_pool.yml'
 
   /v2/databases/{database_cluster_uuid}/eviction_policy:
     get:

--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -569,7 +569,9 @@ paths:
       $ref: 'resources/databases/list_database_clusters.yml'
     post:
       $ref: 'resources/databases/create_database_cluster.yml'
-
+    delete:
+      $ref: 'resources/databases/destroy_cluster.yml'
+      
   /v2/databases/{database_cluster_uuid}:
     get:
       $ref: 'resources/databases/get_database_cluster.yml'

--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -515,6 +515,7 @@ paths:
 
     put:
       $ref: 'resources/cdn/update_endpoint.yml'
+
     delete:
       $ref: 'resources/cdn/delete_endpoint.yml'
 
@@ -582,7 +583,7 @@ paths:
     put:
       $ref: 'resources/databases/start_online_migration.yml'
 
-  /v2/databases/{database_cluster_uuid}/online-migration/{online_migration_id}:
+  /v2/databases/{database_cluster_uuid}/online-migration/{migration_id}:
     delete:
       $ref: 'resources/databases/stop_online_migration.yml'
 

--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -509,6 +509,8 @@ paths:
     get:
       $ref: 'resources/cdn/get_endpoint.yml'
 
+    put:
+      $ref: 'resources/cdn/update_endpoint.yml'
     delete:
       $ref: 'resources/cdn/delete_endpoint.yml'
 

--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -576,6 +576,12 @@ paths:
     get:
       $ref: 'resources/databases/get_database_cluster.yml'
 
+  /v2/databases/{database_cluster_uuid}/online-migration:
+    get:
+      $ref: 'resources/databases/get_migration_status.yml'
+    put:
+      $ref: 'resources/databases/start_online_migration.yml'
+
   /v2/databases/{database_cluster_uuid}/migrate:
     put:
       $ref: 'resources/databases/migrate_database_cluster.yml'

--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -570,13 +570,13 @@ paths:
       $ref: 'resources/databases/list_database_clusters.yml'
     post:
       $ref: 'resources/databases/create_database_cluster.yml'
-    delete:
-      $ref: 'resources/databases/destroy_cluster.yml'
 
   /v2/databases/{database_cluster_uuid}:
     get:
       $ref: 'resources/databases/get_database_cluster.yml'
-
+    delete:
+      $ref: 'resources/databases/destroy_cluster.yml'
+      
   /v2/databases/{database_cluster_uuid}/online-migration:
     get:
       $ref: 'resources/databases/get_migration_status.yml'

--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -647,6 +647,8 @@ paths:
   /v2/databases/{database_cluster_uuid}/pools/{pool_name}:
     get:
       $ref: 'resources/databases/get_connection_pool.yml'
+    delete:
+      $ref: 'resources/databases/delete_connection_pool.yml'
 
   /v2/databases/{database_cluster_uuid}/eviction_policy:
     get:

--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -582,6 +582,10 @@ paths:
     put:
       $ref: 'resources/databases/start_online_migration.yml'
 
+  /v2/databases/{database_cluster_uuid}/online-migration/{online_migration_id}:
+    delete:
+      $ref: 'resources/databases/stop_online_migration.yml'
+
   /v2/databases/{database_cluster_uuid}/migrate:
     put:
       $ref: 'resources/databases/migrate_database_cluster.yml'

--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -639,6 +639,8 @@ paths:
       $ref: 'resources/databases/delete_database.yml'
 
   /v2/databases/{database_cluster_uuid}/pools:
+    get:
+      $ref: 'resources/databases/list_connection_pools.yml'
     post:
       $ref: 'resources/databases/add_connection_pool.yml'
 

--- a/specification/resources/apps/examples/curl/propose_app.yml
+++ b/specification/resources/apps/examples/curl/propose_app.yml
@@ -1,6 +1,0 @@
-lang: cURL
-source: |-
-  curl -X POST \
-    -H "Content-Type: application/json" \
-    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-    "https://api.digitalocean.com/v2/apps/propose"

--- a/specification/resources/apps/models/app_propose.yml
+++ b/specification/resources/apps/models/app_propose.yml
@@ -1,75 +1,12 @@
 type: object
+
 properties:
-  app_is_static:
-    type: boolean
-    description: Indicates whether the app is a static app.
-    example: true
-
-  app_name_available:
-    type: boolean
-    description: Indicates whether the app name is available.
-    example: true
-
-  app_name_suggestion:
-    type: string
-    description: The suggested name if the proposed app name is unavailable.
-    example: newName
-
-  existing_static_apps:
-    type: string
-    description: The maximum number of free static apps the account can have.
-      We will charge you for any additional static apps.
-    example: 2
-
   spec:
     $ref: app_spec.yml
 
-  app_cost:
-    type: integer
-    format: int32
-    description: The monthly cost of the proposed app in USD using the next
-      pricing plan tier. For example, if you propose an app that uses the Basic
-      tier, the `app_tier_upgrade_cost` field displays the monthly cost of the
-      app if it were to use the Professional tier. If the proposed app already
-      uses the most expensive tier, the field is empty.
-    example: 5
-
-  app_tier_downgrade_cost:
-    type: integer
-    format: int32
-    description: The monthly cost of the proposed app in USD using the previous
-      pricing plan tier. For example, if you propose an app that uses the
-      Professional tier, the `app_tier_downgrade_cost` field displays the
-      monthly cost of the app if it were to use the Basic tier. If the proposed
-      app already uses the lest expensive tier, the field is empty.
-    example: 17
-
-  http_path:
+  app_id:
     type: string
-    description: The route path used for the HTTP health check ping. If not set, the
-      HTTP health check will be disabled and a TCP health check used instead.
-    example: /health
-
-  initial_delay_seconds:
-    type: integer
-    format: int32
-    description: The number of seconds to wait before beginning health checks.
-    example: 30
-
-  period_seconds:
-    type: integer
-    format: int32
-    description: The number of seconds to wait between health checks.
-    example: 60
-
-  success_threshold:
-    type: integer
-    format: int32
-    description: The number of successful health checks before considered healthy.
-    example: 3
-
-  timeout_seconds:
-    type: integer
-    format: int32
-    description: The number of seconds after which the check times out.
-    example: 45
+    description: An optional ID of an existing app. If set, the spec will be
+      treated as a proposed update to the specified app. The existing app is not
+      modified using this method.
+    example: b6bdf840-2854-4f87-a36c-5f231c617c84

--- a/specification/resources/apps/models/app_propose.yml
+++ b/specification/resources/apps/models/app_propose.yml
@@ -1,0 +1,74 @@
+type: object
+properties:
+  app_is_static:
+    type: boolean
+    description: Indicates whether the app is a static app.
+    example: true
+
+  app_name_available:
+    type: boolean
+    description: Indicates whether the app name is available.
+    example: true
+
+  app_name_suggestion:
+    type: string
+    description: The suggested name if the proposed app name is unavailable.
+
+  existing_static_apps:
+    type: string
+    description: The maximum number of free static apps the account can have.
+      We will charge you for any additional static apps.
+    example: 2
+
+  spec:
+    $ref: app_spec.yml
+
+  app_cost:
+    type: integer
+    format: int32
+    description: The monthly cost of the proposed app in USD using the next
+      pricing plan tier. For example, if you propose an app that uses the Basic
+      tier, the `app_tier_upgrade_cost` field displays the monthly cost of the
+      app if it were to use the Professional tier. If the proposed app already
+      uses the most expensive tier, the field is empty.
+    example: 5
+
+  app_tier_downgrade_cost:
+    type: integer
+    format: int32
+    description: The monthly cost of the proposed app in USD using the previous
+      pricing plan tier. For example, if you propose an app that uses the
+      Professional tier, the `app_tier_downgrade_cost` field displays the
+      monthly cost of the app if it were to use the Basic tier. If the proposed
+      app already uses the lest expensive tier, the field is empty.
+    example: 17
+
+  http_path:
+    type: string
+    description: The route path used for the HTTP health check ping. If not set, the
+      HTTP health check will be disabled and a TCP health check used instead.
+    example: /health
+
+  initial_delay_seconds:
+    type: integer
+    format: int32
+    description: The number of seconds to wait before beginning health checks.
+    example: 30
+
+  period_seconds:
+    type: integer
+    format: int32
+    description: The number of seconds to wait between health checks.
+    example: 60
+
+  success_threshold:
+    type: integer
+    format: int32
+    description: The number of successful health checks before considered healthy.
+    example: 3
+
+  timeout_seconds:
+    type: integer
+    format: int32
+    description: The number of seconds after which the check times out.
+    example: 45

--- a/specification/resources/apps/models/app_propose.yml
+++ b/specification/resources/apps/models/app_propose.yml
@@ -10,3 +10,6 @@ properties:
       treated as a proposed update to the specified app. The existing app is not
       modified using this method.
     example: b6bdf840-2854-4f87-a36c-5f231c617c84
+
+required:
+  - spec

--- a/specification/resources/apps/models/app_propose.yml
+++ b/specification/resources/apps/models/app_propose.yml
@@ -13,6 +13,7 @@ properties:
   app_name_suggestion:
     type: string
     description: The suggested name if the proposed app name is unavailable.
+    example: newName
 
   existing_static_apps:
     type: string

--- a/specification/resources/apps/models/app_propose_response.yml
+++ b/specification/resources/apps/models/app_propose_response.yml
@@ -20,7 +20,7 @@ properties:
     type: string
     description: The maximum number of free static apps the account can have.
       We will charge you for any additional static apps.
-    example: 2
+    example: '2'
 
   spec:
     $ref: app_spec.yml

--- a/specification/resources/apps/models/app_propose_response.yml
+++ b/specification/resources/apps/models/app_propose_response.yml
@@ -1,0 +1,46 @@
+type: object
+
+properties:
+  app_is_static:
+    type: boolean
+    description: Indicates whether the app is a static app.
+    example: true
+
+  app_name_available:
+    type: boolean
+    description: Indicates whether the app name is available.
+    example: true
+
+  app_name_suggestion:
+    type: string
+    description: The suggested name if the proposed app name is unavailable.
+    example: newName
+
+  existing_static_apps:
+    type: string
+    description: The maximum number of free static apps the account can have.
+      We will charge you for any additional static apps.
+    example: 2
+
+  spec:
+    $ref: app_spec.yml
+
+  app_cost:
+    type: integer
+    format: int32
+    description: The monthly cost of the proposed app in USD using the next
+      pricing plan tier. For example, if you propose an app that uses the Basic
+      tier, the `app_tier_upgrade_cost` field displays the monthly cost of the
+      app if it were to use the Professional tier. If the proposed app already
+      uses the most expensive tier, the field is empty.
+    example: 5
+
+  app_tier_downgrade_cost:
+    type: integer
+    format: int32
+    description: The monthly cost of the proposed app in USD using the previous
+      pricing plan tier. For example, if you propose an app that uses the
+      Professional tier, the `app_tier_downgrade_cost` field displays the
+      monthly cost of the app if it were to use the Basic tier. If the proposed
+      app already uses the lest expensive tier, the field is empty.
+    example: 17

--- a/specification/resources/apps/propose_app.yml
+++ b/specification/resources/apps/propose_app.yml
@@ -15,7 +15,7 @@ requestBody:
   content:
     application/json:
       schema:
-        $ref: models/apps_create_app_request.yml
+        $ref: models/app_propose.yml
       example:
         spec:
           name: web-app
@@ -32,6 +32,7 @@ requestBody:
               instance_size_slug: basic-xxs
               routes:
                 - path: /api
+        app_id: b6bdf840-2854-4f87-a36c-5f231c617c84
   required: true
 
 responses:

--- a/specification/resources/apps/propose_app.yml
+++ b/specification/resources/apps/propose_app.yml
@@ -1,4 +1,4 @@
-operationId: propose_app
+operationId: validate_app_spec
 
 summary: Propose an App Spec
 
@@ -16,7 +16,7 @@ requestBody:
     application/json:
       schema:
         $ref: models/apps_create_app_request.yml
-      example: >-
+      example:
         spec:
           name: web-app
           region: nyc

--- a/specification/resources/apps/propose_app.yml
+++ b/specification/resources/apps/propose_app.yml
@@ -16,7 +16,7 @@ requestBody:
     application/json:
       schema:
         $ref: models/apps_create_app_request.yml
-      example:
+      example: >-
         spec:
           name: web-app
           region: nyc

--- a/specification/resources/apps/propose_app.yml
+++ b/specification/resources/apps/propose_app.yml
@@ -1,0 +1,51 @@
+operationId: propose_app
+
+summary: Propose an App Spec
+
+description: To propose and validate a spec for a new or existing app, send a PUT
+  request to the `/v2/apps/propose` endpoint. The request returns some
+  information about the proposed app, including app cost and upgrade cost. If
+  an existing app ID is specified, the app spec is treated as a proposed update
+  to the existing app.
+
+tags:
+- Apps
+
+requestBody:
+  content:
+    application/json:
+      schema:
+        $ref: models/apps_create_app_request.yml
+      example:
+        spec:
+          name: web-app
+          region: nyc
+          services:
+            - name: api
+              github:
+                branch: main
+                deploy_on_push: true
+                repo: digitalocean/sample-golang
+              run_command: bin/api
+              environment_slug: node-js
+              instance_count: 2
+              instance_size_slug: basic-xxs
+              routes:
+                - path: /api
+  required: true
+
+responses:
+  "200":
+    $ref: responses/propose_app.yml
+
+  "401":
+    $ref: ../../shared/responses/unauthorized.yml
+
+  "500":
+    $ref: ../../shared/responses/server_error.yml
+
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+
+x-codeSamples:
+  - $ref: 'examples/curl/propose_app.yml'

--- a/specification/resources/apps/propose_app.yml
+++ b/specification/resources/apps/propose_app.yml
@@ -47,6 +47,3 @@ responses:
 
   default:
     $ref: ../../shared/responses/unexpected_error.yml
-
-x-codeSamples:
-  - $ref: 'examples/curl/propose_app.yml'

--- a/specification/resources/apps/responses/examples.yml
+++ b/specification/resources/apps/responses/examples.yml
@@ -5,9 +5,9 @@ apps:
         owner_uuid: ff36cbc6fd350fe12577f5123133bb5ba01a2419
         spec:
           name: sample-php
-          services: 
+          services:
             - name: sample-php
-              git: 
+              git:
                 repo_clone_url: https://github.com/digitalocean/sample-php.git
                 branch: main
               run_command: heroku-php-apache2
@@ -15,18 +15,18 @@ apps:
               instance_size_slug: basic-xxs
               instance_count: 1
               http_port: 8080
-              routes: 
+              routes:
                 - path: /
         default_ingress: https://sample-php-iaj87.ondigitalocean.app
         created_at: 2020-11-19T20:27:18Z
         updated_at: 2020-12-01T00:42:16Z
-        active_deployment: 
+        active_deployment:
           id: 3aa4d20e-5527-4c00-b496-601fbd22520a
-          spec: 
+          spec:
             name: sample-php
-            services: 
+            services:
               - name: sample-php
-                git: 
+                git:
                   repo_clone_url: https://github.com/digitalocean/sample-php.git
                   branch: main
                 run_command: heroku-php-apache2
@@ -34,30 +34,30 @@ apps:
                 instance_size_slug: basic-xxs
                 instance_count: 1
                 http_port: 8080
-                routes: 
+                routes:
                   - path: /
             region: fra
-          services: 
+          services:
             - name: sample-php
               source_commit_hash: 54d4a727f457231062439895000d45437c7bb405
           phase_last_updated_at: 2020-12-01T00:42:12Z
           created_at: 2020-12-01T00:40:05Z
           updated_at: 2020-12-01T00:42:12Z
         cause: app spec updated
-        progress: 
+        progress:
           success_steps: 6
           total_steps: 6
-          steps: 
+          steps:
             - name: build
               status: SUCCESS
-              steps: 
+              steps:
               - name: initialize
                 status: SUCCESS
                 started_at: 2020-12-01T00:40:11.979305214Z
                 ended_at: 2020-12-01T00:40:12.470972033Z
               - name: components
                 status: SUCCESS
-                steps: 
+                steps:
                 - name: sample-php
                   status: SUCCESS
                   started_at: 0001-01-01T00:00:00Z
@@ -72,12 +72,12 @@ apps:
           tier_slug: basic
         last_deployment_created_at: 2020-12-01T00:40:05Z
         live_url: https://sample-php-iaj87.ondigitalocean.app
-        region: 
+        region:
           slug: fra
           label: Frankfurt
           flag: germany
           continent: Europe
-          data_centers: 
+          data_centers:
           - fra1
         tier_slug: basic
         live_url_base: https://sample-php-iaj87.ondigitalocean.app
@@ -196,7 +196,7 @@ app:
       tier_slug: basic
       live_url_base: https://sample-golang-zyhgn.ondigitalocean.app
       live_domain: sample-golang-zyhgn.ondigitalocean.app
-  
+
 deployments:
   value:
     deployments:
@@ -204,7 +204,7 @@ deployments:
         spec:
           name: sample-golang
           services:
-            - name: web 
+            - name: web
               github:
                 repo: digitalocean/sample-golang
                 branch: branch
@@ -270,7 +270,7 @@ deployment:
       spec:
         name: sample-golang
         services:
-          - name: web 
+          - name: web
             github:
               repo: digitalocean/sample-golang
               branch: branch
@@ -352,7 +352,7 @@ logs:
   value:
     live_url: https://logs-example/build.log
     url: https://logs/build.log
-    historic_logs: 
+    historic_logs:
       - https://logs-example/archive/build.log
 
 regions:
@@ -400,7 +400,7 @@ components:
       - build_command: makeFile build
         dockerfiles:
           - path/to/dockerfiles
-        environment_slug: s-1vcpu-1gb 
+        environment_slug: s-1vcpu-1gb
         http_ports:
           - 1202
     template:
@@ -434,4 +434,25 @@ detect:
     template_found: true
     template_valid: true
 
-
+propose:
+  value:
+    app_name_available: true
+    existing_static_apps: '2'
+    max_free_static_apps: '3'
+    spec:
+      name: sample-golang
+      services:
+      - name: web
+        github:
+          repo: digitalocean/sample-golang
+          branch: branch
+        run_command: bin/sample-golang
+        environment_slug: go
+        instance_size_slug: basic-xxs
+        instance_count: 1
+        http_port: 8080
+        routes:
+        - path: "/"
+      region: ams
+    app_cost: 5
+    app_tier_upgrade_cost: 17

--- a/specification/resources/apps/responses/propose_app.yml
+++ b/specification/resources/apps/responses/propose_app.yml
@@ -1,9 +1,9 @@
-description: A JSON of a `spec` object.
+description: A JSON object.
 
 content:
   application/json:
     schema:
-      $ref: ../models/app_propose.yml
+      $ref: ../models/app_propose_response.yml
     examples:
       app:
         $ref: examples.yml#/propose

--- a/specification/resources/apps/responses/propose_app.yml
+++ b/specification/resources/apps/responses/propose_app.yml
@@ -5,7 +5,7 @@ content:
     schema:
       $ref: ../models/app_propose_response.yml
     examples:
-      app:
+      propose:
         $ref: examples.yml#/propose
 
 headers:

--- a/specification/resources/apps/responses/propose_app.yml
+++ b/specification/resources/apps/responses/propose_app.yml
@@ -1,0 +1,17 @@
+description: A JSON of a `spec` object.
+
+content:
+  application/json:
+    schema:
+      $ref: ../models/app_propose.yml
+    examples:
+      app:
+        $ref: examples.yml#/propose
+
+headers:
+  ratelimit-limit:
+    $ref: ../../../shared/headers.yml#/ratelimit-limit
+  ratelimit-remaining:
+    $ref: ../../../shared/headers.yml#/ratelimit-remaining
+  ratelimit-reset:
+    $ref: ../../../shared/headers.yml#/ratelimit-reset

--- a/specification/resources/cdn/examples/curl/update_endpoint.yml
+++ b/specification/resources/cdn/examples/curl/update_endpoint.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X PUT \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer b7d03a6947b217efb6f3ec3bd3504582" \
+  -d '{"ttl": 1800}' \
+  "https://api.digitalocean.com/v2/cdn/endpoints/19f06b6a-3ace-4315-b086-499a0e521b76" 

--- a/specification/resources/cdn/examples/go/update_endpoint.yml
+++ b/specification/resources/cdn/examples/go/update_endpoint.yml
@@ -1,0 +1,16 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      pat := "mytoken"
+
+      client := godo.NewFromToken(pat)
+      ctx := context.TODO()
+
+      updateRequest := &godo.CDNUpdateTTLRequest{TTL: 1800}
+      cdn, _, err := client.CDNs.UpdateTTL(ctx, "19f06b6a-3ace-4315-b086-499a0e521b76", updateRequest)
+  }

--- a/specification/resources/cdn/examples/ruby/update_endpoint.yml
+++ b/specification/resources/cdn/examples/ruby/update_endpoint.yml
@@ -1,0 +1,7 @@
+lang: Ruby
+source: |-
+  require 'droplet_kit'
+  token = '16f79fc8cd5adcfe528a0994311fa63cc877737b385b6ff7d12ed6684ba4fef5'
+  client = DropletKit::Client.new(access_token: token)
+
+  client.cdns.update_ttl(id: '19f06b6a-3ace-4315-b086-499a0e521b76', ttl: 1800)

--- a/specification/resources/cdn/models/update_endpoint.yml
+++ b/specification/resources/cdn/models/update_endpoint.yml
@@ -1,0 +1,22 @@
+type: object
+
+properties:
+  ttl:
+    type: integer
+    example: 3600
+    description: The amount of time the content is cached by the CDN's edge
+      servers in seconds.
+
+  certificate_id:
+    type: string
+    format: uuid
+    example: 892071a0-bb95-49bc-8021-3afd67a210bf
+    description: The ID of a DigitalOcean managed TLS certificate used for SSL
+      when a custom subdomain is provided.
+
+  custom_domain:
+    type: string
+    format: hostname
+    example: static.example.com
+    description: The fully qualified domain name (FQDN) of the custom subdomain
+      used with the CDN endpoint.

--- a/specification/resources/cdn/update_endpoint.yml
+++ b/specification/resources/cdn/update_endpoint.yml
@@ -1,0 +1,37 @@
+operationId: update_cdn_endpoint
+
+summary: Update a CDN Endpoint
+
+description: |
+  To update the TTL, certificate ID, or the FQDN of the custom subdomain for
+  an existing CDN endpoint, send a PUT request to
+  `/v2/cdn/endpoints/$ENDPOINT_ID`.
+
+tags:
+  - CDN Endpoints
+
+requestBody:
+  required: true
+
+  content:
+    application/json:
+      schema:
+        $ref: 'models/update_endpoint.yml'
+
+responses:
+  '202':
+    $ref: 'responses/existing_endpoint.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/update_endpoint.yml'
+  - $ref: 'examples/go/update_endpoint.yml'
+  - $ref: 'examples/ruby/update_endpoint.yml'

--- a/specification/resources/cdn/update_endpoint.yml
+++ b/specification/resources/cdn/update_endpoint.yml
@@ -10,6 +10,9 @@ description: |
 tags:
   - CDN Endpoints
 
+parameters:
+  - $ref: 'parameters.yml#/cdn_endpoint_id'
+
 requestBody:
   required: true
 

--- a/specification/resources/databases/add_connection_pool.yml
+++ b/specification/resources/databases/add_connection_pool.yml
@@ -1,0 +1,54 @@
+operationId: add_connection_pool
+
+summary: Add a New Connection Pool (PostgreSQL)
+
+description: |
+  For PostgreSQL database clusters, connection pools can be used to allow a
+  database to share its idle connections. The popular PostgreSQL connection
+  pooling utility PgBouncer is used to provide this service. [See here for more information](https://www.digitalocean.com/docs/databases/postgresql/how-to/manage-connection-pools/)
+  about how and why to use PgBouncer connection pooling including
+  details about the available transaction modes.
+
+  To add a new connection pool to a PostgreSQL database cluster, send a POST
+  request to `/v2/databases/$DATABASE_ID/pools` specifying a name for the pool,
+  the user to connect with, the database to connect to, as well as its desired
+  size and transaction mode.
+
+tags:
+  - Databases
+
+parameters:
+  - $ref: 'parameters.yml#/database_cluster_uuid'
+
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: 'models/connection_pool.yml'
+      example:
+        name: backend-pool
+        mode: transaction
+        size: 10
+        db: defaultdb
+        user: doadmin
+
+responses:
+  '201':
+    $ref: 'responses/connection_pool.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/add_connection_pool.yml'
+  - $ref: 'examples/go/add_connection_pool.yml'

--- a/specification/resources/databases/delete_connection_pool.yml
+++ b/specification/resources/databases/delete_connection_pool.yml
@@ -1,0 +1,36 @@
+operationId: delete_connection_pool
+
+summary: Delete a Connection Pool (PostgreSQL)
+
+description: |
+  To delete a specific connection pool for a PostgreSQL database cluster, send
+  a DELETE request to `/v2/databases/$DATABASE_ID/pools/$POOL_NAME`.
+
+  A status of 204 will be given. This indicates that the request was processed
+  successfully, but that no response body is needed.
+tags:
+  - Databases
+
+parameters:
+  - $ref: 'parameters.yml#/database_cluster_uuid'
+  - $ref: 'parameters.yml#/pool_name'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/delete_connection_pool.yml'
+  - $ref: 'examples/go/delete_connection_pool.yml'

--- a/specification/resources/databases/destroy_cluster.yml
+++ b/specification/resources/databases/destroy_cluster.yml
@@ -1,0 +1,33 @@
+operationId: destroy_cluster
+
+summary: Destroy a Database Cluster
+
+description: >-
+  To destroy a specific database, send a DELETE request to
+  `/v2/databases/$DATABASE_ID`.
+
+  A status of 204 will be given. This indicates that the request was processed
+  successfully, but that no response body is needed.
+
+tags:
+  - Databases
+
+parameters:
+  - $ref: 'parameters.yml#/database_cluster_uuid'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/destroy_cluster.yml'
+  - $ref: 'examples/go/destroy_cluster.yml'

--- a/specification/resources/databases/examples/curl/add_connection_pool.yml
+++ b/specification/resources/databases/examples/curl/add_connection_pool.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer b7d03a6947b217efb6f3ec3bd3504582" \
+  -d '{"name": "backend-pool","mode": "transaction","size": 10,"db": "defaultdb","user": "doadmin"}' \
+  "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/pools" 

--- a/specification/resources/databases/examples/curl/delete_connection_pool.yml
+++ b/specification/resources/databases/examples/curl/delete_connection_pool.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer b7d03a6947b217efb6f3ec3bd3504582" \
+  "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/pools/backend-pool"

--- a/specification/resources/databases/examples/curl/destroy_cluster.yml
+++ b/specification/resources/databases/examples/curl/destroy_cluster.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X DELETE \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer b7d03a6947b217efb6f3ec3bd3504582" \
+  "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" 

--- a/specification/resources/databases/examples/curl/get_connection_pool.yml
+++ b/specification/resources/databases/examples/curl/get_connection_pool.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET /
+  -H "Content-Type: application/json" /
+  -H "Authorization: Bearer b7d03a6947b217efb6f3ec3bd3504582" /
+  "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/pools/backend-pool" 

--- a/specification/resources/databases/examples/curl/get_migration_status.yml
+++ b/specification/resources/databases/examples/curl/get_migration_status.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X PUT \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer b7d03a6947b217efb6f3ec3bd3504582" \
+  -d '{"source":{"host":"source-do-user-6607903-0.b.db.ondigitalocean.com","dbname":"defaultdb","port":25060,"username":"doadmin","password":"paakjnfe10rsrsmf"},"disable_ssl":false}' \
+  "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/online-migration"

--- a/specification/resources/databases/examples/curl/list_connection_pools.yml
+++ b/specification/resources/databases/examples/curl/list_connection_pools.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET /
+  -H "Content-Type: application/json" /
+  -H "Authorization: Bearer b7d03a6947b217efb6f3ec3bd3504582" /
+  "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/pools" 

--- a/specification/resources/databases/examples/curl/resize_database_cluster.yml
+++ b/specification/resources/databases/examples/curl/resize_database_cluster.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X PUT \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer b7d03a6947b217efb6f3ec3bd3504582" \
+  -d '{"size":"db-s-4vcpu-8gb", "num_nodes":3}' \
+  "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/resize" 

--- a/specification/resources/databases/examples/curl/start_online_migration.yml
+++ b/specification/resources/databases/examples/curl/start_online_migration.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X PUT \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer b7d03a6947b217efb6f3ec3bd3504582" \
+  -d '{"source":{"host":"source-do-user-6607903-0.b.db.ondigitalocean.com","dbname":"defaultdb","port":25060,"username":"doadmin","password":"paakjnfe10rsrsmf"},"disable_ssl":false}' \
+  "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/online-migration" 

--- a/specification/resources/databases/examples/curl/stop_online_migration.yml
+++ b/specification/resources/databases/examples/curl/stop_online_migration.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X DELETE \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer b7d03a6947b217efb6f3ec3bd3504582" \
+  "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/online-migration/77b28fc8-19ff-11eb-8c9c-c68e24557488"

--- a/specification/resources/databases/examples/go/add_connection_pool.yml
+++ b/specification/resources/databases/examples/go/add_connection_pool.yml
@@ -1,0 +1,23 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      pat := "mytoken"
+
+      client := godo.NewFromToken(pat)
+      ctx := context.TODO()
+
+      createPoolReq := &godo.DatabaseCreatePoolRequest{
+          Name:     "backend-pool",
+          Database: "defaultdb",
+          Size:     10,
+          User:     "doadmin",
+          Mode:     "transaction",
+      }
+
+      pool, _, err := client.Databases.CreatePool(ctx, "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30", createPoolReq)
+  }

--- a/specification/resources/databases/examples/go/delete_connection_pool.yml
+++ b/specification/resources/databases/examples/go/delete_connection_pool.yml
@@ -1,0 +1,15 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      pat := "mytoken"
+
+      client := godo.NewFromToken(pat)
+      ctx := context.TODO()
+
+      _, err := client.Databases.DeletePool(ctx, "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30", "backend-pool")
+  }

--- a/specification/resources/databases/examples/go/destroy_cluster.yml
+++ b/specification/resources/databases/examples/go/destroy_cluster.yml
@@ -1,0 +1,15 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      pat := "mytoken"
+
+      client := godo.NewFromToken(pat)
+      ctx := context.TODO()
+
+      _, err := client.Databases.Delete(ctx, "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30")
+  }

--- a/specification/resources/databases/examples/go/get_connection_pool.yml
+++ b/specification/resources/databases/examples/go/get_connection_pool.yml
@@ -1,0 +1,15 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      pat := "mytoken"
+
+      client := godo.NewFromToken(pat)
+      ctx := context.TODO()
+
+      pool, _, err := client.Databases.GetPool(ctx, "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30", "backend-pool")
+  }

--- a/specification/resources/databases/examples/go/list_connection_pools.yml
+++ b/specification/resources/databases/examples/go/list_connection_pools.yml
@@ -1,0 +1,15 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      pat := "mytoken"
+
+      client := godo.NewFromToken(pat)
+      ctx := context.TODO()
+
+      pools, _, err := client.Databases.ListPools(ctx, "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30", nil)
+  }

--- a/specification/resources/databases/examples/go/resize_database_cluster.yml
+++ b/specification/resources/databases/examples/go/resize_database_cluster.yml
@@ -1,0 +1,18 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      pat := "mytoken"
+
+      client := godo.NewFromToken(pat)
+      ctx := context.TODO()
+
+      resizeRequest := &godo.DatabaseResizeRequest{
+          SizeSlug: "db-s-4vcpu-8gb",
+          NumNodes: 3,
+      }
+  }

--- a/specification/resources/databases/get_connection_pool.yml
+++ b/specification/resources/databases/get_connection_pool.yml
@@ -1,0 +1,37 @@
+operationId: get_connection_pool
+
+summary: Retrieve Existing Connection Pool (PostgreSQL)
+
+description: >-
+  To show information about an existing connection pool for a PostgreSQL
+  database cluster, send a GET request to
+  `/v2/databases/$DATABASE_ID/pools/$POOL_NAME`.
+
+  The response will be a JSON object with a `pool` key.
+
+tags:
+  - Databases
+
+parameters:
+  - $ref: 'parameters.yml#/database_cluster_uuid'
+  - $ref: 'parameters.yml#/pool_name'
+
+responses:
+  '200':
+    $ref: 'responses/connection_pool.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/get_connection_pool.yml'
+  - $ref: 'examples/go/get_connection_pool.yml'

--- a/specification/resources/databases/get_migration_status.yml
+++ b/specification/resources/databases/get_migration_status.yml
@@ -1,0 +1,33 @@
+operationId: get_migration_status
+
+summary: Retrieve the Status of an Online Migration
+
+description: >-
+  To retrieve the status of an online migration, send a GET request to
+  `/v2/databases/$DATABASE_ID/online-migration`. If a migration has completed,
+  a 200 OK status is returned with no response body.
+
+tags:
+  - Databases
+
+parameters:
+  - $ref: 'parameters.yml#/database_cluster_uuid'
+
+responses:
+  '200':
+    $ref: 'responses/online_migration.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/get_migration_status.yml'

--- a/specification/resources/databases/list_connection_pools.yml
+++ b/specification/resources/databases/list_connection_pools.yml
@@ -1,0 +1,36 @@
+operationId: list_connection_pools
+
+summary: List Connection Pools (PostgreSQL)
+
+description: >-
+  To list all of the connection pools available to a PostgreSQL database
+  cluster, send a GET request to `/v2/databases/$DATABASE_ID/pools`.
+
+  The result will be a JSON object with a `pools` key. This will be set to an
+  array of connection pool objects.
+
+tags:
+  - Databases
+
+parameters:
+  - $ref: 'parameters.yml#/database_cluster_uuid'
+
+responses:
+  '200':
+    $ref: 'responses/connection_pools.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/list_connection_pools.yml'
+  - $ref: 'examples/go/list_connection_pools.yml'

--- a/specification/resources/databases/models/connection_pool.yml
+++ b/specification/resources/databases/models/connection_pool.yml
@@ -1,0 +1,48 @@
+type: object
+
+properties:
+  name:
+    type: string
+    description: >-
+      A unique name for the connection pool. Must be between 3 and 60 characters.
+    example: backend-pool
+  mode:
+    type: string
+    description: >-
+      The PGBouncer transaction mode for the connection pool. The allowed
+      values are session, transaction, and statement.
+    example: transaction
+  size:
+    type: integer
+    format: int32
+    description: >-
+      The desired size of the PGBouncer connection pool. The maximum allowed
+      size is determined by the size of the cluster's primary node. 25 backend
+      server connections are allowed for every 1GB of RAM. Three are reserved
+      for maintenance. For example, a primary node with 1 GB of RAM allows for
+      a maximum of 22 backend server connections while one with 4 GB would
+      allow for 97. Note that these are shared across all connection pools in
+      a cluster.
+    example: 10
+  db:
+    type: string
+    description: The database for use with the connection pool.
+    example: defaultdb
+  user:
+    type: string
+    description: The name of the user for use with the connection pool.
+    example: doadmin
+  connection:
+    allOf:
+    - $ref: './database_connection.yml'
+    - readOnly: true
+  private_connection:
+    allOf:
+    - $ref: './database_connection.yml'
+    - readOnly: true
+required:
+  - name
+  - mode
+  - size
+  - db
+  - user

--- a/specification/resources/databases/models/connection_pools.yml
+++ b/specification/resources/databases/models/connection_pools.yml
@@ -1,0 +1,9 @@
+type: object
+
+properties:
+  pools:
+    type: array
+    readOnly: true
+    description: An array of connection pool objects.
+    items:
+      $ref: connection_pool.yml

--- a/specification/resources/databases/models/database_cluster_resize.yml
+++ b/specification/resources/databases/models/database_cluster_resize.yml
@@ -1,0 +1,19 @@
+type: object
+
+properties:
+  size:
+    type: string
+    example: db-s-4vcpu-8gb
+    description: A slug identifier representing desired the size of the nodes in the database cluster.
+  num_nodes:
+    type: integer
+    format: int32
+    example: 3
+    description: >-
+      The number of nodes in the database cluster. Valid values are are 1-3.
+      In addition to the primary node, up to two standby nodes may be added for
+      highly available configurations.
+
+required:
+  - size
+  - num_nodes

--- a/specification/resources/databases/models/online_migration.yml
+++ b/specification/resources/databases/models/online_migration.yml
@@ -1,0 +1,15 @@
+type: object
+
+properties:
+  id:
+    type: string
+    description: The ID of the currently running migration.
+    example: 77b28fc8-19ff-11eb-8c9c-c68e24557488
+  status:
+    type: string
+    description: The current status of the migration.
+    example: running
+  created_at:
+    type: string
+    description: The time the migration was initiated, in ISO 8601 format.
+    example: 2020-10-29T15:57:38Z

--- a/specification/resources/databases/models/source_database.yml
+++ b/specification/resources/databases/models/source_database.yml
@@ -1,0 +1,10 @@
+type: object
+
+properties:
+  source:
+    allOf:
+    - $ref: './database_connection.yml'
+  disable_ssl:
+    type: boolean
+    description: Enables SSL encryption when connecting to the source database.
+    example: false

--- a/specification/resources/databases/parameters.yml
+++ b/specification/resources/databases/parameters.yml
@@ -43,3 +43,12 @@ tag_name:
   example: production
   schema:
     type: string
+
+pool_name:
+  in: path
+  name: pool_name
+  description: The name used to identify the connection pool.
+  required: true
+  example: backend-pool
+  schema:
+    type: string

--- a/specification/resources/databases/parameters.yml
+++ b/specification/resources/databases/parameters.yml
@@ -52,3 +52,12 @@ pool_name:
   example: backend-pool
   schema:
     type: string
+
+migration_id:
+  in: path
+  name: migration_id
+  description: A unique identifier assigned to the online migration.
+  required: true
+  example: 77b28fc8-19ff-11eb-8c9c-c68e24557488
+  schema:
+    type: string

--- a/specification/resources/databases/resize_database_cluster.yml
+++ b/specification/resources/databases/resize_database_cluster.yml
@@ -15,6 +15,9 @@ description: >-
 tags:
   - Databases
 
+parameters:
+  - $ref: 'parameters.yml#/database_cluster_uuid'
+
 requestBody:
   required: true
 

--- a/specification/resources/databases/resize_database_cluster.yml
+++ b/specification/resources/databases/resize_database_cluster.yml
@@ -1,0 +1,48 @@
+operationId: resize_database_cluster
+
+summary: Resize a Database Cluster
+
+description: >-
+  To resize a database cluster, send a PUT request to
+  `/v2/databases/$DATABASE_ID/resize`. The body of the request must specify
+  both the size and num_nodes attributes.
+
+  A successful request will receive a 202 Accepted status code with no body in
+  response. Querying the database cluster will show that its status attribute
+  will now be set to resizing. This will transition back to online when the
+  resize operation has completed.
+
+tags:
+  - Databases
+
+requestBody:
+  required: true
+
+  content:
+    application/json:
+      schema:
+          $ref: 'models/database_cluster_resize.yml'
+
+      example:
+        size: db-s-4vcpu-8gb
+        num_nodes: 3
+
+responses:
+  '202':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/resize_database_cluster.yml'
+  - $ref: 'examples/go/resize_database_cluster.yml'

--- a/specification/resources/databases/resize_database_cluster.yml
+++ b/specification/resources/databases/resize_database_cluster.yml
@@ -1,4 +1,4 @@
-operationId: resize_database_cluster
+operationId: update_database_cluster_size
 
 summary: Resize a Database Cluster
 

--- a/specification/resources/databases/responses/connection_pool.yml
+++ b/specification/resources/databases/responses/connection_pool.yml
@@ -1,0 +1,34 @@
+description: A JSON object with a key of `pool`.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        pool:
+          $ref: '../models/connection_pool.yml'
+      required:
+        - pool
+    example:
+      pool:
+        user: doadmin
+        name: backend-pool
+        size: 10
+        db: defaultdb
+        mode: transaction
+        connection:
+          uri: postgres://doadmin:wv78n3zpz42xezdk@backend-do-user-19081923-0.db.ondigitalocean.com:25061/backend-pool?sslmode=require
+          database: backend-pool
+          host: backend-do-user-19081923-0.db.ondigitalocean.com
+          port: 25061
+          user: doadmin
+          password: wv78n3zpz42xezdk
+          ssl: true

--- a/specification/resources/databases/responses/connection_pools.yml
+++ b/specification/resources/databases/responses/connection_pools.yml
@@ -1,0 +1,42 @@
+description: A JSON object with a key of `pools`.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/connection_pools.yml'
+    example:
+      pools:
+      - user: doadmin
+        name: reporting-pool
+        size: 10
+        db: defaultdb
+        mode: session
+        connection:
+          uri: postgres://doadmin:wv78n3zpz42xezdk@backend-do-user-19081923-0.db.ondigitalocean.com:25061/foo?sslmode=require
+          database: foo
+          host: backend-do-user-19081923-0.db.ondigitalocean.com
+          port: 25061
+          user: doadmin
+          password: wv78n3zpz42xezdk
+          ssl: true
+      - user: doadmin
+        name: backend-pool
+        size: 10
+        db: defaultdb
+        mode: transaction
+        connection:
+          uri: postgres://doadmin:wv78n3zpz42xezdk@backend-do-user-19081923-0.db.ondigitalocean.com:25061/backend-pool?sslmode=require
+          database: backend-pool
+          host: backend-do-user-19081923-0.db.ondigitalocean.com
+          port: 25061
+          user: doadmin
+          password: wv78n3zpz42xezdk
+          ssl: true

--- a/specification/resources/databases/responses/online_migration.yml
+++ b/specification/resources/databases/responses/online_migration.yml
@@ -1,0 +1,18 @@
+description: A JSON object.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/online_migration.yml'
+    example:
+      id: 77b28fc8-19ff-11eb-8c9c-c68e24557488
+      status: running
+      created_at: '2020-10-29T15:57:38Z'

--- a/specification/resources/databases/start_online_migration.yml
+++ b/specification/resources/databases/start_online_migration.yml
@@ -1,4 +1,4 @@
-operationId: create_online_migration
+operationId: update_online_migration
 
 summary: Start an Online Migration
 

--- a/specification/resources/databases/start_online_migration.yml
+++ b/specification/resources/databases/start_online_migration.yml
@@ -1,0 +1,52 @@
+operationId: start_online_migration
+
+summary: Start an Online Migration
+
+description: >-
+  To start an online migration, send a PUT request to
+  `/v2/databases/$DATABASE_ID/online-migration` endpoint. Migrating a cluster
+  establishes a connection with an existing cluster and replicates its
+  contents to the target cluster. Online migration is only available for
+  PostgreSQL and Redis clusters.
+
+tags:
+  - Databases
+
+parameters:
+  - $ref: 'parameters.yml#/database_cluster_uuid'
+
+requestBody:
+  required: true
+
+  content:
+    application/json:
+      schema:
+          $ref: 'models/source_database.yml'
+
+      example:
+        source:
+          host: source-do-user-6607903-0.b.db.ondigitalocean.com
+          dbname: defaultdb
+          port: 25060
+          username: doadmin
+          password: paakjnfe10rsrsmf
+        disable_ssl: false
+
+responses:
+  '200':
+    $ref: 'responses/online_migration.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/start_online_migration.yml'

--- a/specification/resources/databases/start_online_migration.yml
+++ b/specification/resources/databases/start_online_migration.yml
@@ -1,4 +1,4 @@
-operationId: start_online_migration
+operationId: create_online_migration
 
 summary: Start an Online Migration
 

--- a/specification/resources/databases/stop_online_migration.yml
+++ b/specification/resources/databases/stop_online_migration.yml
@@ -1,4 +1,4 @@
-operationId: stop_online_migration
+operationId: delete_online_migration
 
 summary: Stop an Online Migration
 

--- a/specification/resources/databases/stop_online_migration.yml
+++ b/specification/resources/databases/stop_online_migration.yml
@@ -1,0 +1,33 @@
+operationId: stop_online_migration
+
+summary: Stop an Online Migration
+
+description: |
+  To stop an online migration, send a DELETE request to `/v2/databases/$DATABASE_ID/online-migration/$MIGRATION_ID`.
+
+  A status of 204 will be given. This indicates that the request was processed successfully, but that no response body is needed.
+tags:
+  - Databases
+
+parameters:
+  - $ref: 'parameters.yml#/database_cluster_uuid'
+  - $ref: 'parameters.yml#/migration_id'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/stop_online_migration.yml'

--- a/specification/resources/databases/update_sql_mode.yml
+++ b/specification/resources/databases/update_sql_mode.yml
@@ -1,6 +1,6 @@
 operationId: update_sql_mode
 
-summary: Configure the Eviction Policy for a Redis Cluster
+summary: Update SQL Mode for a Cluster
 
 description: >-
   To configure the SQL modes for an existing MySQL cluster, send a PUT


### PR DESCRIPTION
This PR brings the OpenAPI spec into parity with the current API docs (and then some). Adds the following endpoints into the spec:

* Propose App
* Update CDN Endpoint
* Resize Database
* Destroy a Database Cluster
* Create Database Connection Pool
* List Database Connection Pools
* Get Database Connection Pool
* Delete Database Connection Pool
* Get Online Migration
* Start Online Migration
* Stop Online Migration

Also, corrected title title for Update SQL Modes.