### PR TITLE
distribution: Add Rocky Linux as valid.

### DIFF
--- a/specification/shared/attributes/distribution.yml
+++ b/specification/shared/attributes/distribution.yml
@@ -1,9 +1,9 @@
 type: string
 description: >-
   The name of a custom image's distribution. Currently, the valid values are 
-  "Arch Linux", "CentOS", "CoreOS", "Debian", "Fedora", "Fedora Atomic", 
-  "FreeBSD", "Gentoo", "openSUSE", "RancherOS", "Ubuntu", and "Unknown". 
-  Any other value will be accepted but ignored, and "Unknown" will be used in its place.
+  `Arch Linux`, `CentOS`, `CoreOS`, `Debian`, `Fedora`, `Fedora Atomic`, 
+  `FreeBSD`, `Gentoo`, `openSUSE`, `RancherOS`, `Rocky Linux`, `Ubuntu`, and `Unknown`. 
+  Any other value will be accepted but ignored, and `Unknown` will be used in its place.
 enum:
   - Arch Linux
   - CentOS
@@ -15,6 +15,7 @@ enum:
   - Gentoo
   - openSUSE
   - RancherOS
+  - Rocky Linux
   - Ubuntu
   - Unknown
 example: Ubuntu


### PR DESCRIPTION
We now offer Rocky Linux. Resolves contract testing failure.

```
12:35:38 === CONT  TestImages_CreateGetUpdateDelete/get_images
12:35:38     round_trippers.go:313: [CONTRACT TEST VIOLATION] response body doesn't match the schema: Error at "/images/6/distribution": value is not one of the allowed values
12:35:38         Schema:
12:35:38           {
12:35:38             "description": "The name of a custom image's distribution. Currently, the valid values are  \"Arch Linux\", \"CentOS\", \"CoreOS\", \"Debian\", \"Fedora\", \"Fedora Atomic\",  \"FreeBSD\", \"Gentoo\", \"openSUSE\", \"RancherOS\", \"Ubuntu\", and \"Unknown\".  Any other value will be accepted but ignored, and \"Unknown\" will be used in its place.",
12:35:38             "enum": [
12:35:38               "Arch Linux",
12:35:38               "CentOS",
12:35:38               "CoreOS",
12:35:38               "Debian",
12:35:38               "Fedora",
12:35:38               "Fedora Atomic",
12:35:38               "FreeBSD",
12:35:38               "Gentoo",
12:35:38               "openSUSE",
12:35:38               "RancherOS",
12:35:38               "Ubuntu",
12:35:38               "Unknown"
12:35:38             ],
12:35:38             "example": "Ubuntu",
12:35:38             "type": "string"
12:35:38           }
12:35:38         
12:35:38         Value:
12:35:38           "Rocky Linux"
12:35:38          | Error at "/images/7/distribution": value is not one of the allowed values
````