### PR TITLE
droplets: nullable tags attribute.

### DIFF
--- a/specification/resources/droplets/models/droplet_create.yml
+++ b/specification/resources/droplets/models/droplet_create.yml
@@ -59,6 +59,7 @@ properties:
     type: array
     items:
       type: string
+    nullable: true
     example:
     - env:prod
     - web


### PR DESCRIPTION
Similar to https://github.com/digitalocean/openapi/pull/518

Fixes many instances of:

```
code=type message=should be array severity=Error location=request.body.tags
code=required message=should have required property 'names' severity=Error location=request.body
code=oneOf message=should match exactly one schema in oneOf severity=Error location=request.body
```

Both the `names` and `oneOf` errors are due to the request not matching either the single or multiple Droplet create bodies because of the tags error. Both are resolved with this applied.