### PR TITLE
K8s: add updated docs for HA support

### DIFF
--- a/specification/resources/kubernetes/models/cluster.yml
+++ b/specification/resources/kubernetes/models/cluster.yml
@@ -141,6 +141,14 @@ properties:
       fast and reliable by bringing up new nodes before destroying the outdated
       nodes.
 
+  ha:
+    type: boolean
+    default: false
+    example: true
+    description: A boolean value indicating whether the control plane
+      is run in a highly available configuration in the cluster. Highly available
+      control planes incur less downtime. 
+
   registry_enabled:
     type: boolean
     readOnly: true

--- a/specification/resources/kubernetes/models/cluster_update.yml
+++ b/specification/resources/kubernetes/models/cluster_update.yml
@@ -37,5 +37,13 @@ properties:
       fast and reliable by bringing up new nodes before destroying the outdated
       nodes.
 
+  ha:
+    type: boolean
+    default: false
+    example: true
+    description: A boolean value indicating whether the control plane
+      is run in a highly available configuration in the cluster. Highly available
+      control planes incur less downtime. 
+
 required:
   - name

--- a/specification/resources/kubernetes/responses/examples.yml
+++ b/specification/resources/kubernetes/responses/examples.yml
@@ -97,6 +97,7 @@ kubernetes_clusters_all:
       updated_at: '2018-11-15T16:00:11Z'
       surge_upgrade: false
       registry_enabled: false
+      ha: false
     meta:
       total: 1
 
@@ -198,6 +199,7 @@ kubernetes_single:
       updated_at: '2018-11-15T16:00:11Z'
       surge_upgrade: false
       registry_enabled: false
+      ha: false
 
 kubernetes_updated:
   value:
@@ -297,6 +299,7 @@ kubernetes_updated:
       updated_at: '2018-11-15T16:00:11Z'
       surge_upgrade: true
       registry_enabled: false
+      ha: true
 
 kubernetes_clusters_create_basic_response:
   value:
@@ -361,6 +364,7 @@ kubernetes_clusters_create_basic_response:
       updated_at: '2018-11-15T16:00:11Z'
       surge_upgrade: false
       registry_enabled: false
+      ha: false
 
 kubernetes_clusters_multi_pool_response:
   value:
@@ -462,6 +466,7 @@ kubernetes_clusters_multi_pool_response:
       updated_at: '2018-11-15T16:00:11Z'
       surge_upgrade: false
       registry_enabled: false
+      ha: false
 
 kubernetes_options:
   value:


### PR DESCRIPTION
This PR updates the Kubernetes documentation to include the HA functionality and features.

Please DO NOT merge this PR until the EA date for the HA (October 12).

This PR is to make it so anyone can merge it and update it and there is no bottleneck. It'll also alert us if there are any conflicts that arise.