### PR TITLE
Set proxy port to 8000.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-POSTMAN_BASE_URL ?= http://localhost:8080
+POSTMAN_BASE_URL ?= http://localhost:8000
 PROXY_TARGET ?= http://mock:4010
 
 SPEC_FILE ?= specification/DigitalOcean-public.v2.yaml
@@ -18,7 +18,7 @@ dev-dependencies: ## Install development tooling using npm
 	npm install --only=dev
 
 .PHONY: start-mockedproxy
-start-mockedproxy: ## Start a prism proxy (port 8080) targeting a local mock api (port 4010)
+start-mockedproxy: ## Start a prism proxy (port 8000) targeting a local mock api (port 4010)
 	PROXY_TARGET=$(PROXY_TARGET) docker-compose up -d
 
 .PHONY: stop-services

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,4 +16,4 @@ services:
     volumes:
       - ./specification:/prism
     ports:
-      - "8090:4010"
+      - "8000:4010"


### PR DESCRIPTION
At some point, the port used for the proxy changed from `8080` to `8090`. IIRC, this was so you can run the docs preview and the proxy at the same time. This broke some assumptions in the Makefile. This update makes it so the port used in the docker compose file and Makefile match. I chose `8000` as it's more memorable for me that `8090`, but don't really have a strong opinion.