### PR TITLE
Don't eat new lines in tag descriptions.

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -20,7 +20,7 @@ servers:
 
 tags:
   - name: 1-Click Applications
-    description: >-
+    description: |-
       1-Click applications are pre-built Droplet images or Kubernetes apps with software,
       features, and configuration details already set up for you. They can be found in the
       [DigitalOcean Marketplace](https://www.digitalocean.com/docs/marketplace).
@@ -29,7 +29,7 @@ tags:
     description: Provides information about your current account.
 
   - name: Actions
-    description: >-
+    description: |-
       Actions are records of events that have occurred on the resources in your account.
       These can be things like rebooting a Droplet, or transferring an image to a new region.
 
@@ -40,13 +40,13 @@ tags:
       Every action that creates an action object is available through this endpoint. Completed
       actions are not removed from this list and are always available for querying.
 
-      **Note:** You can pass the following HTTP header with the request to have the API return 
+      **Note:** You can pass the following HTTP header with the request to have the API return
       the `reserved_ips` stanza instead of the `floating_ips` stanza:
 
-      `Accept: application/vnd.digitalocean.reserveip+json`
+      - `Accept: application/vnd.digitalocean.reserveip+json`
 
   - name: Apps
-    description: >-
+    description: |-
       App Platform is a Platform-as-a-Service (PaaS) offering from DigitalOcean that allows
       developers to publish code directly to DigitalOcean servers without worrying about the
       underlying infrastructure.
@@ -59,14 +59,12 @@ tags:
       [product documentation](https://www.digitalocean.com/docs/app-platform/references/app-specification-reference/).
 
   - name: Billing
-    description: >-
+    description: |-
       The billing endpoints allow you to retrieve your account balance, invoices
       and billing history.
 
-
       **Balance:** By sending requests to the `/v2/customers/my/balance` endpoint, you can
       retrieve the balance information for the requested customer account.
-
 
       **Invoices:** [Invoices](https://www.digitalocean.com/docs/accounts/billing/invoices/)
       are generated on the first of each month for every DigitalOcean
@@ -75,7 +73,6 @@ tags:
       invoices, you will generally send requests to the invoices endpoint at
       `/v2/customers/my/invoices`.
 
-
       **Billing History:** Billing history is a record of billing events for your account.
       For example, entries may include events like payments made, invoices
       issued, or credits granted. To interact with invoices, you
@@ -83,7 +80,7 @@ tags:
       `/v2/customers/my/billing_history`.
 
   - name: Block Storage
-    description: >-
+    description: |-
       [DigitalOcean Block Storage Volumes](https://www.digitalocean.com/docs/volumes/)
       provide expanded storage capacity for your Droplets and can be moved
       between Droplets within a specific region.
@@ -93,11 +90,11 @@ tags:
       any file system supported by the OS. They may be created in sizes from
       1GiB to 16TiB.
 
-      By sending requests to the /v2/volumes endpoint, you can list, create, or
+      By sending requests to the `/v2/volumes` endpoint, you can list, create, or
       delete volumes as well as attach and detach them from Droplets
 
   - name: Block Storage Actions
-    description: >-
+    description: |-
       Block storage actions are commands that can be given to a DigitalOcean
       Block Storage Volume. An example would be detaching or attaching a volume
       from a Droplet. These requests are made on the
@@ -107,7 +104,7 @@ tags:
       requested action.
 
   - name: CDN Endpoints
-    description: >-
+    description: |-
       Content hosted in DigitalOcean's object storage solution,
       [Spaces](https://www.digitalocean.com/docs/spaces/overview/),
       can optionally be served by our globally distributed Content Delivery
@@ -118,7 +115,7 @@ tags:
       for the custom subdomain.
 
   - name: Certificates
-    description: >-
+    description: |-
       In order to perform SSL termination on load balancers, DigitalOcean offers
       two types of [SSL certificate management](https://www.digitalocean.com/docs/accounts/security/#certificates):
 
@@ -131,7 +128,7 @@ tags:
       renewed as required.
 
   - name: Container Registry
-    description: >-
+    description: |-
       DigitalOcean offers the ability for you to create a
       [private container registry](https://www.digitalocean.com/docs/images/container-registry/quickstart/)
       to store your Docker images for use with your Kubernetes clusters. This
@@ -142,7 +139,7 @@ tags:
       that registry to create as many repositories as you wish.
 
   - name: Databases
-    description: |
+    description: |-
       DigitalOcean's [managed database service](https://www.digitalocean.com/docs/databases)
       simplifies the creation and management of highly available database clusters. Currently, it
       offers support for [PostgreSQL](http://www.digitalocean.com/docs/databases/postgresql/),
@@ -198,7 +195,7 @@ tags:
 
 
   - name: Domain Records
-    description: |
+    description: |-
       Domain record resources are used to set or retrieve information about the
       individual DNS records configured for a domain. This allows you to build
       and manage DNS zone files by adding and modifying individual records for a
@@ -220,7 +217,7 @@ tags:
       SOA   | This record type defines administrative information about the zone. Can only have ttl changed, cannot be deleted                                   |
 
   - name: Domains
-    description: >-
+    description: |-
       Domain resources are domain names that you have purchased from a domain
       name registrar that you are managing through the
       [DigitalOcean DNS interface](https://www.digitalocean.com/docs/networking/dns/).
@@ -230,7 +227,7 @@ tags:
       [Domain Records](#tag/Domain-Records) resource.
 
   - name: Droplet Actions
-    description: >-
+    description: |-
       Droplet actions are tasks that can be executed on a Droplet. These can be
       things like rebooting, resizing, snapshotting, etc.
 
@@ -250,7 +247,7 @@ tags:
       fail with a status of 422.
 
   - name: Droplets
-    description: >-
+    description: |-
       A [Droplet](https://www.digitalocean.com/docs/droplets/) is a DigitalOcean
       virtual machine. By sending requests to the Droplet endpoint, you can
       list, create, or delete Droplets.
@@ -261,7 +258,7 @@ tags:
       respective sections.
 
   - name: Firewalls
-    description: >-
+    description: |-
       [DigitalOcean Cloud Firewalls](https://www.digitalocean.com/docs/networking/firewalls/)
       provide the ability to restrict network access to and from a Droplet
       allowing you to define which ports will accept inbound or outbound
@@ -269,17 +266,17 @@ tags:
       list, create, or delete firewalls as well as modify access rules.
 
   - name: Floating IP Actions
-    description: |
-      As of 16 June 2022, we have renamed the Floating IP product to [Reserved IPs](https://docs.digitalocean.com/reference/api/api-reference/#tag/Reserved-IPs). 
-      The Reserved IP product's endpoints function the exact same way as Floating IPs. 
+    description: |-
+      As of 16 June 2022, we have renamed the Floating IP product to [Reserved IPs](https://docs.digitalocean.com/reference/api/api-reference/#tag/Reserved-IPs).
+      The Reserved IP product's endpoints function the exact same way as Floating IPs.
       The only difference is the name change throughout the URLs and fields.
-      For example, the `floating_ips` field is now the `reserved_ips` field. 
-      The Floating IP endpoints will remain active until fall 2023 before being 
+      For example, the `floating_ips` field is now the `reserved_ips` field.
+      The Floating IP endpoints will remain active until fall 2023 before being
       permanently deprecated.
 
-      With the exception of the [Projects API](https://docs.digitalocean.com/reference/api/api-reference/#tag/Projects), 
-      we will reflect this change as an additional field in the responses across the API 
-      where the `floating_ip` field is used. For example, the Droplet metadata response 
+      With the exception of the [Projects API](https://docs.digitalocean.com/reference/api/api-reference/#tag/Projects),
+      we will reflect this change as an additional field in the responses across the API
+      where the `floating_ip` field is used. For example, the Droplet metadata response
       will contain the field `reserved_ips` in addition to the `floating_ips` field.
       Floating IPs retrieved using the Projects API will retain the original name.
 
@@ -291,17 +288,17 @@ tags:
       requested action.
 
   - name: Floating IPs
-    description: |
-      As of 16 June 2022, we have renamed the Floating IP product to [Reserved IPs](https://docs.digitalocean.com/reference/api/api-reference/#tag/Reserved-IPs). 
-      The Reserved IP product's endpoints function the exact same way as Floating IPs. 
+    description: |-
+      As of 16 June 2022, we have renamed the Floating IP product to [Reserved IPs](https://docs.digitalocean.com/reference/api/api-reference/#tag/Reserved-IPs).
+      The Reserved IP product's endpoints function the exact same way as Floating IPs.
       The only difference is the name change throughout the URLs and fields.
-      For example, the `floating_ips` field is now the `reserved_ips` field. 
-      The Floating IP endpoints will remain active until fall 2023 before being 
+      For example, the `floating_ips` field is now the `reserved_ips` field.
+      The Floating IP endpoints will remain active until fall 2023 before being
       permanently deprecated.
 
-      With the exception of the [Projects API](https://docs.digitalocean.com/reference/api/api-reference/#tag/Projects), 
-      we will reflect this change as an additional field in the responses across the API 
-      where the `floating_ip` field is used. For example, the Droplet metadata response 
+      With the exception of the [Projects API](https://docs.digitalocean.com/reference/api/api-reference/#tag/Projects),
+      we will reflect this change as an additional field in the responses across the API
+      where the `floating_ip` field is used. For example, the Droplet metadata response
       will contain the field `reserved_ips` in addition to the `floating_ips` field.
       Floating IPs retrieved using the Projects API will retain the original name.
 
@@ -313,7 +310,7 @@ tags:
       Floating IPs are bound to a specific region.
 
   - name: Image Actions
-    description: >+
+    description: |-
       Image actions are commands that can be given to a DigitalOcean image. In
       general, these requests are made on the actions endpoint of a specific
       image.
@@ -322,7 +319,7 @@ tags:
       of the requested action.
 
   - name: Images
-    description: >-
+    description: |-
       A DigitalOcean [image](https://www.digitalocean.com/docs/images/) can be
       used to create a Droplet and may come in a number of flavors. Currently,
       there are five types of images: snapshots, backups, applications,
@@ -349,7 +346,7 @@ tags:
       endpoint at /v2/images.
 
   - name: Kubernetes
-    description: >-
+    description: |-
       [DigitalOcean Kubernetes](https://www.digitalocean.com/docs/kubernetes/)
       allows you to quickly deploy scalable and secure Kubernetes clusters. By
       sending requests to the `/v2/kubernetes/clusters` endpoint, you can list,
@@ -358,7 +355,7 @@ tags:
       a cluster.
 
   - name: Load Balancers
-    description: >-
+    description: |-
       [DigitalOcean Load Balancers](https://www.digitalocean.com/docs/networking/load-balancers/)
       provide a way to distribute traffic across multiple Droplets. By sending
       requests to the `/v2/load_balancers` endpoint, you can list, create, or
@@ -366,7 +363,7 @@ tags:
       and other configuration details.
 
   - name: Monitoring
-    description: >-
+    description: |-
       The DigitalOcean Monitoring API makes it possible to programmatically retrieve metrics as well as configure alert
       policies based on these metrics. The Monitoring API can help you gain insight into how your apps are performing
       and consuming resources.
@@ -411,7 +408,7 @@ tags:
       `service_down`     | There was a problem retrieving or assigning a resource. Please try again.
 
   - name: Projects
-    description: >-
+    description: |-
       Projects allow you to organize your resources into groups that fit the way
       you work. You can group resources (like Droplets, Spaces, load balancers,
       domains, and floating IPs) in ways that align with the applications
@@ -421,17 +418,17 @@ tags:
     description: Provides information about DigitalOcean data center regions.
 
   - name: Reserved IP Actions
-    description: |
-      As of 16 June 2022, we have renamed the [Floating IP](https://docs.digitalocean.com/reference/api/api-reference/#tag/Floating-IPs) 
-      product to Reserved IPs. The Reserved IP product's endpoints function the exact 
-      same way as Floating IPs. The only difference is the name change throughout the 
-      URLs and fields. For example, the `floating_ips` field is now the `reserved_ips` field. 
-      The Floating IP endpoints will remain active until fall 2023 before being 
+    description: |-
+      As of 16 June 2022, we have renamed the [Floating IP](https://docs.digitalocean.com/reference/api/api-reference/#tag/Floating-IPs)
+      product to Reserved IPs. The Reserved IP product's endpoints function the exact
+      same way as Floating IPs. The only difference is the name change throughout the
+      URLs and fields. For example, the `floating_ips` field is now the `reserved_ips` field.
+      The Floating IP endpoints will remain active until fall 2023 before being
       permanently deprecated.
 
-      With the exception of the [Projects API](https://docs.digitalocean.com/reference/api/api-reference/#tag/Projects), 
-      we will reflect this change as an additional field in the responses across the API 
-      where the `floating_ip` field is used. For example, the Droplet metadata response 
+      With the exception of the [Projects API](https://docs.digitalocean.com/reference/api/api-reference/#tag/Projects),
+      we will reflect this change as an additional field in the responses across the API
+      where the `floating_ip` field is used. For example, the Droplet metadata response
       will contain the field `reserved_ips` in addition to the `floating_ips` field.
       Floating IPs retrieved using the Projects API will retain the original name.
 
@@ -443,28 +440,28 @@ tags:
       requested action.
 
   - name: Reserved IPs
-    description: |
-      As of 16 June 2022, we have renamed the [Floating IP](https://docs.digitalocean.com/reference/api/api-reference/#tag/Floating-IPs) 
-      product to Reserved IPs. The Reserved IP product's endpoints function the exact 
-      same way as Floating IPs. The only difference is the name change throughout the 
-      URLs and fields. For example, the `floating_ips` field is now the `reserved_ips` field. 
-      The Floating IP endpoints will remain active until fall 2023 before being 
+    description: |-
+      As of 16 June 2022, we have renamed the [Floating IP](https://docs.digitalocean.com/reference/api/api-reference/#tag/Floating-IPs)
+      product to Reserved IPs. The Reserved IP product's endpoints function the exact
+      same way as Floating IPs. The only difference is the name change throughout the
+      URLs and fields. For example, the `floating_ips` field is now the `reserved_ips` field.
+      The Floating IP endpoints will remain active until fall 2023 before being
       permanently deprecated.
 
-      With the exception of the [Projects API](https://docs.digitalocean.com/reference/api/api-reference/#tag/Projects), 
-      we will reflect this change as an additional field in the responses across the API 
-      where the `floating_ip` field is used. For example, the Droplet metadata response 
+      With the exception of the [Projects API](https://docs.digitalocean.com/reference/api/api-reference/#tag/Projects),
+      we will reflect this change as an additional field in the responses across the API
+      where the `floating_ip` field is used. For example, the Droplet metadata response
       will contain the field `reserved_ips` in addition to the `floating_ips` field.
       Floating IPs retrieved using the Projects API will retain the original name.
 
-      DigitalOcean Reserved IPs are publicly-accessible static IP addresses that can be 
-      mapped to one of your Droplets. They can be used to create highly available 
+      DigitalOcean Reserved IPs are publicly-accessible static IP addresses that can be
+      mapped to one of your Droplets. They can be used to create highly available
       setups or other configurations requiring movable addresses.
 
       Reserved IPs are bound to a specific region.
 
   - name: Sizes
-    description: >-
+    description: |-
       The sizes objects represent different packages of hardware resources that
       can be used for Droplets. When a Droplet is created, a size must be
       selected so that the correct resources can be allocated.
@@ -475,7 +472,7 @@ tags:
       details and the regions that the size is available in.
 
   - name: Snapshots
-    description: >-
+    description: |-
       [Snapshots](https://www.digitalocean.com/docs/images/snapshots/) are saved
       instances of a Droplet or a block storage volume, which is reflected in
       the `resource_type` attribute. In order to avoid problems with compressing
@@ -490,7 +487,7 @@ tags:
     description: Manage SSH keys available on your account.
 
   - name: Tags
-    description: >-
+    description: |-
       A tag is a label that can be applied to a resource (currently Droplets,
       Images, Volumes, Volume Snapshots, and Database clusters) in order to
       better organize or facilitate the lookups and actions on it.
@@ -499,7 +496,7 @@ tags:
       `resources` attribute with information about resources that have been tagged.
 
   - name: VPCs
-    description: >-
+    description: |-
       [VPCs (virtual private clouds)](https://www.digitalocean.com/docs/networking/vpc/)
       allow you to create virtual networks containing resources that can
       communicate with each other in full isolation using private IP addresses.


### PR DESCRIPTION
The yaml scalar being used in many of the tag descriptions strips out line breaks. This updates it to use the literal style. 

https://yaml.org/spec/1.2.2/#23-scalars

