### PR TITLE
Fixes quotes in app domain spec

### DIFF
--- a/specification/resources/apps/models/app_domain_spec.yml
+++ b/specification/resources/apps/models/app_domain_spec.yml
@@ -44,8 +44,10 @@ properties:
     type: string
     maxLength: 3
     minLength: 3
-    pattern: ^1.[2 | 3]$
-    description: 'The minimum version of TLS a client application can use to access resources for the domain.  Must be one of the following values wrapped within quotations: `\"1.2\"` or `\"1.3\"`.'
+    enum:
+      - "1.2"
+      - "1.3"
+    description: 'The minimum version of TLS a client application can use to access resources for the domain.  Must be one of the following values wrapped within quotations: `"1.2"` or `"1.3"`.'
     example: "1.3"
 required:
 - domain


### PR DESCRIPTION
Submitting this on its own so it's not blocked by the discussion about model changes in #670.

This change makes the field and enum since only the two listed strings are allowed and I was able to leave the double quotes within back-ticks for it to successfully render in preview like this:

![image](https://user-images.githubusercontent.com/8887224/175375621-22a1a73a-2c31-49f0-9b26-5dce394d1377.png)

I think the text specifying "Must be one of the following values ..." is superfluous after making the field an enum but I'll leave that for discussion.

I also generated the client from this change and was able to successfully import it and use it to create a droplet.

I'll also push a commit to #670 to remove this from that PR.