### PR TITLE
firewalls: Update response code is 200 not 202.

### DIFF
--- a/specification/resources/firewalls/update_firewall.yml
+++ b/specification/resources/firewalls/update_firewall.yml
@@ -56,7 +56,7 @@ requestBody:
           - frontend
 
 responses:
-  '202':
+  '200':
     $ref: 'responses/put_firewall_response.yml'
 
   '401':


### PR DESCRIPTION
In contract testing, we've found that the response code for `PUT /v2/firewalls/{id}` is actually 200.

```
$ curl -s -o /dev/null -w "%{http_code}" -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer $DO_TOKEN" -d '{"name":"test-updated","inbound_rules":[{"protocol":"tcp","ports":"2222","sources":{"addresses":["0.0.0.0/0","::/0"]}}]}'  "https://api.digitalocean.com/v2/firewalls/be049df1-a5fc-42aa-99f6-8b48f8e8cdd8"
200
```

Legacy docs omit the status code completely: https://developers.digitalocean.com/documentation/v2/#update-a-firewall