### PR TITLE
droplets: Document request body for selectively destroying associated resources.

### DIFF
--- a/specification/resources/droplets/destroy_with_associated_resources_selective.yml
+++ b/specification/resources/droplets/destroy_with_associated_resources_selective.yml
@@ -21,6 +21,12 @@ tags:
 parameters:
   - $ref: 'parameters.yml#/droplet_id'
 
+requestBody:
+  content:
+    application/json:
+      schema:
+        $ref: 'models/selective_destroy_associated_resource.yml'
+
 responses:
   '202':
     $ref: '../../shared/responses/accepted.yml'

--- a/specification/resources/droplets/examples/curl/destroy_with_associated_resources_selective.yml
+++ b/specification/resources/droplets/examples/curl/destroy_with_associated_resources_selective.yml
@@ -3,5 +3,5 @@ source: |-
   curl -X DELETE \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-    -d '{"floating_ips":["6186916"],"snapshots": ["61486916"],"volumes": ["ba49449a-7435-11ea-b89e-0a58ac14480f"],"volume_snapshots": ["edb0478d-7436-11ea-86e6-0a58ac144b91"]}' \
+    -d '{"reserved_ips":["6186916"],"snapshots": ["61486916"],"volumes": ["ba49449a-7435-11ea-b89e-0a58ac14480f"],"volume_snapshots": ["edb0478d-7436-11ea-86e6-0a58ac144b91"]}' \
     "https://api.digitalocean.com/v2/droplets/187000742/destroy_with_associated_resources/selective"

--- a/specification/resources/droplets/models/selective_destroy_associated_resource.yml
+++ b/specification/resources/droplets/models/selective_destroy_associated_resource.yml
@@ -1,0 +1,46 @@
+type: object
+
+description: An object containing information about a resource to be scheduled
+  for deletion.
+
+properties:
+  floating_ips:
+    type: array
+    deprecated: true
+    description: An array of unique identifiers for the floating IPs to be scheduled for deletion.
+    items:
+      type: string
+    example:
+      - '6186916'
+
+  reserved_ips:
+    type: array
+    description: An array of unique identifiers for the reserved IPs to be scheduled for deletion.
+    items:
+      type: string
+    example:
+      - '6186916'
+
+  snapshots:
+    type: array
+    description: An array of unique identifiers for the snapshots to be scheduled for deletion.
+    items:
+      type: string
+    example:
+      - '61486916'
+
+  volumes:
+    type: array
+    description: An array of unique identifiers for the volumes to be scheduled for deletion.
+    items:
+       type: string
+    example:
+      - ba49449a-7435-11ea-b89e-0a58ac14480f
+
+  volume_snapshots:
+    type: array
+    description: An array of unique identifiers for the volume snapshots to be scheduled for deletion.
+    items:
+      type: string
+    example:
+      - edb0478d-7436-11ea-86e6-0a58ac144b91


### PR DESCRIPTION
Somehow we are missing documentation for the request body of the `/v2/droplets/{id}/destroy_with_associated_resources/selective` endpoint.