### PR TITLE
Add files to main operationID to fix merge conflicts

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -630,6 +630,22 @@ paths:
     post:
       $ref: 'resources/apps/apps_revert_rollback.yml'
 
+  /v2/apps/{app_id}/rollback:
+    post:
+      $ref: 'resources/apps/rollback_app.yml'
+
+  /v2/apps/{app_id}/rollback/validate:
+    post:
+      $ref: 'resources/apps/validate_app_rollback.yml'
+
+  /v2/apps/{app_id}/rollback/commit:
+    post:
+      $ref: 'resources/apps/run_commit_app_rollback.yml'
+
+  /v2/apps/{app_id}/rollback/revert:
+    post:
+      $ref: 'resources/apps/run_revert_app_rollback.yml'
+
   /v2/cdn/endpoints:
     get:
       $ref: 'resources/cdn/cdn_list_endpoints.yml'
@@ -1319,6 +1335,31 @@ paths:
   /v2/reserved_ips/{reserved_ip}/actions/{action_id}:
     get:
       $ref: 'resources/reserved_ips/reservedIPsActions_get.yml'
+
+  /v2/reserved_ips:
+    get:
+      $ref: 'resources/reserved_ips/list_reserved_ips.yml'
+
+    post:
+      $ref: 'resources/reserved_ips/create_reserved_ip.yml'
+
+  /v2/reserved_ips/{reserved_ip}:
+    get:
+      $ref: 'resources/reserved_ips/get_reserved_ip.yml'
+
+    delete:
+      $ref: 'resources/reserved_ips/delete_reserved_ip.yml'
+
+  /v2/reserved_ips/{reserved_ip}/actions:
+    get:
+      $ref: 'resources/reserved_ips/list_reserved_ip_actions.yml'
+
+    post:
+      $ref: 'resources/reserved_ips/post_reserved_ip_action.yml'
+
+  /v2/reserved_ips/{reserved_ip}/actions/{action_id}:
+    get:
+      $ref: 'resources/reserved_ips/get_reserved_ip_action.yml'
 
   /v2/sizes:
     get:

--- a/specification/resources/apps/responses/validate_app_rollback.yml
+++ b/specification/resources/apps/responses/validate_app_rollback.yml
@@ -1,0 +1,43 @@
+description: A JSON object with the validation results.
+
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        valid:
+          type: boolean
+          description: Indicates whether the app can be rolled back to the specified deployment.
+        error:
+          allOf:
+            - description: Contains the failing condition that is causing the rollback to be invalid.
+            - $ref: ../models/app_rollback_validation_condition.yml
+        warnings:
+          type: array
+          description: Contains a list of warnings that may cause the rollback to run under unideal circumstances.
+          items:
+            $ref: ../models/app_rollback_validation_condition.yml
+    examples:
+      "Valid rollback":
+        value:
+          valid: true
+      "Valid rollback with warnings":
+        value:
+          valid: true
+          warnings:
+            - code: image_source_missing_digest
+              components: ["docker-worker"]
+              message: one or more components are missing an image digest and are not guaranteed rollback to the old version
+      "Invalid rollback":
+        value:
+          valid: false
+          error:
+            code: incompatible_result
+            message: deployment result "failed" is unsuitable for rollback
+headers:
+  ratelimit-limit:
+    $ref: ../../../shared/headers.yml#/ratelimit-limit
+  ratelimit-remaining:
+    $ref: ../../../shared/headers.yml#/ratelimit-remaining
+  ratelimit-reset:
+    $ref: ../../../shared/headers.yml#/ratelimit-reset

--- a/specification/resources/apps/rollback_app.yml
+++ b/specification/resources/apps/rollback_app.yml
@@ -1,0 +1,47 @@
+operationId: create_app_rollback
+
+summary: Rollback App
+
+description: |
+  Rollback an app to a previous deployment. A new deployment will be created to perform the rollback.
+  The app will be pinned to the rollback deployment preventing any new deployments from being created,
+  either manually or through Auto Deploy on Push webhooks. To resume deployments, the rollback must be
+  either committed or reverted.
+
+  It is recommended to use the Validate App Rollback endpoint to double check if the rollback is
+  valid and if there are any warnings.
+
+tags:
+  - Apps
+
+parameters:
+  - $ref: parameters.yml#/app_id
+
+requestBody:
+  content:
+    application/json:
+      schema:
+        $ref: models/apps_rollback_app_request.yml
+  required: true
+
+responses:
+  "200":
+    $ref: responses/new_app_deployment.yml
+
+  "401":
+    $ref: ../../shared/responses/unauthorized.yml
+
+  "404":
+    $ref: "../../shared/responses/not_found.yml"
+
+  "429":
+    $ref: "../../shared/responses/too_many_requests.yml"
+
+  "500":
+    $ref: ../../shared/responses/server_error.yml
+
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+
+x-codeSamples:
+  - $ref: "examples/curl/rollback_app.yml"

