### PR TITLE
update some curl examples with double quotes for proper env substitution

### DIFF
--- a/specification/resources/projects/examples/curl/delete_project.yml
+++ b/specification/resources/projects/examples/curl/delete_project.yml
@@ -1,4 +1,4 @@
 lang: cURL
 source: |-
-  curl -X DELETE -H 'Content-Type: application/json' -H 'Authorization: Bearer $DIGITALOCEAN_TOKEN' \
+  curl -X DELETE -H 'Content-Type: application/json' -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
     "https://api.digitalocean.com/v2/projects/4e1bfbc3-dc3e-41f2-a18f-1b4d7ba71679"

--- a/specification/resources/snapshots/examples/curl/delete_snapshot.yml
+++ b/specification/resources/snapshots/examples/curl/delete_snapshot.yml
@@ -2,5 +2,5 @@ lang: cURL
 source: |-
   curl -X DELETE \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer $DIGITALOCEAN_TOKEN' \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
     "https://api.digitalocean.com/v2/snapshots/fbe805e8-866b-11e6-96bf-000f53315a41"

--- a/specification/resources/snapshots/examples/curl/get_snapshots.yml
+++ b/specification/resources/snapshots/examples/curl/get_snapshots.yml
@@ -2,5 +2,5 @@ lang: cURL
 source: |-
   curl -X GET \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer $DIGITALOCEAN_TOKEN' \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
     "https://api.digitalocean.com/v2/snapshots/fbe805e8-866b-11e6-96bf-000f53315a41"

--- a/specification/resources/snapshots/examples/curl/list_all_snapshots.yml
+++ b/specification/resources/snapshots/examples/curl/list_all_snapshots.yml
@@ -3,17 +3,17 @@ source: |-
   # List all snapshots
   curl -X GET \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer $DIGITALOCEAN_TOKEN' \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
     "https://api.digitalocean.com/v2/snapshots?page=1&per_page=1"
 
   # List all Droplet snapshots
   curl -X GET \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer $DIGITALOCEAN_TOKEN' \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
     "https://api.digitalocean.com/v2/snapshots?page=1&per_page=1&resource_type=droplet"
 
   # List volume snapshots
   curl -X GET \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer $DIGITALOCEAN_TOKEN' \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
     "https://api.digitalocean.com/v2/snapshots?page=1&per_page=1&resource_type=volume"

--- a/specification/resources/volumes/examples/curl/create_volume_snapshot.yml
+++ b/specification/resources/volumes/examples/curl/create_volume_snapshot.yml
@@ -2,6 +2,6 @@ lang: cURL
 source: |-
   curl -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer $DIGITALOCEAN_TOKEN' \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
     -d '{"name":"big-data-snapshot1475261774", "tags":["aninterestingtag"]}' \
     "https://api.digitalocean.com/v2/volumes/82a48a18-873f-11e6-96bf-000f53315a41/snapshots"

--- a/specification/resources/volumes/examples/curl/delete_volume_snapshot_by_id.yml
+++ b/specification/resources/volumes/examples/curl/delete_volume_snapshot_by_id.yml
@@ -1,4 +1,4 @@
 lang: cURL
 source: |-
-  curl -X DELETE -H 'Content-Type: application/json' -H 'Authorization: Bearer $DIGITALOCEAN_TOKEN' \
+  curl -X DELETE -H 'Content-Type: application/json' -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
     "https://api.digitalocean.com/v2/snapshots/fbe805e8-866b-11e6-96bf-000f53315a41"

--- a/specification/resources/volumes/examples/curl/list_volume_snapshots.yml
+++ b/specification/resources/volumes/examples/curl/list_volume_snapshots.yml
@@ -2,5 +2,5 @@ lang: cURL
 source: |-
   curl -X GET \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer $DIGITALOCEAN_TOKEN' \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
     "https://api.digitalocean.com/v2/volumes/82a48a18-873f-11e6-96bf-000f53315a41/snapshots?page=1&per_page=1"


### PR DESCRIPTION
via a customer report: https://digitalocean.slack.com/archives/CA4LXTX6J/p1646074972041299

Some of our curl examples used single quotes for the `Authorization: Bearer $DIGITALOCEAN_TOKEN` header, resulting in no variable substitution and auth errors for customers copy/pasting from the docs. Fixed in 9 different examples.