### PR TITLE
apps: IDs are in path not body.

### DIFF
--- a/specification/resources/apps/models/apps_create_deployment_request.yml
+++ b/specification/resources/apps/models/apps_create_deployment_request.yml
@@ -1,13 +1,7 @@
+type: object
 properties:
-  app_id:
-    title: The app ID
-    type: string
-    example: 4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf
   force_build:
     title: Indicates whether to force a build of app from source even if an existing
       cached build is suitable for re-use
     type: boolean
     example: true
-required:
-- app_id
-type: object

--- a/specification/resources/apps/models/apps_update_app_request.yml
+++ b/specification/resources/apps/models/apps_update_app_request.yml
@@ -1,11 +1,6 @@
+type: object
 properties:
-  id:
-    title: The ID of the app
-    type: string
-    example: 4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf
   spec:
     $ref: app_spec.yml
 required:
-- id
 - spec
-type: object


### PR DESCRIPTION
These operations have IDs marked as required in their bodies, but they are actually part of their paths (and are also marked as required there). This seems to be from an error in the initial generation from the protos.

* `POST /v2/apps/{id}/deployments`: https://developers.digitalocean.com/documentation/v2/#create-an-app-deployment
* `PUT /v2/apps/{id}`: https://developers.digitalocean.com/documentation/v2/#update-an-app

With these changes applied, the apps contract tests pass 100%.