### PR TITLE
Clarify default error example

### DIFF
--- a/specification/shared/responses/unexpected_error.yml
+++ b/specification/shared/responses/unexpected_error.yml
@@ -13,5 +13,5 @@ content:
     schema:
       $ref: '../models/error.yml'
     example:
-      id: im_a_teapot
-      message: how do you do?
+      id: example_error
+      message: some error message


### PR DESCRIPTION
The existing example can be misleading in that it seems to reference an actual HTTP status code/message.