### PR TITLE
registry: missing the surrounding subscription in response.

### DIFF
--- a/specification/resources/registry/models/subscription_tier.yml
+++ b/specification/resources/registry/models/subscription_tier.yml
@@ -40,6 +40,12 @@ subscription_tier_base:
       example: 500
       description: The monthly cost of the subscription tier in cents.
 
+    storage_overage_price_in_cents:
+      type: integer
+      example: 2
+      description: The price paid in cents per GiB for additional storage beyond
+        what is included in the subscription plan.
+
 subscription_tier_extended:
   type: object
   properties:

--- a/specification/resources/registry/responses/subscription_response.yml
+++ b/specification/resources/registry/responses/subscription_response.yml
@@ -12,4 +12,6 @@ headers:
 content:
   application/json:
     schema:
-      $ref: '../models/subscription.yml'
+      properties:
+        subscription:
+          $ref: '../models/subscription.yml'


### PR DESCRIPTION
The documented response for registry subscriptions is missing the surrounding  `subscription` object. For example, here is a real API response:

```
$ curl -X GET -s   -H "Content-Type: application/json"   -H "Authorization: Bearer $DO_TOKEN"   "https://api.digitalocean.com/v2/registry/subscription" | jq .
{
  "subscription": {
    "tier": {
      "name": "Basic",
      "slug": "basic",
      "included_repositories": 5,
      "included_storage_bytes": 5368709120,
      "allow_storage_overage": true,
      "included_bandwidth_bytes": 5368709120,
      "monthly_price_in_cents": 500,
      "storage_overage_price_in_cents": 2
    },
    "created_at": "2020-01-23T21:19:12Z",
    "updated_at": "2020-11-09T21:07:01Z"
  }
}
```

It is currently documented as:

```
{
  "tier": {
    "name": "Basic",
    "slug": "basic",
    "included_repositories": 5,
    "included_storage_bytes": 5368709120,
    "allow_storage_overage": true,
    "included_bandwidth_bytes": 5368709120,
    "monthly_price_in_cents": 500
  },
  "created_at": "2020-01-23T21:19:12.000Z",
  "updated_at": "2020-11-05T15:53:24.000Z"
}
```