### PR TITLE
Removes required field

### DIFF
--- a/specification/resources/billing/responses/billing_history.yml
+++ b/specification/resources/billing/responses/billing_history.yml
@@ -19,23 +19,21 @@ content:
               type: array
               items:
                 $ref: '../models/billing_history.yml'
-          required:
-            - billing_history
         - $ref: '../../../shared/pages.yml#/pagination'
         - $ref: '../../../shared/meta.yml'
 
       example:
         billing_history:
-        - description: Invoice for May 2018
-          amount: '12.34'
-          invoice_id: '123'
-          invoice_uuid: example-uuid
-          date: '2018-06-01T08:44:38Z'
-          type: Invoice
-        - description: Payment (MC 2018)
-          amount: "-12.34"
-          date: '2018-06-02T08:44:38Z'
-          type: Payment
+          - description: Invoice for May 2018
+            amount: '12.34'
+            invoice_id: '123'
+            invoice_uuid: example-uuid
+            date: '2018-06-01T08:44:38Z'
+            type: Invoice
+          - description: Payment (MC 2018)
+            amount: '-12.34'
+            date: '2018-06-02T08:44:38Z'
+            type: Payment
         links:
           pages:
             next: https://api.digitalocean.com/v2/customers/my/billing_history?page=2&per_page=2


### PR DESCRIPTION
In the case of our admin test account that doesn't get billed, we can see the `billing_history` field isn't included in the response.

The example got auto-formatted also.