### PR TITLE
billing/pdf: add content type header

### DIFF
--- a/specification/resources/billing/responses/invoice_pdf.yml
+++ b/specification/resources/billing/responses/invoice_pdf.yml
@@ -1,7 +1,9 @@
-description: >- 
+description: >-
   The response will be a PDF file.
 
 headers:
+  content-type:
+    $ref: '../../../shared/headers.yml#/content-type'
   content-disposition:
     $ref: '../../../shared/headers.yml#/content-disposition'
   ratelimit-limit:
@@ -12,7 +14,7 @@ headers:
     $ref: '../../../shared/headers.yml#/ratelimit-reset'
 
 content:
-  application/pdf: 
+  application/pdf:
     schema:
       type: string
       format: binary


### PR DESCRIPTION
The response for `/v2/customers/my/invoices/{uuid}/pdf` contains a `content-type` header in the response, so we should include that in the spec.