### PR TITLE
registry: Fix validate name request body.

### DIFF
--- a/specification/resources/registry/examples/curl/validate_registry_name.yml
+++ b/specification/resources/registry/examples/curl/validate_registry_name.yml
@@ -3,4 +3,5 @@ source: |-
   curl -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    -d '{"name": "example"}' \
     "https://api.digitalocean.com/v2/registry/validate-name"

--- a/specification/resources/registry/models/validate_registry.yml
+++ b/specification/resources/registry/models/validate_registry.yml
@@ -1,0 +1,14 @@
+type: object
+
+properties:
+  name:
+    type: string
+    maxLength: 63
+    pattern: '^[a-z0-9-]{1,63}$'
+    example: example
+    description: A globally unique name for the container registry. Must be
+      lowercase and be composed only of numbers, letters and `-`, up to a limit
+      of 63 characters.
+
+required:
+- name

--- a/specification/resources/registry/validate_registry_name.yml
+++ b/specification/resources/registry/validate_registry_name.yml
@@ -19,7 +19,7 @@ requestBody:
   content:
     application/json:
       schema:
-        $ref: 'models/registry.yml'
+        $ref: 'models/validate_registry.yml'
 
 responses:
   '204':


### PR DESCRIPTION
The wrong model was ref-ed for this operation. Additionally, the cURL example was missing the body altogether.