### PR TITLE
Reserved IP Launch Updates

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -40,6 +40,11 @@ tags:
       Every action that creates an action object is available through this endpoint. Completed
       actions are not removed from this list and are always available for querying.
 
+      **Note:** You can pass the following HTTP header with the request to have the API return 
+      the `reserved_ips` stanza instead of the `floating_ips` stanza:
+
+      `Accept: application/vnd.digitalocean.reserveip+json`
+
   - name: Apps
     description: >-
       App Platform is a Platform-as-a-Service (PaaS) offering from DigitalOcean that allows
@@ -265,7 +270,7 @@ tags:
 
   - name: Floating IP Actions
     description: |
-      As of 16 June 2022, we are renaming the Floating IP product to [Reserved IPs](https://docs.digitalocean.com/reference/api/api-reference/#tag/Reserved-IPs). 
+      As of 16 June 2022, we have renamed the Floating IP product to [Reserved IPs](https://docs.digitalocean.com/reference/api/api-reference/#tag/Reserved-IPs). 
       The Reserved IP product's endpoints function the exact same way as Floating IPs. 
       The only difference is the name change throughout the URLs and fields.
       For example, the `floating_ips` field is now the `reserved_ips` field. 
@@ -287,10 +292,10 @@ tags:
 
   - name: Floating IPs
     description: |
-      As of 16 June 2022, we are renaming the Floating IP product to [Reserved IPs](https://docs.digitalocean.com/reference/api/api-reference/#tag/Reserved-IPs). 
+      As of 16 June 2022, we have renamed the Floating IP product to [Reserved IPs](https://docs.digitalocean.com/reference/api/api-reference/#tag/Reserved-IPs). 
       The Reserved IP product's endpoints function the exact same way as Floating IPs. 
-      The only difference is the name change throughout the URLs and fields. 
-      For example, the `floating_ips` field is now the `reserved_ips` field.
+      The only difference is the name change throughout the URLs and fields.
+      For example, the `floating_ips` field is now the `reserved_ips` field. 
       The Floating IP endpoints will remain active until fall 2023 before being 
       permanently deprecated.
 
@@ -417,12 +422,12 @@ tags:
 
   - name: Reserved IP Actions
     description: |
-      As of 16 June 2022, we are renaming the [Floating IP](https://docs.digitalocean.com/reference/api/api-reference/#tag/Floating-IPs) 
+      As of 16 June 2022, we have renamed the [Floating IP](https://docs.digitalocean.com/reference/api/api-reference/#tag/Floating-IPs) 
       product to Reserved IPs. The Reserved IP product's endpoints function the exact 
       same way as Floating IPs. The only difference is the name change throughout the 
       URLs and fields. For example, the `floating_ips` field is now the `reserved_ips` field. 
       The Floating IP endpoints will remain active until fall 2023 before being 
-      permanently deprecated. These endpoints will become available on 16 June 2022.
+      permanently deprecated.
 
       With the exception of the [Projects API](https://docs.digitalocean.com/reference/api/api-reference/#tag/Projects), 
       we will reflect this change as an additional field in the responses across the API 
@@ -439,12 +444,12 @@ tags:
 
   - name: Reserved IPs
     description: |
-      As of 16 June 2022, we are renaming the [Floating IP](https://docs.digitalocean.com/reference/api/api-reference/#tag/Floating-IPs) 
+      As of 16 June 2022, we have renamed the [Floating IP](https://docs.digitalocean.com/reference/api/api-reference/#tag/Floating-IPs) 
       product to Reserved IPs. The Reserved IP product's endpoints function the exact 
       same way as Floating IPs. The only difference is the name change throughout the 
       URLs and fields. For example, the `floating_ips` field is now the `reserved_ips` field. 
       The Floating IP endpoints will remain active until fall 2023 before being 
-      permanently deprecated. These endpoints will become available on 16 June 2022.
+      permanently deprecated.
 
       With the exception of the [Projects API](https://docs.digitalocean.com/reference/api/api-reference/#tag/Projects), 
       we will reflect this change as an additional field in the responses across the API 

--- a/specification/resources/droplets/models/associated_resource_status.yml
+++ b/specification/resources/droplets/models/associated_resource_status.yml
@@ -12,6 +12,10 @@ properties:
     description: An object containing additional information about resource
       related to a Droplet requested to be destroyed.
     properties:
+      reserved_ips:
+        type: array
+        items:
+          $ref: 'destroyed_associated_resource.yml'
       floating_ips:
         type: array
         items:

--- a/specification/resources/droplets/responses/associated_resources_list.yml
+++ b/specification/resources/droplets/responses/associated_resources_list.yml
@@ -15,6 +15,10 @@ content:
       allOf:
         - type: object
           properties:
+            reserved_ips:
+              type: array
+              items:
+                $ref: '../models/associated_resource.yml'
             floating_ips:
               type: array
               items:
@@ -33,6 +37,10 @@ content:
                 $ref: '../models/associated_resource.yml'
 
     example:
+      reserved_ips:
+      - id: '6186916'
+        name: 45.55.96.47
+        cost: '4.00'
       floating_ips:
       - id: '6186916'
         name: 45.55.96.47

--- a/specification/resources/droplets/responses/associated_resources_status.yml
+++ b/specification/resources/droplets/responses/associated_resources_status.yml
@@ -20,6 +20,10 @@ content:
         name: ubuntu-s-1vcpu-1gb-nyc1-01
         destroyed_at: '2020-04-01T18:11:49Z'
       resources:
+        reserved_ips:
+        - id: '6186916'
+          name: 45.55.96.47
+          destroyed_at: '2020-04-01T18:11:44Z'
         floating_ips:
         - id: '6186916'
           name: 45.55.96.47


### PR DESCRIPTION
This PR updates some copy and adds the `reserved_ip` field to various responses around the API. These changes are expected to go live on June 16.