### PR TITLE
volumes: Document creating from a snapshot.

### DIFF
--- a/specification/resources/volumes/create_new_volume.yml
+++ b/specification/resources/volumes/create_new_volume.yml
@@ -46,6 +46,15 @@ requestBody:
             region: nyc1
             filesystem_type: xfs
             filesystem_label: xfs_volume01
+        Volume from a snapshot:
+          value:
+            size_gigabytes: 10
+            name: snapshot_example
+            snapshot_id: b0798135-fb76-11eb-946a-0a58ac146f33
+            region: nyc1
+            description: A new volume based on a snapshot
+            filesystem_type: ext4
+            filesystem_label: ext4_volume_01
 
 responses:
   '201':

--- a/specification/resources/volumes/models/attributes.yml
+++ b/specification/resources/volumes/models/attributes.yml
@@ -1,6 +1,6 @@
 volume_write_file_system_type:
   type: object
-  required: 
+  required:
     - filesystem_type
   properties:
     filesystem_type:
@@ -38,3 +38,10 @@ volume_action_droplet_id:
     The unique identifier for the Droplet the volume will be attached or
     detached from.
   example: 11612190
+
+volume_snapshot_id:
+  properties:
+    snapshot_id:
+      type: string
+      description: The unique identifier for the volume snapshot from which to create the volume.
+      example: b0798135-fb76-11eb-946a-0a58ac146f33

--- a/specification/resources/volumes/models/new_volume_ext4.yml
+++ b/specification/resources/volumes/models/new_volume_ext4.yml
@@ -1,6 +1,7 @@
 type: object
 allOf:
   - $ref: 'volume_base.yml'
+  - $ref: 'attributes.yml#/volume_snapshot_id'
   - $ref: 'attributes.yml#/volume_write_file_system_type'
   - properties:
       region:

--- a/specification/resources/volumes/models/new_volume_ext4.yml
+++ b/specification/resources/volumes/models/new_volume_ext4.yml
@@ -11,4 +11,7 @@ allOf:
           - $ref: 'attributes.yml#/volume_write_file_system_label'
           - maxLength: 16
     required:
+      - name
+      - size_gigabytes
+      - region
       - filesystem_type

--- a/specification/resources/volumes/models/new_volume_xfs.yml
+++ b/specification/resources/volumes/models/new_volume_xfs.yml
@@ -1,6 +1,7 @@
 type: object
 allOf:
   - $ref: 'volume_base.yml'
+  - $ref: 'attributes.yml#/volume_snapshot_id'
   - $ref: 'attributes.yml#/volume_write_file_system_type'
   - properties:
       region:

--- a/specification/resources/volumes/models/new_volume_xfs.yml
+++ b/specification/resources/volumes/models/new_volume_xfs.yml
@@ -10,3 +10,8 @@ allOf:
         allOf:
           - $ref: 'attributes.yml#/volume_write_file_system_label'
           - maxLength: 12
+    required:
+      - name
+      - size_gigabytes
+      - region
+      - filesystem_type


### PR DESCRIPTION
It was reported that we are missing the `snapshot_id` attribute required for creating a new volume from a snapshot. This was in the old docs and omitted here by oversight. I also realized that we are not labeling the attributes required for creates. 