### PR TITLE
certs: Mention how to create a wildcard cert.

### DIFF
--- a/specification/resources/certificates/models/certificate_create.yml
+++ b/specification/resources/certificates/models/certificate_create.yml
@@ -177,7 +177,8 @@ certificate_request_lets_encrypt:
           - www.example.com
           - example.com
           description: An array of fully qualified domain names (FQDNs) for
-            which the certificate was issued.
+            which the certificate was issued. A certificate covering all
+            subdomains can be issued using a wildcard (e.g. `*.example.com`).
 
       required:
       - dns_names


### PR DESCRIPTION
Support for wildcard certs was [just made available](https://docs.digitalocean.com/release-notes/#september-21). Think it is worth an explicit mention here.