### PR TITLE
Updates to FLIP Examples

### DIFF
--- a/specification/resources/floating_ips/responses/examples.yml
+++ b/specification/resources/floating_ips/responses/examples.yml
@@ -161,7 +161,6 @@ floating_ip_assigned:
           - sgp1
           - tor1
           created_at: '2020-05-15T05:47:50Z'
-          type: snapshot
           min_disk_size: 20
           size_gigabytes: 2.36
           description: ''

--- a/specification/resources/floating_ips/responses/examples.yml
+++ b/specification/resources/floating_ips/responses/examples.yml
@@ -142,6 +142,7 @@ floating_ip_assigned:
         image:
           id: 63663980
           name: 20.04 (LTS) x64
+          type: base
           distribution: Ubuntu
           slug: ubuntu-20-04-x64
           public: true
@@ -212,7 +213,6 @@ floating_ip_assigned:
           name: New York 3
           slug: nyc3
           features:
-              - private_networking
               - backups
               - ipv6
               - metadata
@@ -243,7 +243,6 @@ floating_ip_assigned:
         name: New York 3
         slug: nyc3
         features:
-        - private_networking
         - backups
         - ipv6
         - metadata


### PR DESCRIPTION
This PR addresses PDOCS-1113. The FLIP team are bringing their API responses inline with the current `/v2/droplets` responses, i.e. the `droplet` and `region` fields in FLIP responses will mirror the `droplet` field from `/v2/droplets` and `/v2/regions`, respectively. Turns out that the spec already reflects this new structure (woops). This PR just updates the FLIP response examples to reflect that new structure.

Very minor changes to the examples.

See [Slack thread for more details](https://digitalocean.slack.com/archives/C044HSU40/p1619015117013100).