### PR TITLE
snakeAndCamel

### DIFF
--- a/spectral/functions/ensureSnakeCaseWithDigits.js
+++ b/spectral/functions/ensureSnakeCaseWithDigits.js
@@ -1,17 +1,17 @@
 /*
  *
- * Ensures the the property is in snake_case and allows for digits.
+ * Ensures the the property is in snake_case (this may include camelCase) and allows for digits.
  * A custom function is needed as the built-in Spectral rule does not
  * allow for leading digits.
  *
  */
 
 module.exports = (param, _, paths) => {
-    const re = RegExp('^[a-z0-9_]+$');
+    const re = RegExp('^(([a-z]+([A-Z0-9a-z]+)*([A-Z])*)_)+[a-zA-Z0-9]+$');
 
     if (re.test(param)) { return }
 
     return [{
-        message: `${paths.target ? paths.target.join('.') : 'property'} is not snake_case`
+        message: `${paths.target ? paths.target.join('.') : 'property'} is not snake_case or camelCase`
     }]
 }

--- a/spectral/ruleset.yml
+++ b/spectral/ruleset.yml
@@ -125,15 +125,13 @@ rules:
       function: ensureAllArraysHaveItemTypes
 
   operationid-must-be-snake-cased:
-    description: operationIds must be snake cased (e.g. snake_case)
+    description: operationIds must be snake cased (This may include camelCase e.g. snakeAndCamel_case).
     type: style
     given: "$..operationId"
     severity: error
     message: "{{description}}; {{value}} incorrect"
     then:
-      function: casing
-      functionOptions:
-        type: snake
+      function: ensureSnakeCaseWithDigits
 
   operationid-must-follow-naming-conventions:
     description: operationIds must follow naming conventions for method


### PR DESCRIPTION
operationID's can now be snake_case with camelCase.

Example: `dropletActions_get`