--- a/specification/resources/apps/run_commit_app_rollback.yml
+++ b/specification/resources/apps/run_commit_app_rollback.yml
@@ -1,0 +1,34 @@
+operationId: run_commit_app_rollback
+
+summary: Commit App Rollback
+
+description: |
+  Commit an app rollback. This action permanently applies the rollback and unpins the app to resume new deployments.
+
+tags:
+  - Apps
+
+parameters:
+  - $ref: parameters.yml#/app_id
+
+responses:
+  "200":
+    $ref: "../../shared/responses/no_content.yml"
+
+  "401":
+    $ref: ../../shared/responses/unauthorized.yml
+
+  "404":
+    $ref: "../../shared/responses/not_found.yml"
+
+  "429":
+    $ref: "../../shared/responses/too_many_requests.yml"
+
+  "500":
+    $ref: ../../shared/responses/server_error.yml
+
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+
+x-codeSamples:
+  - $ref: "examples/curl/commit_app_rollback.yml"

--- a/specification/resources/apps/run_revert_app_rollback.yml
+++ b/specification/resources/apps/run_revert_app_rollback.yml
@@ -1,0 +1,35 @@
+operationId: run_revert_app_rollback
+
+summary: Revert App Rollback
+
+description: |
+  Revert an app rollback. This action reverts the active rollback by creating a new deployment from the
+  latest app spec prior to the rollback and unpins the app to resume new deployments.
+
+tags:
+  - Apps
+
+parameters:
+  - $ref: parameters.yml#/app_id
+
+responses:
+  "200":
+    $ref: responses/new_app_deployment.yml
+
+  "401":
+    $ref: ../../shared/responses/unauthorized.yml
+
+  "404":
+    $ref: "../../shared/responses/not_found.yml"
+
+  "429":
+    $ref: "../../shared/responses/too_many_requests.yml"
+
+  "500":
+    $ref: ../../shared/responses/server_error.yml
+
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+
+x-codeSamples:
+  - $ref: "examples/curl/revert_app_rollback.yml"

--- a/specification/resources/apps/validate_app_rollback.yml
+++ b/specification/resources/apps/validate_app_rollback.yml
@@ -1,0 +1,44 @@
+operationId: validate_app_rollback
+
+summary: Validate App Rollback
+
+description: |
+  Check whether an app can be rolled back to a specific deployment. This endpoint can also be used
+  to check if there are any warnings or validation conditions that will cause the rollback to proceed
+  under unideal circumstances. For example, if a component must be rebuilt as part of the rollback
+  causing it to take longer than usual.
+
+tags:
+  - Apps
+
+parameters:
+  - $ref: parameters.yml#/app_id
+
+requestBody:
+  content:
+    application/json:
+      schema:
+        $ref: models/apps_rollback_app_request.yml
+  required: true
+
+responses:
+  "200":
+    $ref: responses/validate_app_rollback.yml
+
+  "401":
+    $ref: ../../shared/responses/unauthorized.yml
+
+  "404":
+    $ref: "../../shared/responses/not_found.yml"
+
+  "429":
+    $ref: "../../shared/responses/too_many_requests.yml"
+
+  "500":
+    $ref: ../../shared/responses/server_error.yml
+
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+
+x-codeSamples:
+  - $ref: "examples/curl/validate_app_rollback.yml"

--- a/specification/resources/databases/databases_update_firewall.yml
+++ b/specification/resources/databases/databases_update_firewall.yml
@@ -9,12 +9,14 @@ description: >-
   able to open connections to the database. You may limit connections to
   specific Droplets, Kubernetes clusters, or IP addresses. When a tag is
   provided, any Droplet or Kubernetes node with that tag applied to it will
