### PR TITLE
Added forking terminology to DBaaS Create description

### DIFF
--- a/specification/resources/databases/create_database_cluster.yml
+++ b/specification/resources/databases/create_database_cluster.yml
@@ -18,7 +18,8 @@ description: >-
   To create a new database cluster based on a backup of an exising cluster, send a POST
   request to `/v2/databases`. In addition to the standard database cluster attributes, the
   JSON body must include a key named `backup_restore` with the name of the original
-  database cluster and the timestamp of the backup to be restored.
+  database cluster and the timestamp of the backup to be restored. Creating a database 
+  from a backup is the same as forking a database in the control panel.
 
   Note: Backups are not supported for Redis clusters.
 

--- a/specification/resources/databases/examples/curl/create_database_cluster.yml
+++ b/specification/resources/databases/examples/curl/create_database_cluster.yml
@@ -3,5 +3,5 @@ source: |-
   curl -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-    -d '{"name": "backend", "engine": "pg", "version": "10", "region": "nyc3", "size": "db-s-2vcpu-4gb", "num_nodes": 2, "tags": ["production"]}' \
+    -d '{"name": "backend", "engine": "pg", "version": "14", "region": "nyc3", "size": "db-s-2vcpu-4gb", "num_nodes": 2, "tags": ["production"]}' \
     "https://api.digitalocean.com/v2/databases"

--- a/specification/resources/databases/examples/curl/create_database_cluster.yml
+++ b/specification/resources/databases/examples/curl/create_database_cluster.yml
@@ -3,5 +3,5 @@ source: |-
   curl -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-    -d '{"name": "backend", "engine": "pg", "version": "14", "region": "nyc3", "size": "db-s-2vcpu-4gb", "num_nodes": 2, "tags": ["production"]}' \
+    -d '{"name": "backend", "engine": "pg", "version": "13", "region": "nyc3", "size": "db-s-2vcpu-4gb", "num_nodes": 2, "tags": ["production"]}' \
     "https://api.digitalocean.com/v2/databases"

--- a/specification/resources/databases/examples/go/create_database_cluster.yml
+++ b/specification/resources/databases/examples/go/create_database_cluster.yml
@@ -16,7 +16,7 @@ source: |-
       createRequest := &godo.DatabaseCreateRequest{
           Name:       "backend",
           EngineSlug: "pg",
-          Version:    "14",
+          Version:    "13",
           Region:     "nyc3",
           SizeSlug:   "db-s-2vcpu-4gb",
           NumNodes:   2,

--- a/specification/resources/databases/examples/go/create_database_cluster.yml
+++ b/specification/resources/databases/examples/go/create_database_cluster.yml
@@ -16,7 +16,7 @@ source: |-
       createRequest := &godo.DatabaseCreateRequest{
           Name:       "backend",
           EngineSlug: "pg",
-          Version:    "10",
+          Version:    "14",
           Region:     "nyc3",
           SizeSlug:   "db-s-2vcpu-4gb",
           NumNodes:   2,


### PR DESCRIPTION
Per the [conversation in this thread](https://digitalocean.slack.com/archives/CASLGBDGW/p1643235051047100), I updated the database create description to equate the backup restore functionality to the forking functionality in the UI. I've also updated the version fields in the create examples to something more current.