### PR TITLE
dbaas: Use pattern not format when UUID can be blank.

### DIFF
--- a/specification/resources/databases/models/database_cluster.yml
+++ b/specification/resources/databases/models/database_cluster.yml
@@ -58,7 +58,7 @@ properties:
     readOnly: true
   private_network_uuid:
     type: string
-    format: uuid
+    pattern: '^$|[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}'
     example: d455e75d-4858-4eec-8c95-da2f0a5f93a7
     description: >-
       A string specifying the UUID of the VPC to which the database cluster will be

--- a/specification/resources/databases/models/firewall_rule.yml
+++ b/specification/resources/databases/models/firewall_rule.yml
@@ -3,12 +3,12 @@ type: object
 properties:
   uuid:
     type: string
-    format: uuid
+    pattern: '^$|[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}'
     example: 79f26d28-ea8a-41f2-8ad8-8cfcdd020095
     description: A unique ID for the firewall rule itself.
   cluster_uuid:
     type: string
-    format: uuid
+    pattern: '^$|[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}'
     example: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
     description: A unique ID for the database cluster to which the rule is applied.
   type:


### PR DESCRIPTION
Replaces `format: uuid` with a regex matching a UUID as well as an empty string. Fixes multiple instances of this contract viloation:

    code=format message=should match format \"uuid\" severity=Error location=request.body.private_network_uuid
    code=format message=should match format \"uuid\" severity=Error location=request.body.rules[0].uuid
    code=format message=should match format \"uuid\" severity=Error location=request.body.rules[0].cluster_uuid

