### PR TITLE
Use SHA not ref in PR comment trigger.

### DIFF
--- a/.github/workflows/spec.pr-comment-trigger.yml
+++ b/.github/workflows/spec.pr-comment-trigger.yml
@@ -64,7 +64,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ${{ fromJSON(steps.get-pr-branch.outputs.result).repo.full_name }}
-        ref: ${{ fromJSON(steps.get-pr-branch.outputs.result).ref }}
+        ref: ${{ fromJSON(steps.get-pr-branch.outputs.result).sha }}
 
     - name: Bundle
       if: steps.is-digitalocean-member.outputs.result == 'true'


### PR DESCRIPTION
This resolves a potential timing attack. As the commit in the ref can change in-between calling `!deploy` and the the workflow beginning, it should use the SHA instead. This prevents execution of un-reviewed code as a new push to the fork would be a new SHA.