### PR TITLE
apps: Use standard meta  to prevent duplicate component.

### DIFF
--- a/specification/resources/apps/models/apps_deployments_response.yml
+++ b/specification/resources/apps/models/apps_deployments_response.yml
@@ -1,11 +1,10 @@
-properties:
-  deployments:
-    items:
-      $ref: apps_deployment.yml
-    title: A list of deployments
-    type: array
-  links:
-    $ref: ../../../shared/pages.yml#/page_links
-  meta:
-    $ref: ../../../shared/meta.yml#/properties/meta
-type: object
+allOf:
+  - type: object
+    properties:
+      deployments:
+        title: A list of deployments
+        type: array
+        items:
+          $ref: apps_deployment.yml
+  - $ref: ../../../shared/pages.yml#/pagination
+  - $ref: ../../../shared/meta.yml

--- a/specification/resources/apps/models/apps_response.yml
+++ b/specification/resources/apps/models/apps_response.yml
@@ -1,11 +1,10 @@
-properties:
-  apps:
-    items:
-      $ref: app.yml
-    title: A list of apps
-    type: array
-  links:
-    $ref: ../../../shared/pages.yml#/page_links
-  meta:
-    $ref: ../../../shared/meta.yml#/properties/meta
-type: object
+allOf:
+  - type: object
+    properties:
+      apps:
+        title: A list of apps
+        type: array
+        items:
+          $ref: app.yml
+  - $ref: ../../../shared/pages.yml#/pagination
+  - $ref: ../../../shared/meta.yml

--- a/specification/resources/apps/responses/examples.yml
+++ b/specification/resources/apps/responses/examples.yml
@@ -82,6 +82,11 @@ apps:
         tier_slug: basic
         live_url_base: https://sample-php-iaj87.ondigitalocean.app
         live_domain: sample-php-iaj87.ondigitalocean.app
+    links:
+      pages: {}
+    meta:
+      total:
+        1
 
 app:
   value:
@@ -262,6 +267,11 @@ deployments:
               status: PENDING
         phase: PENDING_BUILD
         tier_slug: basic
+    links:
+      pages: {}
+    meta:
+      total:
+        1
 
 deployment:
   value:

--- a/specification/resources/apps/responses/list_deployment.yml
+++ b/specification/resources/apps/responses/list_deployment.yml
@@ -5,8 +5,8 @@ content:
     schema:
       $ref: ../models/apps_deployment_response.yml
     examples:
-      deployment: 
-        $ref: examples.yml#/deployment 
+      deployment:
+        $ref: examples.yml#/deployment
 
 headers:
   ratelimit-limit:

--- a/specification/shared/meta.yml
+++ b/specification/shared/meta.yml
@@ -3,9 +3,7 @@ type: object
 properties:
   meta:
     description: Information about the response itself.
-
     type: object
-
     properties:
       total:
         description: Number of objects returned by the request.


### PR DESCRIPTION
This addresses the linting error being thrown in https://github.com/digitalocean/openapi/pull/556

```
/home/runner/work/openapi/openapi/tests/openapi-bundled.yaml
 18977:21  error  schema-key-must-be-snake-cased  components.schemas.properties-meta is not snake_case  components.schemas.properties-meta
```

Seems there was a behavior change in bundling when we updated `openapi-cli` in https://github.com/digitalocean/openapi/pull/555 Because of the way app responses were ref-ing the shared meta component, `openapi-cli` was creating a new component named `properties-meta`. This PR updates the apps schemas to ref the meta component the same way others do. Doing so also exposed a real linting error that the apps list response examples were missing pagination. This fixes that as well.