### PR TITLE
images: Updates to address contract validation errors.

### DIFF
--- a/specification/resources/images/get_image.yml
+++ b/specification/resources/images/get_image.yml
@@ -21,7 +21,7 @@ parameters:
       **Private** images *must* be identified by image `id`.
     required: true
     schema:
-      oneOf:
+      anyOf:
         - type: integer
         - type: string
     examples:

--- a/specification/resources/images/models/image.yml
+++ b/specification/resources/images/models/image.yml
@@ -90,6 +90,7 @@ properties:
        `available`, `pending`, `deleted`, or `retired`.
     enum:
       - NEW
+      - new
       - available
       - pending
       - deleted

--- a/specification/resources/images/models/image.yml
+++ b/specification/resources/images/models/image.yml
@@ -66,11 +66,13 @@ properties:
     description: >-
       The minimum disk size in GB required for a Droplet to use this image.
     example: 20
+    nullable: true
     minimum: 0
 
   size_gigabytes:
     type: number
     format: float
+    nullable: true
     description: >-
       The size of the image in gigabytes.
     example: 2.34


### PR DESCRIPTION
This PR bundles three updates to address contract validation errors:

* Use anyOf for path attribute. This is a workaround for https://github.com/stoplightio/prism/issues/1339 Technically they are both strings as they are in a URL path, but retaining the underlaying type info is useful for documentation and clients. We use this for SSH keys as well: https://github.com/digitalocean/openapi/blob/4caff6ae7b96b5f0030bda19edfaf8e45effb58e/specification/resources/ssh_keys/parameters/ssh_key_identifier.yml#L6
* `min_disk_size` and `size_gigabytes` can be `null` in response to the initial POST to create a custom image as that info is not yet available.
* `status` can be both `NEW` or `new` and prism is case sensitive. A bit unfortunate, but we're documenting reality here not the ideal design.