### PR TITLE
droplet actions: use anyOf instead of allOf.

### DIFF
--- a/specification/resources/droplets/post_droplet_action.yml
+++ b/specification/resources/droplets/post_droplet_action.yml
@@ -40,7 +40,7 @@ requestBody:
   content:
     application/json:
       schema:
-        oneOf:
+        anyOf:
           - $ref: 'models/droplet_actions.yml#/droplet_action_type'
           - $ref: 'models/droplet_actions.yml#/droplet_action_restore'
           - $ref: 'models/droplet_actions.yml#/droplet_action_resize'


### PR DESCRIPTION
Both the rename and snapshot Droplet actions have the same attributes in their request body, `type` and `name`. This means we can not use `allOf` as that requires matching against _exactly one_ of the subschemas. Instead, we need `anyOf`.

https://github.com/digitalocean/openapi/blob/e7d843aba7629434683bea43889bbbe16563fe97/specification/resources/droplets/models/droplet_actions.yml#L70-L78

and

https://github.com/digitalocean/openapi/blob/e7d843aba7629434683bea43889bbbe16563fe97/specification/resources/droplets/models/droplet_actions.yml#L91-L99


Fixes: 

```
=== RUN   TestDropletAction_Rename/create_droplet_action-rename/contract
    prism_proxy.go:209: [CONTRACT TEST VIOLATION] code=oneOf message=should match exactly one schema in oneOf severity=Error location=request.body
```