### PR TITLE
Remove 'read' scope from operations requiring write permissions.

### DIFF
--- a/specification/resources/1-clicks/install_kubernetes.yml
+++ b/specification/resources/1-clicks/install_kubernetes.yml
@@ -39,5 +39,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/apps/assign_alert_destinations.yml
+++ b/specification/resources/apps/assign_alert_destinations.yml
@@ -43,5 +43,4 @@ x-codeSamples:
   - $ref: 'examples/curl/assign_alert_destinations.yml'
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/apps/cancel_deployment.yml
+++ b/specification/resources/apps/cancel_deployment.yml
@@ -35,5 +35,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/apps/create_app.yml
+++ b/specification/resources/apps/create_app.yml
@@ -52,5 +52,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/apps/create_deployment.yml
+++ b/specification/resources/apps/create_deployment.yml
@@ -42,5 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/apps/delete_app.yml
+++ b/specification/resources/apps/delete_app.yml
@@ -36,5 +36,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/apps/update_app.yml
+++ b/specification/resources/apps/update_app.yml
@@ -42,5 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/cdn/create_endpoint.yml
+++ b/specification/resources/cdn/create_endpoint.yml
@@ -58,5 +58,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/cdn/delete_endpoint.yml
+++ b/specification/resources/cdn/delete_endpoint.yml
@@ -41,5 +41,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/cdn/purge_cdn_cache.yml
+++ b/specification/resources/cdn/purge_cdn_cache.yml
@@ -50,5 +50,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/cdn/update_endpoint.yml
+++ b/specification/resources/cdn/update_endpoint.yml
@@ -47,5 +47,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/certificates/create_certificates.yml
+++ b/specification/resources/certificates/create_certificates.yml
@@ -49,5 +49,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/certificates/delete_certificate.yml
+++ b/specification/resources/certificates/delete_certificate.yml
@@ -38,5 +38,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/add_connection_pool.yml
+++ b/specification/resources/databases/add_connection_pool.yml
@@ -58,5 +58,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/add_database.yml
+++ b/specification/resources/databases/add_database.yml
@@ -51,5 +51,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/add_user.yml
+++ b/specification/resources/databases/add_user.yml
@@ -63,5 +63,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/create_database_cluster.yml
+++ b/specification/resources/databases/create_database_cluster.yml
@@ -18,7 +18,7 @@ description: >-
   To create a new database cluster based on a backup of an exising cluster, send a POST
   request to `/v2/databases`. In addition to the standard database cluster attributes, the
   JSON body must include a key named `backup_restore` with the name of the original
-  database cluster and the timestamp of the backup to be restored. Creating a database 
+  database cluster and the timestamp of the backup to be restored. Creating a database
   from a backup is the same as forking a database in the control panel.
 
   Note: Backups are not supported for Redis clusters.
@@ -86,5 +86,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/create_replica.yml
+++ b/specification/resources/databases/create_replica.yml
@@ -62,5 +62,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/delete_connection_pool.yml
+++ b/specification/resources/databases/delete_connection_pool.yml
@@ -40,5 +40,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/delete_database.yml
+++ b/specification/resources/databases/delete_database.yml
@@ -43,5 +43,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/delete_user.yml
+++ b/specification/resources/databases/delete_user.yml
@@ -43,5 +43,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/destroy_cluster.yml
+++ b/specification/resources/databases/destroy_cluster.yml
@@ -40,5 +40,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/destroy_replica.yml
+++ b/specification/resources/databases/destroy_replica.yml
@@ -43,5 +43,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/migrate_database_cluster.yml
+++ b/specification/resources/databases/migrate_database_cluster.yml
@@ -61,5 +61,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/patch_database_config.yml
+++ b/specification/resources/databases/patch_database_config.yml
@@ -46,5 +46,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/reset_auth.yml
+++ b/specification/resources/databases/reset_auth.yml
@@ -4,7 +4,7 @@ summary: Reset a Database User's Password or Authentication Method
 
 description: |
   To reset the password for a database user, send a POST request to
-  `/v2/databases/$DATABASE_ID/users/$USERNAME/reset_auth`. 
+  `/v2/databases/$DATABASE_ID/users/$USERNAME/reset_auth`.
 
   For `mysql` databases, the authentication method can be specifying by
   including a key in the JSON body called `mysql_settings` with the `auth_plugin`
