### PR TITLE
Online Migration Available for MySQL (Jan. 25)

### DIFF
--- a/specification/resources/databases/start_online_migration.yml
+++ b/specification/resources/databases/start_online_migration.yml
@@ -7,7 +7,7 @@ description: >-
   `/v2/databases/$DATABASE_ID/online-migration` endpoint. Migrating a cluster
   establishes a connection with an existing cluster and replicates its
   contents to the target cluster. Online migration is only available for
-  PostgreSQL and Redis clusters.
+  MySQL, PostgreSQL, and Redis clusters.
 
 tags:
   - Databases


### PR DESCRIPTION
Added MySQL to the list of DBs available for online migration. Releases Tuesday, Jan. 25 at noon.