### PR TITLE
image actions: response code is 201 not 202.

### DIFF
--- a/specification/resources/images/post_image_action.yml
+++ b/specification/resources/images/post_image_action.yml
@@ -37,7 +37,7 @@ requestBody:
             transfer: 'models/image_action.yml#/image_action_transfer'
 
 responses:
-  '202':
+  '201':
     $ref: 'responses/post_image_action_response.yml'
 
   '401':


### PR DESCRIPTION
The response to a successful POST to the image actions endpoint should be 201 not 202.

https://developers.digitalocean.com/documentation/v2/#transfer-an-image

Resolves:
```
=== RUN   TestImagesActions/transfer_image/contract
    prism_proxy.go:211: [CONTRACT TEST VIOLATION] code=required message=should have required property 'id' severity=Error location=response.body
    prism_proxy.go:211: [CONTRACT TEST VIOLATION] code=required message=should have required property 'message' severity=Error location=response.body
```