### PR TITLE
trigger-python-client-gen: Only run when 'Spec Main' workflow completes successfully.

### DIFF
--- a/.github/workflows/trigger-python-client-gen.yml
+++ b/.github/workflows/trigger-python-client-gen.yml
@@ -1,14 +1,15 @@
 name: Trigger Python Client Generation
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'specification/**'
+  workflow_run:
+    workflows: [Spec Main]
+    types:
+      - completed
+
 jobs:
   build:
     name: Trigger digitalocean-client-python Workflow
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: trigger-workflow
         run: gh workflow run --repo digitalocean/digitalocean-client-python python-client-gen.yml --ref main -f commit_url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA


### PR DESCRIPTION
To prevent a race condition where we trigger the client to be generated before the new spec has been uploaded, this PR changes the trigger-python-client-gen workflow to only run after the "Spec Main" workflow succeeds using the `workflow_run` trigger. 

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run