### PR TITLE
UDP support for load balancers

### DIFF
--- a/specification/resources/load_balancers/models/forwarding_rule.yml
+++ b/specification/resources/load_balancers/models/forwarding_rule.yml
@@ -10,6 +10,7 @@ properties:
     - https
     - http2
     - tcp
+    - udp
     example: https
     description: >
       The protocol used for traffic to the load balancer. The possible values

--- a/specification/resources/load_balancers/models/forwarding_rule.yml
+++ b/specification/resources/load_balancers/models/forwarding_rule.yml
@@ -35,7 +35,7 @@ properties:
     example: http
     description: >
       The protocol used for traffic from the load balancer to the backend
-      Droplets. The possible values are: `http`, `https`, `http2`, `tcp` or `udp`.
+      Droplets. The possible values are: `http`, `https`, `http2`, `tcp`, or `udp`.
       If you set the `target_protocol` to `upd`, the `entry_protocol` must be set to 
       `udp`. When using UDP, the load balancer requires that you set up a health 
       check with a port that uses TCP, HTTP, or HTTPS to work properly.

--- a/specification/resources/load_balancers/models/forwarding_rule.yml
+++ b/specification/resources/load_balancers/models/forwarding_rule.yml
@@ -13,7 +13,10 @@ properties:
     example: https
     description: >
       The protocol used for traffic to the load balancer. The possible values
-      are: `http`, `https`, `http2`, or `tcp`.
+      are: `http`, `https`, `http2`, `tcp`, or `udp`. If you set the 
+      `entry_protocol` to `upd`, the `target_protocol` must be set to `udp`. 
+      When using UDP, the load balancer requires that you set up a health 
+      check with a port that uses TCP, HTTP, or HTTPS to work properly.
 
   entry_port:
     type: integer
@@ -28,10 +31,14 @@ properties:
     - https
     - http2
     - tcp
+    - udp
     example: http
     description: >
       The protocol used for traffic from the load balancer to the backend
-      Droplets. The possible values are: `http`, `https`, `http2`, or `tcp`.
+      Droplets. The possible values are: `http`, `https`, `http2`, `tcp` or `udp`.
+      If you set the `target_protocol` to `upd`, the `entry_protocol` must be set to 
+      `udp`. When using UDP, the load balancer requires that you set up a health 
+      check with a port that uses TCP, HTTP, or HTTPS to work properly.
 
   target_port:
     type: integer


### PR DESCRIPTION
This PR adds UDP support to the list of available protocols for load balancers.