### PR TITLE
adding "volume_name" to example in block storage

### DIFF
--- a/specification/resources/volumes/post_volume_action_by_name.yml
+++ b/specification/resources/volumes/post_volume_action_by_name.yml
@@ -59,6 +59,7 @@ requestBody:
         VolumeActionAttach:
           value:
             type: attach
+            volume_name: example
             droplet_id: 11612190
             region: nyc1
             tags:
@@ -67,6 +68,7 @@ requestBody:
         VolumeActionDetatch:
           value:
             type: detach
+            volume_name: example
             droplet_id: 11612190
             region: nyc1
 


### PR DESCRIPTION
the doc and curl example has "volume_name" while the payload did not.

https://docs.digitalocean.com/reference/api/api-reference/#operation/post_volume_action_by_name