### PR TITLE
domains: Fix example for creates and add ip_address attribute.

### DIFF
--- a/specification/resources/domains/create_domain.yml
+++ b/specification/resources/domains/create_domain.yml
@@ -16,10 +16,8 @@ requestBody:
     application/json:
       schema:
         $ref: 'models/domain.yml'
-
-      examples:
-        All Domain Records:
-          $ref: 'examples.yml#/domain_record_created'
+      example:
+        name: example.com
 
 responses:
   '201':

--- a/specification/resources/domains/models/domain.yml
+++ b/specification/resources/domains/models/domain.yml
@@ -8,6 +8,14 @@ properties:
       format of domain.TLD. For instance, `example.com` is a valid domain name.
     example: example.com
 
+  ip_address:
+    type: string
+    writeOnly: true
+    description: This optional attribute may contain an IP address. When
+      provided, an A record will be automatically created pointing to the
+      apex domain.
+    example: 192.0.2.1
+
   ttl:
     type: integer
     readOnly: true


### PR DESCRIPTION
The example for creating a new domain actually shows the domain record payload. While fixing this, I noticed that `ip_address` attribute was also missing despite being mentioned in the description.