### PR TITLE
Remove type: string from kubconfig response

### DIFF
--- a/specification/resources/kubernetes/responses/kubeconfig.yml
+++ b/specification/resources/kubernetes/responses/kubeconfig.yml
@@ -10,9 +10,6 @@ headers:
 
 content:
   application/yaml:
-    schema:
-      type: string
-
     example: |
       apiVersion: v1
       clusters:


### PR DESCRIPTION
Since the content type is `application/yaml`, the body is technically an object (default type).
This should resolve the current contract test violation for `TestKubernetes_CreateBasic/get_kubernetes_cluster_kubeconfig`:

```
12:46:18     round_trippers.go:313: [CONTRACT TEST VIOLATION] response body doesn't match the schema: Field must be set to string or not be present
12:46:18         Schema:
12:46:18           {
12:46:18             "type": "string"
12:46:18           }
12:46:18         
12:46:18         Value:
12:46:18           "object"
```