@@ -58,5 +58,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/resize_database_cluster.yml
+++ b/specification/resources/databases/resize_database_cluster.yml
@@ -55,5 +55,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/start_online_migration.yml
+++ b/specification/resources/databases/start_online_migration.yml
@@ -56,5 +56,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/stop_online_migration.yml
+++ b/specification/resources/databases/stop_online_migration.yml
@@ -37,5 +37,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/update_database_firewall.yml
+++ b/specification/resources/databases/update_database_firewall.yml
@@ -70,5 +70,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/update_eviction_policy.yml
+++ b/specification/resources/databases/update_eviction_policy.yml
@@ -47,5 +47,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/update_maintenance_window.yml
+++ b/specification/resources/databases/update_maintenance_window.yml
@@ -51,5 +51,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/databases/update_sql_mode.yml
+++ b/specification/resources/databases/update_sql_mode.yml
@@ -51,5 +51,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/domains/create_domain.yml
+++ b/specification/resources/domains/create_domain.yml
@@ -42,5 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/domains/create_domain_record.yml
+++ b/specification/resources/domains/create_domain_record.yml
@@ -82,5 +82,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/domains/delete_domain.yml
+++ b/specification/resources/domains/delete_domain.yml
@@ -37,5 +37,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/domains/delete_domain_record.yml
+++ b/specification/resources/domains/delete_domain_record.yml
@@ -42,5 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/domains/patch_update_domain_record.yml
+++ b/specification/resources/domains/patch_update_domain_record.yml
@@ -47,5 +47,4 @@ responses:
     $ref: '../../shared/responses/unexpected_error.yml'
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/domains/update_domain_record.yml
+++ b/specification/resources/domains/update_domain_record.yml
@@ -53,5 +53,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/droplets/create_droplet.yml
+++ b/specification/resources/droplets/create_droplet.yml
@@ -69,5 +69,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/droplets/destroy_droplet.yml
+++ b/specification/resources/droplets/destroy_droplet.yml
@@ -40,5 +40,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/droplets/destroy_droplets_by_tag.yml
+++ b/specification/resources/droplets/destroy_droplets_by_tag.yml
@@ -42,5 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/droplets/destroy_with_associated_resources_dangerous.yml
+++ b/specification/resources/droplets/destroy_with_associated_resources_dangerous.yml
@@ -45,5 +45,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/droplets/destroy_with_associated_resources_selective.yml
+++ b/specification/resources/droplets/destroy_with_associated_resources_selective.yml
@@ -45,5 +45,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/droplets/post_droplet_action.yml
+++ b/specification/resources/droplets/post_droplet_action.yml
@@ -93,5 +93,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/droplets/post_droplet_action_by_tag.yml
+++ b/specification/resources/droplets/post_droplet_action_by_tag.yml
@@ -71,5 +71,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/droplets/retry_destroy_with_associated_resources.yml
+++ b/specification/resources/droplets/retry_destroy_with_associated_resources.yml
@@ -45,5 +45,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/firewalls/add_firewall_droplets.yml
+++ b/specification/resources/firewalls/add_firewall_droplets.yml
@@ -68,5 +68,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/firewalls/add_firewall_rules.yml
+++ b/specification/resources/firewalls/add_firewall_rules.yml
@@ -75,5 +75,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/firewalls/add_firewall_tags.yml
+++ b/specification/resources/firewalls/add_firewall_tags.yml
@@ -65,5 +65,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/firewalls/create_firewall.yml
+++ b/specification/resources/firewalls/create_firewall.yml
@@ -76,5 +76,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/firewalls/delete_firewall.yml
+++ b/specification/resources/firewalls/delete_firewall.yml
@@ -41,5 +41,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/firewalls/delete_firewall_droplets.yml
+++ b/specification/resources/firewalls/delete_firewall_droplets.yml
@@ -68,5 +68,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/firewalls/delete_firewall_rules.yml
+++ b/specification/resources/firewalls/delete_firewall_rules.yml
@@ -75,5 +75,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/firewalls/delete_firewall_tags.yml
+++ b/specification/resources/firewalls/delete_firewall_tags.yml
@@ -65,5 +65,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/firewalls/update_firewall.yml
+++ b/specification/resources/firewalls/update_firewall.yml
@@ -86,5 +86,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/floating_ips/create_floating_ip.yml
+++ b/specification/resources/floating_ips/create_floating_ip.yml
@@ -49,5 +49,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/floating_ips/delete_floating_ip.yml
+++ b/specification/resources/floating_ips/delete_floating_ip.yml
@@ -41,5 +41,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/floating_ips/post_floating_ip_action.yml
+++ b/specification/resources/floating_ips/post_floating_ip_action.yml
@@ -61,5 +61,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/images/create_custom_image.yml
+++ b/specification/resources/images/create_custom_image.yml
@@ -42,5 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/images/delete_image.yml
+++ b/specification/resources/images/delete_image.yml
@@ -37,5 +37,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/images/post_image_action.yml
+++ b/specification/resources/images/post_image_action.yml
@@ -62,5 +62,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/images/update_image.yml
+++ b/specification/resources/images/update_image.yml
@@ -47,5 +47,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/kubernetes/add_node_pool.yml
+++ b/specification/resources/kubernetes/add_node_pool.yml
@@ -57,5 +57,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/kubernetes/add_registry.yml
+++ b/specification/resources/kubernetes/add_registry.yml
@@ -36,5 +36,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/kubernetes/create_cluster.yml
+++ b/specification/resources/kubernetes/create_cluster.yml
@@ -53,5 +53,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/kubernetes/delete_cluster.yml
+++ b/specification/resources/kubernetes/delete_cluster.yml
@@ -41,5 +41,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/kubernetes/delete_node.yml
+++ b/specification/resources/kubernetes/delete_node.yml
@@ -49,5 +49,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/kubernetes/delete_node_pool.yml
+++ b/specification/resources/kubernetes/delete_node_pool.yml
@@ -42,5 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/kubernetes/destroy_with_associated_resources_dangerous.yml
+++ b/specification/resources/kubernetes/destroy_with_associated_resources_dangerous.yml
@@ -38,5 +38,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/kubernetes/destroy_with_associated_resources_selective.yml
+++ b/specification/resources/kubernetes/destroy_with_associated_resources_selective.yml
@@ -53,5 +53,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/kubernetes/recycle_node_pool.yml
+++ b/specification/resources/kubernetes/recycle_node_pool.yml
@@ -50,5 +50,4 @@ responses:
     $ref: '../../shared/responses/unexpected_error.yml'
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/kubernetes/remove_registry.yml
+++ b/specification/resources/kubernetes/remove_registry.yml
@@ -36,5 +36,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/kubernetes/update_cluster.yml
+++ b/specification/resources/kubernetes/update_cluster.yml
@@ -47,5 +47,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/kubernetes/update_node_pool.yml
+++ b/specification/resources/kubernetes/update_node_pool.yml
@@ -49,5 +49,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/kubernetes/upgrade_cluster.yml
+++ b/specification/resources/kubernetes/upgrade_cluster.yml
@@ -54,5 +54,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/load_balancers/add_droplets.yml
+++ b/specification/resources/load_balancers/add_droplets.yml
@@ -57,5 +57,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/load_balancers/add_forwarding_rules.yml
+++ b/specification/resources/load_balancers/add_forwarding_rules.yml
@@ -59,5 +59,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/load_balancers/create_load_balancer.yml
+++ b/specification/resources/load_balancers/create_load_balancer.yml
@@ -60,5 +60,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/load_balancers/delete_load_balancer.yml
+++ b/specification/resources/load_balancers/delete_load_balancer.yml
@@ -42,5 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/load_balancers/remove_droplets.yml
+++ b/specification/resources/load_balancers/remove_droplets.yml
@@ -54,5 +54,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/load_balancers/remove_forwarding_rules.yml
+++ b/specification/resources/load_balancers/remove_forwarding_rules.yml
@@ -59,5 +59,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/load_balancers/update_load_balancer.yml
+++ b/specification/resources/load_balancers/update_load_balancer.yml
@@ -54,5 +54,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/monitoring/create_alert.yml
+++ b/specification/resources/monitoring/create_alert.yml
@@ -55,5 +55,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/monitoring/delete_alert.yml
+++ b/specification/resources/monitoring/delete_alert.yml
@@ -32,5 +32,4 @@ x-codeSamples:
   - $ref: 'examples/curl/delete_alert.yml'
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/monitoring/update_alert.yml
+++ b/specification/resources/monitoring/update_alert.yml
@@ -60,5 +60,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/projects/assign_default_project_resources.yml
+++ b/specification/resources/projects/assign_default_project_resources.yml
@@ -49,5 +49,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/projects/assign_project_resources.yml
+++ b/specification/resources/projects/assign_project_resources.yml
@@ -52,5 +52,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/projects/create_project.yml
+++ b/specification/resources/projects/create_project.yml
@@ -44,5 +44,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/projects/delete_project.yml
+++ b/specification/resources/projects/delete_project.yml
@@ -45,5 +45,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/projects/patch_default_project.yml
+++ b/specification/resources/projects/patch_default_project.yml
@@ -46,5 +46,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/projects/patch_project.yml
+++ b/specification/resources/projects/patch_project.yml
@@ -49,5 +49,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/projects/update_default_project.yml
+++ b/specification/resources/projects/update_default_project.yml
@@ -50,5 +50,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/projects/update_project.yml
+++ b/specification/resources/projects/update_project.yml
@@ -53,5 +53,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/registry/create_registry.yml
+++ b/specification/resources/registry/create_registry.yml
@@ -41,5 +41,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/registry/delete_registry.yml
+++ b/specification/resources/registry/delete_registry.yml
@@ -32,5 +32,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/registry/delete_repository_manifest.yml
+++ b/specification/resources/registry/delete_repository_manifest.yml
@@ -46,5 +46,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/registry/delete_repository_tag.yml
+++ b/specification/resources/registry/delete_repository_tag.yml
@@ -46,5 +46,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/registry/get_garbage_collection.yml
+++ b/specification/resources/registry/get_garbage_collection.yml
@@ -35,5 +35,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/registry/list_garbage_collections.yml
+++ b/specification/resources/registry/list_garbage_collections.yml
@@ -37,5 +37,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/registry/post_registry_subscription.yml
+++ b/specification/resources/registry/post_registry_subscription.yml
@@ -45,5 +45,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/registry/run_garbage_collection.yml
+++ b/specification/resources/registry/run_garbage_collection.yml
@@ -55,5 +55,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/registry/update_garbage_collection.yml
+++ b/specification/resources/registry/update_garbage_collection.yml
@@ -45,5 +45,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/registry/validate_registry_name.yml
+++ b/specification/resources/registry/validate_registry_name.yml
@@ -45,5 +45,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/snapshots/delete_snapshot.yml
+++ b/specification/resources/snapshots/delete_snapshot.yml
@@ -42,5 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/ssh_keys/create_ssh_key.yml
+++ b/specification/resources/ssh_keys/create_ssh_key.yml
@@ -41,5 +41,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/ssh_keys/destroy_ssh_key.yml
+++ b/specification/resources/ssh_keys/destroy_ssh_key.yml
@@ -41,5 +41,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/ssh_keys/update_ssh_key.yml
+++ b/specification/resources/ssh_keys/update_ssh_key.yml
@@ -52,5 +52,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/tags/create_new_tag.yml
+++ b/specification/resources/tags/create_new_tag.yml
@@ -42,5 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/tags/delete_tag.yml
+++ b/specification/resources/tags/delete_tag.yml
@@ -39,5 +39,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/tags/tag_resource.yml
+++ b/specification/resources/tags/tag_resource.yml
@@ -51,5 +51,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/tags/untag_resource.yml
+++ b/specification/resources/tags/untag_resource.yml
@@ -51,5 +51,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/volumes/create_new_volume.yml
+++ b/specification/resources/volumes/create_new_volume.yml
@@ -85,5 +85,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/volumes/create_volume_snapshot.yml
+++ b/specification/resources/volumes/create_volume_snapshot.yml
@@ -60,5 +60,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/volumes/delete_volume.yml
+++ b/specification/resources/volumes/delete_volume.yml
@@ -42,5 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/volumes/delete_volume_by_name.yml
+++ b/specification/resources/volumes/delete_volume_by_name.yml
@@ -42,5 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/volumes/delete_volume_snapshot_by_id.yml
+++ b/specification/resources/volumes/delete_volume_snapshot_by_id.yml
@@ -41,5 +41,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/volumes/post_volume_action_by_id.yml
+++ b/specification/resources/volumes/post_volume_action_by_id.yml
@@ -112,5 +112,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/volumes/post_volume_action_by_name.yml
+++ b/specification/resources/volumes/post_volume_action_by_name.yml
@@ -96,5 +96,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/vpcs/create_vpc.yml
+++ b/specification/resources/vpcs/create_vpc.yml
@@ -50,5 +50,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/vpcs/delete_vpc.yml
+++ b/specification/resources/vpcs/delete_vpc.yml
@@ -42,5 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/vpcs/patch_vpc.yml
+++ b/specification/resources/vpcs/patch_vpc.yml
@@ -47,5 +47,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'

--- a/specification/resources/vpcs/update_vpc.yml
+++ b/specification/resources/vpcs/update_vpc.yml
@@ -50,5 +50,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'read'
     - 'write'


### PR DESCRIPTION
Reviewing how the changes adding the required scopes are displayed on the docs site, I think we should remove the `read` scope from operations requiring `write` permissions. I think the intention was to suggest a token with both `read` and `write` are required as we add an implicit `read` scope to tokens with `write`, but the display is somewhat confusing. It feels as if it means either `read` or `write` is fine rather than both `read` and `write` are required.

![image](https://user-images.githubusercontent.com/46943/165400908-5b970f2d-4b89-4acb-9db1-2923216198b6.png)
