### PR TITLE
DBaaS Online Migration Available for MySQL (2022-01-25)

### DIFF
--- a/specification/resources/databases/start_online_migration.yml
+++ b/specification/resources/databases/start_online_migration.yml
@@ -7,7 +7,7 @@ description: >-
   `/v2/databases/$DATABASE_ID/online-migration` endpoint. Migrating a cluster
   establishes a connection with an existing cluster and replicates its
   contents to the target cluster. Online migration is only available for
-  PostgreSQL and Redis clusters.
+  MySQL, PostgreSQL, and Redis clusters.
 
 tags:
   - Databases

--- a/specification/resources/load_balancers/models/load_balancer_base.yml
+++ b/specification/resources/load_balancers/models/load_balancer_base.yml
@@ -21,6 +21,19 @@ properties:
     example: '104.131.186.241'
     description: An attribute containing the public-facing IP address of the
       load balancer.
+      
+  size_unit:
+    type: integer
+    default: 1
+    minimum: 1
+    maximum: 100
+    example: 3
+    description: How many nodes the load balancer contains. Each additional 
+      node increases the load balancer's ability to manage more connections.
+      Load balancers can be scaled up or down, and you can change the number of 
+      nodes after creation up to once per hour. This field is currently not 
+      available in the AMS2, NYC2, or SFO1 regions. Use the `size` field to 
+      scale load balancers that reside in these regions.
 
   size:
     type: string
@@ -28,12 +41,22 @@ properties:
     - lb-small
     - lb-medium
     - lb-large
+    deprecated: true
     default: lb-small
     example: lb-small
-    description: The size of the load balancer. The available sizes are
-      `lb-small`, `lb-medium`, or `lb-large`. You can resize load balancers
-      after creation up to once per hour. You cannot resize a load balancer
-      within the first hour of its creation.
+    description: This field has been replaced by the `size_unit` field for all 
+      regions except in AMS2, NYC2, and SFO1. Each available load balancer size 
+      now equates to the load balancer having a set number of nodes. 
+
+      * `lb-small` = 1 node
+
+      * `lb-medium` = 3 nodes
+
+      * `lb-large` = 6 nodes
+
+
+      You can resize load balancers after creation up to once per hour. You 
+      cannot resize a load balancer within the first hour of its creation.
 
   algorithm:
     type: string
@@ -41,10 +64,10 @@ properties:
     enum:
       - round_robin
       - least_connections
+    deprecated: true
     default: round_robin
-    description: The load balancing algorithm used to determine which backend
-      Droplet will be selected by a client. It must be either `round_robin` or
-      `least_connections`.
+    description: This field has been deprecated. You can no longer specify an 
+      algorithm for load balancers.
 
   status:
     type: string


### PR DESCRIPTION
Just added MySQL to the list of available DBs for online migration. Releases on Jan. 25.