### PR TITLE
Remove "delete" from kubernetes recycle node pool operation

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -1059,7 +1059,7 @@ paths:
 
   /v2/kubernetes/clusters/{cluster_id}/node_pools/{node_pool_id}/recycle:
     post:
-      $ref: 'resources/kubernetes/kubernetes_delete_RecycleNodePool.yml'
+      $ref: 'resources/kubernetes/kubernetes_recycle_nodePool.yml'
 
   /v2/kubernetes/clusters/{cluster_id}/user:
     get:

--- a/specification/resources/kubernetes/kubernetes_recycle_nodePool.yml
+++ b/specification/resources/kubernetes/kubernetes_recycle_nodePool.yml
@@ -1,4 +1,4 @@
-operationId: kubernetes_delete_RecycleNodePool
+operationId: kubernetes_recycle_node_pool
 
 deprecated: true
 


### PR DESCRIPTION
This is a `post` operation so it shouldn't have `delete` in the operation ID. 