### PR TITLE
tags: include missing pagination query params.

### DIFF
--- a/specification/resources/tags/tags_list.yml
+++ b/specification/resources/tags/tags_list.yml
@@ -7,6 +7,10 @@ description: To list all of your tags, you can send a GET request to `/v2/tags`.
 tags:
   - Tags
 
+parameters:
+  - $ref: '../../shared/parameters.yml#/per_page'
+  - $ref: '../../shared/parameters.yml#/page'
+
 responses:
   '200':
     $ref: 'responses/tags_all.yml'


### PR DESCRIPTION
Writing tests for the generated client led me to notice that the pagination query params are missing for the tags_list operation.