### PR TITLE
kubernetes: add supported_features field in kubernetes/options response object

### DIFF
--- a/specification/resources/kubernetes/models/options.yml
+++ b/specification/resources/kubernetes/models/options.yml
@@ -1,4 +1,5 @@
 kubernetes_options:
+
   type: object
   properties:
     options:
@@ -29,6 +30,16 @@ kubernetes_version:
       type: string
       example: '1.16.13'
       description: The upstream version string for the version of Kubernetes
+        provided by a given slug.
+    supported_features:
+      type: array
+      items:
+        type: string
+      example:
+      - cluster-autoscaler
+      - docr-integration
+      - token-authentication
+      description: The features available with the version of Kubernetes
         provided by a given slug.
 
 kubernetes_region:

--- a/specification/resources/kubernetes/responses/examples.yml
+++ b/specification/resources/kubernetes/responses/examples.yml
@@ -490,10 +490,22 @@ kubernetes_options:
       versions:
         - slug: 1.18.8-do.0
           kubernetes_version: 1.18.8
+          supported_features:
+            - cluster-autoscaler
+            - docr-integration
+            - token-authentication
         - slug: 1.17.11-do.0
           kubernetes_version: 1.17.11
+          supported_features:
+            - cluster-autoscaler
+            - docr-integration
+            - token-authentication
         - slug: 1.16.14-do.0
           kubernetes_version: 1.16.14
+          supported_features:
+            - cluster-autoscaler
+            - docr-integration
+            - token-authentication
       sizes:
         - name: s-1vcpu-2gb
           slug: s-1vcpu-2gb


### PR DESCRIPTION
The DOKS team has added a `supported_features` field to the `kubernetes/options` endpoint. This PR adds it to the documentation.