### PR TITLE
Add missing 404 responses and Spectral rule to enforce them.

### DIFF
--- a/specification/resources/apps/cancel_deployment.yml
+++ b/specification/resources/apps/cancel_deployment.yml
@@ -18,6 +18,9 @@ responses:
   "401":
     $ref: ../../shared/responses/unauthorized.yml
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   "500":
     $ref: ../../shared/responses/server_error.yml
 

--- a/specification/resources/apps/create_deployment.yml
+++ b/specification/resources/apps/create_deployment.yml
@@ -25,6 +25,9 @@ responses:
   "401":
     $ref: ../../shared/responses/unauthorized.yml
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   "500":
     $ref: ../../shared/responses/server_error.yml
 

--- a/specification/resources/apps/delete_app.yml
+++ b/specification/resources/apps/delete_app.yml
@@ -19,6 +19,9 @@ responses:
   "401":
     $ref: ../../shared/responses/unauthorized.yml
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   "500":
     $ref: ../../shared/responses/server_error.yml
 

--- a/specification/resources/apps/get_app.yml
+++ b/specification/resources/apps/get_app.yml
@@ -21,6 +21,9 @@ responses:
   "401":
     $ref: ../../shared/responses/unauthorized.yml
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   "500":
     $ref: ../../shared/responses/server_error.yml
 

--- a/specification/resources/apps/get_deployment.yml
+++ b/specification/resources/apps/get_deployment.yml
@@ -18,6 +18,9 @@ responses:
   "401":
     $ref: ../../shared/responses/unauthorized.yml
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   "500":
     $ref: ../../shared/responses/server_error.yml
 

--- a/specification/resources/apps/get_instance_size.yml
+++ b/specification/resources/apps/get_instance_size.yml
@@ -18,6 +18,9 @@ responses:
   "401":
     $ref: ../../shared/responses/unauthorized.yml
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   "500":
     $ref: ../../shared/responses/server_error.yml
 

--- a/specification/resources/apps/get_logs.yml
+++ b/specification/resources/apps/get_logs.yml
@@ -25,6 +25,9 @@ responses:
   "401":
     $ref: ../../shared/responses/unauthorized.yml
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   "500":
     $ref: ../../shared/responses/server_error.yml
 

--- a/specification/resources/apps/get_logs_aggregate.yml
+++ b/specification/resources/apps/get_logs_aggregate.yml
@@ -24,6 +24,9 @@ responses:
   "401":
     $ref: ../../shared/responses/unauthorized.yml
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   "500":
     $ref: ../../shared/responses/server_error.yml
 

--- a/specification/resources/apps/get_tier.yml
+++ b/specification/resources/apps/get_tier.yml
@@ -17,6 +17,9 @@ responses:
   "401":
     $ref: ../../shared/responses/unauthorized.yml
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   "500":
     $ref: ../../shared/responses/server_error.yml
 

--- a/specification/resources/apps/list_deployments.yml
+++ b/specification/resources/apps/list_deployments.yml
@@ -19,6 +19,9 @@ responses:
   "401":
     $ref: ../../shared/responses/unauthorized.yml
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   "500":
     $ref: ../../shared/responses/server_error.yml
 

--- a/specification/resources/apps/update_app.yml
+++ b/specification/resources/apps/update_app.yml
@@ -25,6 +25,9 @@ responses:
   "401":
     $ref: ../../shared/responses/unauthorized.yml
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   "500":
     $ref: ../../shared/responses/server_error.yml
 

--- a/specification/resources/cdn/update_endpoint.yml
+++ b/specification/resources/cdn/update_endpoint.yml
@@ -28,6 +28,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/databases/create_replica.yml
+++ b/specification/resources/databases/create_replica.yml
@@ -44,6 +44,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/databases/destroy_cluster.yml
+++ b/specification/resources/databases/destroy_cluster.yml
@@ -22,6 +22,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/databases/destroy_replica.yml
+++ b/specification/resources/databases/destroy_replica.yml
@@ -25,6 +25,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/databases/get_eviction_policy.yml
+++ b/specification/resources/databases/get_eviction_policy.yml
@@ -22,6 +22,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/databases/get_sql_mode.yml
+++ b/specification/resources/databases/get_sql_mode.yml
@@ -22,6 +22,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/domains/create_domain_record.yml
+++ b/specification/resources/domains/create_domain_record.yml
@@ -63,6 +63,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/domains/get_domain_record.yml
+++ b/specification/resources/domains/get_domain_record.yml
@@ -19,6 +19,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/domains/list_all_domain_records.yml
+++ b/specification/resources/domains/list_all_domain_records.yml
@@ -29,6 +29,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/domains/patch_update_domain_record.yml
+++ b/specification/resources/domains/patch_update_domain_record.yml
@@ -34,6 +34,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/domains/update_domain_record.yml
+++ b/specification/resources/domains/update_domain_record.yml
@@ -34,6 +34,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/droplets/get_destroy_with_associated_resources_status.yml
+++ b/specification/resources/droplets/get_destroy_with_associated_resources_status.yml
@@ -20,6 +20,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/droplets/list_associated_resources.yml
+++ b/specification/resources/droplets/list_associated_resources.yml
@@ -24,6 +24,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/firewalls/add_firewall_droplets.yml
+++ b/specification/resources/firewalls/add_firewall_droplets.yml
@@ -46,6 +46,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/firewalls/add_firewall_rules.yml
+++ b/specification/resources/firewalls/add_firewall_rules.yml
@@ -53,6 +53,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/firewalls/add_firewall_tags.yml
+++ b/specification/resources/firewalls/add_firewall_tags.yml
@@ -43,6 +43,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/firewalls/update_firewall.yml
+++ b/specification/resources/firewalls/update_firewall.yml
@@ -62,6 +62,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/images/post_image_action.yml
+++ b/specification/resources/images/post_image_action.yml
@@ -43,6 +43,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/kubernetes/list_node_pools.yml
+++ b/specification/resources/kubernetes/list_node_pools.yml
@@ -19,6 +19,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/registry/list_registry_repositories.yml
+++ b/specification/resources/registry/list_registry_repositories.yml
@@ -20,6 +20,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/registry/list_repository_tags.yml
+++ b/specification/resources/registry/list_repository_tags.yml
@@ -27,6 +27,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/volumes/create_volume_snapshot.yml
+++ b/specification/resources/volumes/create_volume_snapshot.yml
@@ -41,6 +41,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/specification/resources/volumes/list_all_volume_actions.yml
+++ b/specification/resources/volumes/list_all_volume_actions.yml
@@ -21,6 +21,9 @@ responses:
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
   '500':
     $ref: '../../shared/responses/server_error.yml'
 

--- a/spectral/ruleset.yml
+++ b/spectral/ruleset.yml
@@ -81,6 +81,15 @@ rules:
       - field: '401'
         function: truthy
 
+  common-responses-not-found:
+    description: Responses should contain common response - 404 (not found)
+    message: "{{description}}. Missing {{property}}"
+    severity: error
+    given: $.paths[?(@property.match(/.*\/{.*}.*/))]..responses
+    then:
+      - field: '404'
+        function: truthy
+
   common-responses-server-error:
     description: Responses should contain common response - 500 (server error)
     message: "{{description}}. Missing {{property}}"


### PR DESCRIPTION
The first commit adds a Spectral rule to enforce including 404 responses when a path requires a resource ID. The next commit fixes the violations reported by that rule.

Related to https://github.com/digitalocean/openapi/issues/498