### PR TITLE
firewalls: nullable array attributes.

### DIFF
--- a/specification/resources/firewalls/models/firewall.yml
+++ b/specification/resources/firewalls/models/firewall.yml
@@ -8,7 +8,7 @@ allOf:
           A unique ID that can be used to identify and reference a firewall.
         readOnly: true
         example: bb4b2611-3d72-467b-8602-280330ecd65c
-      
+
       status:
         type: string
         description: >-
@@ -20,7 +20,7 @@ allOf:
           - failed
         readOnly: true
         example: waiting
-      
+
       created_at:
         type: string
         format: date-time
@@ -29,7 +29,7 @@ allOf:
           represents when the firewall was created.
         readOnly: true
         example: '2020-05-23T21:24:00Z'
-      
+
       pending_changes:
         type: array
         description: >-
@@ -43,20 +43,20 @@ allOf:
             droplet_id:
               type: integer
               example: 8043964
-            
+
             removing:
               type: boolean
               example: false
-            
+
             status:
               type: string
               example: waiting
         readOnly: true
-        example: 
+        example:
           - droplet_id: 8043964
             removing: false
             status: waiting
-      
+
       name:
         type: string
         description: >-
@@ -65,21 +65,22 @@ allOf:
           characters, a period (.), or a dash (-).
         pattern: '^[a-zA-Z0-9][a-zA-Z0-9\.-]+$'
         example: firewall
-      
+
       droplet_ids:
         type: array
         description: >-
           An array containing the IDs of the Droplets assigned to the firewall.
-        items: 
+        nullable: true
+        items:
           type: integer
-        example: 
+        example:
           - 8043964
-      
+
       tags:
         allOf:
           - $ref: '../../../shared/attributes/tags_array.yml'
           - description: >-
               An array containing the names of the Tags assigned to the firewall.
             example: gateway
-  
+
   - $ref: 'firewall_rule.yml#/firewall_rules'

--- a/specification/resources/firewalls/models/firewall_rule.yml
+++ b/specification/resources/firewalls/models/firewall_rule.yml
@@ -1,6 +1,6 @@
 firewall_rule_base:
   type: object
-  
+
   properties:
     protocol:
       type: string
@@ -21,7 +21,7 @@ firewall_rule_base:
         ports are open for a protocol. For ICMP rules this parameter will always
         return "0".
       example: '8000'
-  
+
   required:
     - protocol
     - ports
@@ -33,39 +33,39 @@ firewall_rule_target:
   properties:
     addresses:
       type: array
-      items: 
+      items:
         type: string
-      description: >- 
+      description: >-
         An array of strings containing the IPv4 addresses, IPv6 addresses, IPv4
         CIDRs, and/or IPv6 CIDRs to which the firewall will allow traffic.
-      example: 
+      example:
         - '1.2.3.4'
         - '18.0.0.0/8'
 
     droplet_ids:
       type: array
-      items: 
+      items:
         type: integer
-      description: >- 
+      description: >-
         An array containing the IDs of the Droplets to which the firewall will
         allow traffic.
-      example: 
+      example:
         - 8043964
 
     load_balancer_uids:
       type: array
-      items: 
+      items:
         type: string
-      description: >- 
+      description: >-
         An array containing the IDs of the load balancers to which the firewall
         will allow traffic.
       example:
         - 4de7ac8b-495b-4884-9a69-1050c6793cd6
 
     tags:
-      allOf: 
+      allOf:
         - $ref: '../../../shared/attributes/tags_array.yml'
-        - description: >- 
+        - description: >-
             An array containing the names of Tags corresponding to groups of
             Droplets to which the firewall will allow traffic.
           example:
@@ -73,9 +73,10 @@ firewall_rule_target:
 
 firewall_rules:
   type: object
-  
+
   properties:
     inbound_rules:
+      nullable: true
       type: array
       items:
         allOf:
@@ -91,15 +92,16 @@ firewall_rules:
               - sources
 
     outbound_rules:
+      nullable: true
       type: array
       items:
         allOf:
           - $ref: '#/firewall_rule_base'
-          - properties: 
+          - properties:
               destinations:
                 allOf:
                   - $ref: '#/firewall_rule_target'
-                  - description: >- 
+                  - description: >-
                       An object specifying locations to which outbound
                       traffic that will be allowed.
             required:

--- a/specification/shared/attributes/tags_array.yml
+++ b/specification/shared/attributes/tags_array.yml
@@ -1,6 +1,7 @@
 type: array
 items:
   type: string
+nullable: true
 description: >-
   A flat array of tag names as strings to be applied to the resource.
   Tag names may be for either existing or new tags.


### PR DESCRIPTION
This sets `tags`, `droplet_ids`, `inbound_rules`, and `outbound_rules` to `nullable`. 

This addresses multiple instances of these prism violations:

```
code=type message=should be array severity=Error location=request.body.tags
code=type message=should be array severity=Error location=request.body.inbound_rules
code=type message=should be array severity=Error location=request.body.outbound_rules
code=type message=should be array severity=Error location=request.body.droplet_ids
```

