### PR TITLE
registry: Break out create request model.

### DIFF
--- a/specification/resources/registry/create_registry.yml
+++ b/specification/resources/registry/create_registry.yml
@@ -18,7 +18,7 @@ requestBody:
   content:
     application/json:
       schema:
-        $ref: 'models/registry.yml'
+        $ref: 'models/registry_create.yml'
 
 responses:
   '201':

--- a/specification/resources/registry/models/registry.yml
+++ b/specification/resources/registry/models/registry.yml
@@ -10,17 +10,6 @@ properties:
       lowercase and be composed only of numbers, letters and `-`, up to a limit
       of 63 characters.
 
-  subscription_tier_slug:
-    type: string
-    writeOnly: true
-    enum:
-    - starter
-    - basic
-    - professional
-    example: basic
-    description: The slug of the subscription tier to sign up for. Valid values
-      can be retrieved using the options endpoint.
-
   created_at:
     type: string
     format: date-time
@@ -48,7 +37,3 @@ properties:
     allOf:
     - readOnly: true
     - $ref: 'subscription.yml'
-
-required:
-- name
-- subscription_tier_slug

--- a/specification/resources/registry/models/registry_create.yml
+++ b/specification/resources/registry/models/registry_create.yml
@@ -1,0 +1,25 @@
+type: object
+
+properties:
+  name:
+    type: string
+    maxLength: 63
+    pattern: '^[a-z0-9-]{1,63}$'
+    example: example
+    description: A globally unique name for the container registry. Must be
+      lowercase and be composed only of numbers, letters and `-`, up to a limit
+      of 63 characters.
+
+  subscription_tier_slug:
+    type: string
+    enum:
+    - starter
+    - basic
+    - professional
+    example: basic
+    description: The slug of the subscription tier to sign up for. Valid values
+      can be retrieved using the options endpoint.
+
+required:
+- name
+- subscription_tier_slug


### PR DESCRIPTION
Prism does not play well with attributed that are `writeOnly` + `required` (https://github.com/stoplightio/prism/issues/1142). This leads to a number of contract validation failures:

    code=required message=should have required property 'subscription_tier_slug' severity=Error location=response.body.registry

This PR works around the issue by creating a separate  registry create model. 