### PR TITLE
APICLI-1322: Fix Type Error for droplets_create

### DIFF
--- a/specification/resources/droplets/models/droplet.yml
+++ b/specification/resources/droplets/models/droplet.yml
@@ -6,6 +6,7 @@ properties:
     example: 3164444
     description: A unique identifier for each Droplet instance. This is
       automatically generated upon Droplet creation.
+    readOnly: true
 
   name:
     type: string
@@ -17,22 +18,26 @@ properties:
     multipleOf: 8
     example: 1024
     description: Memory of the Droplet in megabytes.
+    readOnly: true
 
   vcpus:
     type: integer
     example: 1
     description: The number of virtual CPUs.
+    readOnly: true
 
   disk:
     type: integer
     example: 25
     description: The size of the Droplet's disk in gigabytes.
+    readOnly: true
 
   locked:
     type: boolean
     example: false
     description: A boolean value indicating whether the Droplet has been locked,
       preventing actions by users.
+    readOnly: true
 
   status:
     type: string
@@ -44,9 +49,11 @@ properties:
     example: active
     description: A status string indicating the state of the Droplet instance.
       This may be "new", "active", "off", or "archive".
+    readOnly: true
 
   kernel:
     $ref: './kernel.yml'
+    readOnly: true
 
   created_at:
     type: string
@@ -54,6 +61,7 @@ properties:
     example: '2020-07-21T18:37:44Z'
     description: A time value given in ISO8601 combined date and time format
       that represents when the Droplet was created.
+    readOnly: true
 
   features:
     type: array
@@ -64,6 +72,7 @@ properties:
     - private_networking
     - ipv6
     description: An array of features enabled on this Droplet.
+    readOnly: true
 
   backup_ids:
     type: array
@@ -74,6 +83,7 @@ properties:
     description: An array of backup IDs of any backups that have been taken
       of the Droplet instance.  Droplet backups are enabled at the time of the
       instance creation.
+    readOnly: true
 
   next_backup_window:
     type: object
@@ -94,6 +104,7 @@ properties:
         example: "2019-12-04T23:00:00Z"
         description: A time value given in ISO8601 combined date and time format
           specifying the end of the Droplet's backup window.
+    readOnly: true
 
   snapshot_ids:
     type: array
@@ -103,6 +114,7 @@ properties:
     - 67512819
     description: An array of snapshot IDs of any snapshots created from the
       Droplet instance.
+    readOnly: true
 
   image:
     $ref: '../../images/models/image.yml'
@@ -115,6 +127,7 @@ properties:
     - '506f78a4-e098-11e5-ad9f-000f53306ae1'
     description: A flat array including the unique identifier for each Block
       Storage volume attached to the Droplet.
+    readOnly: true
 
   size:
     $ref: '../../sizes/models/size.yml'
@@ -123,6 +136,7 @@ properties:
     type: string
     example: s-1vcpu-1gb
     description: The unique slug identifier for the size of this Droplet.
+    readOnly: true    
 
   networks:
     type: object
@@ -141,6 +155,7 @@ properties:
         type: array
         items:
           $ref: 'network_v6.yml'
+    readOnly: true
 
   region:
     $ref: '../../regions/models/region.yml'
@@ -161,23 +176,7 @@ properties:
       is assigned.
 
 required:
-- id
 - name
-- memory
-- vcpus
-- disk
-- locked
-- status
-- kernel
-- created_at
-- features
-- backup_ids
-- next_backup_window
-- snapshot_ids
-- image
-- volume_ids
-- size
-- size_slug
-- networks
 - region
-- tags
+- size
+- image


### PR DESCRIPTION
Before, this would error out in client gen:
```
        # This approach does not work as the read-only attributes are treated as
        # required leading to a TypeError. 
        #
        # droplet = Droplet(
        #     name = "test",
        #     region = REGION,
        #     size = "s-1vcpu-1gb",
        #     image =  "ubuntu-22-04-x64"
        # )
        # create_req = droplet.as_dict
        #
        # Traceback (most recent call last):
        #   File "generated/dropletctl.py", line 23, in <module>
        #     droplet = Droplet(
        # TypeError: __init__() missing 16 required keyword-only arguments: 'id', 'memory',
        # 'vcpus', 'disk', 'locked', 'status', 'kernel', 'created_at', 'features', 'backup_ids',
        # 'next_backup_window', 'snapshot_ids', 'volume_ids', 'size_slug', 'networks', and 'tags'

```

because the previous spec for droplets generated this for Droplets model:
```
    _validation = {
        'id': {'required': True},
        'name': {'required': True},
        'memory': {'required': True, 'multiple': 8},
        'vcpus': {'required': True},
        'disk': {'required': True},
        'locked': {'required': True},
        'status': {'required': True},
        'kernel': {'required': True},
        'created_at': {'required': True},
        'features': {'required': True},
        'backup_ids': {'required': True},
        'next_backup_window': {'required': True},
        'snapshot_ids': {'required': True},
        'image': {'required': True},
        'volume_ids': {'required': True},
        'size': {'required': True},
        'size_slug': {'required': True},
        'networks': {'required': True},
        'region': {'required': True},
        'tags': {'required': True},
    }
```

where everything is required. With these changes, it will generate this code for Droplets:
```
    _validation = {
        'id': {'readonly': True},
        'name': {'required': True},
        'memory': {'readonly': True, 'multiple': 8},
        'vcpus': {'readonly': True},
        'disk': {'readonly': True},
        'locked': {'readonly': True},
        'status': {'readonly': True},
        'kernel': {'readonly': True},
        'created_at': {'readonly': True},
        'features': {'readonly': True},
        'backup_ids': {'readonly': True},
        'next_backup_window': {'readonly': True},
        'snapshot_ids': {'readonly': True},
        'image': {'required': True},
        'volume_ids': {'readonly': True},
        'size': {'required': True},
        'size_slug': {'readonly': True},
        'networks': {'readonly': True},
        'region': {'required': True},
    }
```
which would specify which attributes are readOnly and which are required.

With these changes, the end user can do this to create a droplet:
```
        droplet = Droplet(
            name = "test",
            region = REGION,
            size = "s-1vcpu-1gb",
            image =  "ubuntu-22-04-x64"
        )
        create_req = droplet.__dict__
        droplet = self.create_droplet(create_req)
```

and missing any of the required field would require this to error:
```
        droplet = Droplet(
            region = REGION,
            size = "s-1vcpu-1gb",
            image =  "ubuntu-22-04-x64"
        )
        create_req = droplet.__dict__
        droplet = self.create_droplet(create_req)
```

```
Traceback (most recent call last):
  File "/Users/danaelhertani/Documents/Github/gh-demo/openapi/o3/openapi/water/python-client-test/generated/test.py", line 204, in <module>
    dc.main()
  File "/Users/danaelhertani/Documents/Github/gh-demo/openapi/o3/openapi/water/python-client-test/generated/test.py", line 70, in main
    droplet = Droplet(
TypeError: __init__() missing 1 required keyword-only argument: 'name'
```


At some point, we should comb through the spec and see if the occurs anywhere else. 