### PR TITLE
app: Reorder list endpoint for better display.

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -444,29 +444,11 @@ paths:
     get:
       $ref: 'resources/actions/get_action.yml'
 
-  /v2/apps/tiers:
-    get:
-      $ref: 'resources/apps/list_tiers.yml'
-
-  /v2/apps/{app_id}/deployments:
-    get:
-      $ref: 'resources/apps/list_deployments.yml'
-    post:
-      $ref: 'resources/apps/create_deployment.yml'
-
-  /v2/apps/{app_id}/deployments/{deployment_id}/components/{component_name}/logs:
-    get:
-      $ref: 'resources/apps/get_logs.yml'
-
   /v2/apps:
     get:
       $ref: 'resources/apps/list_apps.yml'
     post:
       $ref: 'resources/apps/create_app.yml'
-
-  /v2/apps/{app_id}/deployments/{deployment_id}/logs:
-    get:
-      $ref: 'resources/apps/get_logs_aggregate.yml'
 
   /v2/apps/{id}:
     delete:
@@ -476,29 +458,47 @@ paths:
     put:
       $ref: 'resources/apps/update_app.yml'
 
-  /v2/apps/tiers/instance_sizes:
+  /v2/apps/{app_id}/deployments:
     get:
-      $ref: 'resources/apps/list_instance_sizes.yml'
-
-  /v2/apps/{app_id}/deployments/{deployment_id}/cancel:
+      $ref: 'resources/apps/list_deployments.yml'
     post:
-      $ref: 'resources/apps/cancel_deployment.yml'
-
-  /v2/apps/regions:
-    get:
-      $ref: 'resources/apps/list_regions.yml'
+      $ref: 'resources/apps/create_deployment.yml'
 
   /v2/apps/{app_id}/deployments/{deployment_id}:
     get:
       $ref: 'resources/apps/get_deployment.yml'
 
-  /v2/apps/tiers/instance_sizes/{slug}:
+  /v2/apps/{app_id}/deployments/{deployment_id}/cancel:
+    post:
+      $ref: 'resources/apps/cancel_deployment.yml'
+
+  /v2/apps/{app_id}/deployments/{deployment_id}/components/{component_name}/logs:
     get:
-      $ref: 'resources/apps/get_instance_size.yml'
+      $ref: 'resources/apps/get_logs.yml'
+
+  /v2/apps/{app_id}/deployments/{deployment_id}/logs:
+    get:
+      $ref: 'resources/apps/get_logs_aggregate.yml'
+
+  /v2/apps/tiers:
+    get:
+      $ref: 'resources/apps/list_tiers.yml'
 
   /v2/apps/tiers/{slug}:
     get:
       $ref: 'resources/apps/get_tier.yml'
+
+  /v2/apps/tiers/instance_sizes:
+    get:
+      $ref: 'resources/apps/list_instance_sizes.yml'
+
+  /v2/apps/tiers/instance_sizes/{slug}:
+    get:
+      $ref: 'resources/apps/get_instance_size.yml'
+
+  /v2/apps/regions:
+    get:
+      $ref: 'resources/apps/list_regions.yml'
 
   /v2/apps/propose:
     post:


### PR DESCRIPTION
This fixes PR fixes a pet peeve of mine. It reorders the Apps endpoints in the root spec file with the aim of making them display more logically in the side bar. It moves the core CRUD operations to the top of the list and groups related operations more closely.

Old order:

![2021-09-17_15-29](https://user-images.githubusercontent.com/46943/133843530-8daa1073-4463-4103-88db-3e64b0df32f0.png)

New order:

![2021-09-17_15-30](https://user-images.githubusercontent.com/46943/133843602-25a6b4f7-9e60-4827-aa1c-b38433a9e4b8.png)

