### PR TITLE
fix list_associated_resouces example

### DIFF
--- a/specification/resources/kubernetes/examples/curl/list_associated_resources.yml
+++ b/specification/resources/kubernetes/examples/curl/list_associated_resources.yml
@@ -1,6 +1,6 @@
 lang: cURL
 source: |-
-  curl -X DELETE \
+  curl -X GET \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
     "https://api.digitalocean.com/v2/kubernetes/clusters/bd5f5959-5e1e-4205-a714-a914373942af/destroy_with_associated_resources"


### PR DESCRIPTION
listing kubernetes associated resources is a GET request. The example provided in doc has it being a delete request