### PR TITLE
Update token used to trigger Python client workflow.

### DIFF
--- a/.github/workflows/trigger-python-client-gen.yml
+++ b/.github/workflows/trigger-python-client-gen.yml
@@ -1,5 +1,5 @@
 name: Trigger Python Client Generation
-on: 
+on:
   push:
     branches:
       - main
@@ -13,4 +13,4 @@ jobs:
       - name: trigger-workflow
         run: gh workflow run --repo digitalocean/digitalocean-client-python python-client-gen.yml --ref main -f commit_url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENAPI_SECRET }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TRIGGER_TOKEN }}


### PR DESCRIPTION
The API token being used to trigger Python client workflow does not have the correct permissions leading to the workflow failing with:

```
HTTP 401: Bad credentials (https://api.github.com/repos/digitalocean/digitalocean-client-python/actions/workflows/python-client-gen.yml)
Try authenticating with:  gh auth login
```

https://github.com/digitalocean/openapi/runs/7222091456?check_suite_focus=true#step:2:7

This new secret should have the correct permissions.