### PR TITLE
Fix create volume snapshot code example

### DIFF
--- a/specification/resources/volumes/examples/go/create_volume_snapshot.yml
+++ b/specification/resources/volumes/examples/go/create_volume_snapshot.yml
@@ -13,5 +13,10 @@ source: |-
       client := godo.NewFromToken(token)
       ctx := context.TODO()
 
-      snapshot, _, err := client.Storage.CreateSnapshot(ctx, "82a48a18-873f-11e6-96bf-000f53315a41")
+      snapshot, _, err := client.Storage.CreateSnapshot(ctx, &godo.SnapshotCreateRequest{
+        VolumeID:    "82a48a18-873f-11e6-96bf-000f53315a41",
+        Name:        "my snapshot",
+        Description: "my description",
+        Tags:        []string{"one", "two"},
+      })
   }


### PR DESCRIPTION
Relates to https://github.com/digitalocean/godo/issues/512

The current example for creating a volume snapshot incorrectly lists the example as accepting only a volume ID as an argument, but godo requires that a struct be passed (see https://pkg.go.dev/github.com/digitalocean/godo#StorageServiceOp.CreateSnapshot).