### PR TITLE
Change volumeActions_attach to volumeActions_run

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -1363,7 +1363,7 @@ paths:
 
   /v2/volumes/actions:
     post:
-      $ref: 'resources/volumes/volumeActions_attach.yml'
+      $ref: 'resources/volumes/volumeActions_run.yml'
 
   /v2/volumes/snapshot/{snapshot_id}:
     get:
@@ -1381,7 +1381,7 @@ paths:
     get:
       $ref: 'resources/volumes/volumeActions_list.yml'
     post:
-      $ref: 'resources/volumes/volumeActions_attach_byId.yml'
+      $ref: 'resources/volumes/volumeActions_run_byId.yml'
 
   /v2/volumes/{volume_id}/actions/{action_id}:
     get:

--- a/specification/resources/volumes/volumeActions_run.yml
+++ b/specification/resources/volumes/volumeActions_run.yml
@@ -1,4 +1,4 @@
-operationId: volumeActions_attach
+operationId: volumeActions_run
 
 summary: Initiate A Block Storage Action By Volume Name
 

--- a/specification/resources/volumes/volumeActions_run_byId.yml
+++ b/specification/resources/volumes/volumeActions_run_byId.yml
@@ -1,4 +1,4 @@
-operationId: volumeActions_attach_byId
+operationId: volumeActions_run_byId
 
 summary: Initiate A Block Storage Action By Volume Id
 


### PR DESCRIPTION
`attach` is one of the enum values for the `type` field of volumeActions so these file/operation names are incorrect.

`run` is already an allowed alias for `POST` in the spectral rules so this should work.

I have some other suggestions that I'll create a separate PR for.