### PR TITLE
Updated Smallest VPC Size Available

### DIFF
--- a/specification/resources/vpcs/models/vpc.yml
+++ b/specification/resources/vpcs/models/vpc.yml
@@ -71,6 +71,6 @@ vpc_create:
       description: The range of IP addresses in the VPC in CIDR notation.
         Network ranges cannot overlap with other networks in the same account
           and must be in range of private addresses as defined in RFC1918. It
-          may not be smaller than `/24` nor larger than `/16`. If no IP range
+          may not be smaller than `/28` nor larger than `/16`. If no IP range
           is specified, a `/20` network range is generated that won't conflict
           with other VPC networks in your account.


### PR DESCRIPTION
We now support `/28` sized networks. Tiny change for tiny networks.