-  have access. The firewall is limited to 100 rules (or trusted sources). When
-  possible, we recommend
-  [placing your databases into a VPC network](https://www.digitalocean.com/docs/networking/vpc/)
+  have access. When possible, we recommend [placing your databases into a VPC network](https://www.digitalocean.com/docs/networking/vpc/)
   to limit access to them instead of using a firewall.
-
-  A successful
+  
+  By default, database clusters only support up to 100 IP addresses.
+  Note that different resources add varying numbers of IP addresses to 
+  your cluster. For example, Droplets typically have two IP addresses, 
+  one public and one private, both of which count towards the 100-address
+  maximum. To add more than 100 IP addresses, contact support.
 
 tags:
   - Databases

--- a/specification/resources/reserved_ips/create_reserved_ip.yml
+++ b/specification/resources/reserved_ips/create_reserved_ip.yml
@@ -1,0 +1,52 @@
+operationId: create_reserved_ip
+
+summary: Create a New Reserved IP
+
+description: >-
+  On creation, a reserved IP must be either assigned to a Droplet or reserved
+  to a region.
+
+  * To create a new reserved IP assigned to a Droplet, send a POST
+    request to `/v2/reserved_ips` with the `droplet_id` attribute.
+
+  * To create a new reserved IP reserved to a region, send a POST request to
+    `/v2/reserved_ips` with the `region` attribute.
+
+  **Note**:  In addition to the standard rate limiting, only 12 reserved IPs may
+  be created per 60 seconds.
+
+tags:
+  - Reserved IPs
+
+requestBody:
+  required: true
+
+  content:
+    application/json:
+      schema:
+        $ref: 'models/reserved_ip_create.yml'
+
+responses:
+  '202':
+    $ref: 'responses/reserved_ip_created.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/create_reserved_ip.yml'
+  - $ref: 'examples/go/create_reserved_ip.yml'
+  - $ref: 'examples/ruby/create_reserved_ip.yml'
+
+security:
+  - bearer_auth:
+    - 'write'

--- a/specification/resources/reserved_ips/delete_reserved_ip.yml
+++ b/specification/resources/reserved_ips/delete_reserved_ip.yml
@@ -1,0 +1,44 @@
+operationId: delete_reserved_ip
+
+summary: Delete a Reserved IPs
+
+description: |
+  To delete a reserved IP and remove it from your account, send a DELETE request
+  to `/v2/reserved_ips/$RESERVED_IP_ADDR`.
+
+  A successful request will receive a 204 status code with no body in response.
+  This indicates that the request was processed successfully.
+
+tags:
+  - Reserved IPs
+
+parameters:
+  - $ref: 'parameters.yml#/reserved_ip'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/delete_reserved_ip.yml'
+  - $ref: 'examples/go/delete_reserved_ip.yml'
+  - $ref: 'examples/ruby/delete_reserved_ip.yml'
+
+security:
+  - bearer_auth:
+    - 'write'

--- a/specification/resources/reserved_ips/get_reserved_ip.yml
+++ b/specification/resources/reserved_ips/get_reserved_ip.yml
@@ -1,0 +1,41 @@
+operationId: get_reserved_ip
+
+summary: Retrieve an Existing Reserved IP
+
+description: To show information about a reserved IP, send a GET request to
+  `/v2/reserved_ips/$RESERVED_IP_ADDR`.
+
+tags:
+  - Reserved IPs
+
+parameters:
+  - $ref: 'parameters.yml#/reserved_ip'
+
+responses:
+  '200':
+    $ref: 'responses/reserved_ip.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/get_reserved_ip.yml'
+  - $ref: 'examples/go/get_reserved_ip.yml'
+  - $ref: 'examples/ruby/get_reserved_ip.yml'
+
+security:
+  - bearer_auth:
+    - 'read'
+

--- a/specification/resources/reserved_ips/get_reserved_ip_action.yml
+++ b/specification/resources/reserved_ips/get_reserved_ip_action.yml
@@ -1,0 +1,42 @@
+operationId: get_reserved_ip_action
+
+summary: Retrieve an Existing Reserved IP Action
+
+description: To retrieve the status of a reserved IP action, send a GET request
+  to `/v2/reserved_ips/$RESERVED_IP/actions/$ACTION_ID`.
+
+tags:
+  - Reserved IP Actions
+
+parameters:
+  - $ref: 'parameters.yml#/reserved_ip'
+  - $ref: '../actions/parameters.yml#/action_id'
+
+responses:
+  '200':
+    $ref: 'responses/reserved_ip_action.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/get_reserved_ip_action.yml'
+  - $ref: 'examples/go/get_reserved_ip_action.yml'
+  - $ref: 'examples/ruby/get_reserved_ip_action.yml'
+
+security:
+  - bearer_auth:
+    - 'read'
+

--- a/specification/resources/reserved_ips/list_reserved_ip_actions.yml
+++ b/specification/resources/reserved_ips/list_reserved_ip_actions.yml
@@ -1,0 +1,41 @@
+operationId: list_reserved_ip_actions
+
+summary: List All Actions for a Reserved IP
+
+description: To retrieve all actions that have been executed on a reserved IP,
+  send a GET request to `/v2/reserved_ips/$RESERVED_IP/actions`.
+
+tags:
+  - Reserved IP Actions
+
+parameters:
+  - $ref: 'parameters.yml#/reserved_ip'
+
+responses:
+  '200':
+    $ref: 'responses/reserved_ip_actions.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/list_reserved_ip_actions.yml'
+  - $ref: 'examples/go/list_reserved_ip_actions.yml'
+  - $ref: 'examples/ruby/list_reserved_ip_actions.yml'
+
+security:
+  - bearer_auth:
+    - 'read'
+

--- a/specification/resources/reserved_ips/list_reserved_ips.yml
+++ b/specification/resources/reserved_ips/list_reserved_ips.yml
@@ -1,0 +1,35 @@
+operationId: list_reserved_ips
+
+summary: List All Reserved IPs
+
+description: To list all of the reserved IPs available on your account, send a
+  GET request to `/v2/reserved_ips`.
+
+tags:
+  - Reserved IPs
+
+responses:
+  '200':
+    $ref: 'responses/reserved_ip_list.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/list_reserved_ips.yml'
+  - $ref: 'examples/go/list_reserved_ips.yml'
+  - $ref: 'examples/ruby/list_reserved_ips.yml'
+
+security:
+  - bearer_auth:
+    - 'read'
+

--- a/specification/resources/reserved_ips/post_reserved_ip_action.yml
+++ b/specification/resources/reserved_ips/post_reserved_ip_action.yml
@@ -1,0 +1,64 @@
+operationId: post_reserved_ip_action
+
+summary: Initiate a Reserved IP Action
+
+description: |
+    To initiate an action on a reserved IP send a POST request to
+    `/v2/reserved_ips/$RESERVED_IP/actions`. In the JSON body to the request,
+    set the `type` attribute to on of the supported action types:
+
+    | Action     | Details
+    |------------|--------
+    | `assign`   | Assigns a reserved IP to a Droplet
+    | `unassign` | Unassign a reserved IP from a Droplet
+
+tags:
+  -  Reserved IP Actions
+
+parameters:
+  - $ref: 'parameters.yml#/reserved_ip'
+
+requestBody:
+  description: |
+    The `type` attribute set in the request body will specify the action that
+    will be taken on the reserved IP.
+
+  content:
+    application/json:
+      schema:
+        anyOf:
+          - $ref: 'models/reserved_ip_actions.yml#/reserved_ip_action_unassign'
+          - $ref: 'models/reserved_ip_actions.yml#/reserved_ip_action_assign'
+        discriminator:
+          propertyName: type
+          mapping:
+            unassign: 'models/reserved_ip_actions.yml#/reserved_ip_action_unassign'
+            assign: 'models/reserved_ip_actions.yml#/reserved_ip_action_assign'
+
+responses:
+  '201':
+    $ref: 'responses/reserved_ip_action.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/post_reserved_ip_action.yml'
+  - $ref: 'examples/go/post_reserved_ip_action.yml'
+  - $ref: 'examples/ruby/post_reserved_ip_action.yml'
+
+security:
+  - bearer_auth:
+    - 'write'


### PR DESCRIPTION
git needs [these files to fix the merge conflicts](https://github.com/digitalocean/openapi/pull/679/files#diff-15446161c848abdc8ebcc5c2dfba24502963b50f1e35384f5d7968df063b803a). These were endpoints that were written after we started the operationID rename work. Although we already re-wrote them properly, the old files will need to persist for the conflicts to squash out. There will be a PR to remove them and get main back in a working state as soon as opID is in main.

Spec linter will fail due to unwanted files not following the new id naming format. as stated, these files will be deleted once merged into main.