### PR TITLE
fix bug for 0 value of integer

### DIFF
--- a/spectral/functions/ensurePropertiesExample.js
+++ b/spectral/functions/ensurePropertiesExample.js
@@ -41,7 +41,7 @@ module.exports =(item, _, paths) => {
 
   // if the item does not have an example
   // throw an error
-  if (!item.example) {
+  if (item.example == undefined) {
     return [
       {
         message: `${paths.target ? paths.target.join('.') : 'property'} does not include example`,


### PR DESCRIPTION
previously, 0 was not a valid example for an `integer`.

This PR fixes this bug