### PR TITLE
Address issues found during model generation.

### DIFF
--- a/specification/resources/apps/models/app_domain_spec.yml
+++ b/specification/resources/apps/models/app_domain_spec.yml
@@ -2,7 +2,6 @@ type: object
 properties:
   domain:
     type: string
-    format: hostname
     maxLength: 253
     minLength: 4
     pattern: ^((xn--)?[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-zA-Z]{2,}\.?$
@@ -13,10 +12,10 @@ properties:
     type: string
     default: UNSPECIFIED
     enum:
-    - UNSPECIFIED
-    - DEFAULT
-    - PRIMARY
-    - ALIAS
+      - UNSPECIFIED
+      - DEFAULT
+      - PRIMARY
+      - ALIAS
     description: |-
       - DEFAULT: The default `.ondigitalocean.app` domain assigned to this app
       - PRIMARY: The primary domain for this app that is displayed as the default in the control panel, used in bindable environment variables, and any other places that reference an app's live URL. Only one domain may be set as primary.
@@ -45,9 +44,9 @@ properties:
     maxLength: 3
     minLength: 3
     enum:
-      - "1.2"
-      - "1.3"
+      - '1.2'
+      - '1.3'
     description: 'The minimum version of TLS a client application can use to access resources for the domain.  Must be one of the following values wrapped within quotations: `"1.2"` or `"1.3"`.'
-    example: "1.3"
+    example: '1.3'
 required:
-- domain
+  - domain

--- a/specification/resources/droplets/models/droplet.yml
+++ b/specification/resources/droplets/models/droplet.yml
@@ -37,10 +37,10 @@ properties:
   status:
     type: string
     enum:
-    - new
-    - active
-    - off
-    - archive
+      - new
+      - active
+      - off
+      - archive
     example: active
     description: A status string indicating the state of the Droplet instance.
       This may be "new", "active", "off", or "archive".
@@ -60,9 +60,9 @@ properties:
     items:
       type: string
     example:
-    - backups
-    - private_networking
-    - ipv6
+      - backups
+      - private_networking
+      - ipv6
     description: An array of features enabled on this Droplet.
 
   backup_ids:
@@ -70,7 +70,7 @@ properties:
     items:
       type: integer
     example:
-    - 53893572
+      - 53893572
     description: An array of backup IDs of any backups that have been taken
       of the Droplet instance.  Droplet backups are enabled at the time of the
       instance creation.
@@ -85,13 +85,13 @@ properties:
       start:
         type: string
         format: date-time
-        example: "2019-12-04T00:00:00Z"
+        example: '2019-12-04T00:00:00Z'
         description: A time value given in ISO8601 combined date and time format
           specifying the start of the Droplet's backup window.
       end:
         type: string
         format: date-time
-        example: "2019-12-04T23:00:00Z"
+        example: '2019-12-04T23:00:00Z'
         description: A time value given in ISO8601 combined date and time format
           specifying the end of the Droplet's backup window.
 
@@ -100,7 +100,7 @@ properties:
     items:
       type: integer
     example:
-    - 67512819
+      - 67512819
     description: An array of snapshot IDs of any snapshots created from the
       Droplet instance.
 
@@ -112,7 +112,7 @@ properties:
     items:
       type: string
     example:
-    - '506f78a4-e098-11e5-ad9f-000f53306ae1'
+      - '506f78a4-e098-11e5-ad9f-000f53306ae1'
     description: A flat array including the unique identifier for each Block
       Storage volume attached to the Droplet.
 
@@ -150,8 +150,8 @@ properties:
     items:
       type: string
     example:
-    - web
-    - env:prod
+      - web
+      - env:prod
     description: An array of Tags the Droplet has been tagged with.
 
   vpc_uuid:
@@ -161,23 +161,22 @@ properties:
       is assigned.
 
 required:
-- id
-- name
-- memory
-- vcpus
-- disk
-- locked
-- status
-- kernel
-- created_at
-- features
-- backup_ids
-- next_backup_window
-- snapshot_ids
-- image
-- volume_ids
-- size
-- size_slug
-- networks
-- region
-- tags
+  - id
+  - name
+  - memory
+  - vcpus
+  - disk
+  - locked
+  - status
+  - created_at
+  - features
+  - backup_ids
+  - next_backup_window
+  - snapshot_ids
+  - image
+  - volume_ids
+  - size
+  - size_slug
+  - networks
+  - region
+  - tags

--- a/specification/resources/load_balancers/loadBalancers_add_forwardingRules.yml
+++ b/specification/resources/load_balancers/loadBalancers_add_forwardingRules.yml
@@ -27,11 +27,11 @@ requestBody:
         properties:
           forwarding_rules:
             type: array
-            minimum: 1
+            minItems: 1
             items:
               $ref: 'models/forwarding_rule.yml'
         required:
-         - forwarding_rules
+          - forwarding_rules
 
 responses:
   '204':
@@ -59,4 +59,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'write'
+      - 'write'

--- a/specification/resources/load_balancers/loadBalancers_remove_forwardingRules.yml
+++ b/specification/resources/load_balancers/loadBalancers_remove_forwardingRules.yml
@@ -27,11 +27,11 @@ requestBody:
         properties:
           forwarding_rules:
             type: array
-            minimum: 1
+            minItems: 1
             items:
               $ref: 'models/forwarding_rule.yml'
         required:
-         - forwarding_rules
+          - forwarding_rules
 
 responses:
   '204':
@@ -59,4 +59,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'write'
+      - 'write'

--- a/specification/resources/load_balancers/models/load_balancer_base.yml
+++ b/specification/resources/load_balancers/models/load_balancer_base.yml
@@ -21,32 +21,32 @@ properties:
     example: '104.131.186.241'
     description: An attribute containing the public-facing IP address of the
       load balancer.
-      
+
   size_unit:
     type: integer
     default: 1
     minimum: 1
     maximum: 100
     example: 3
-    description: How many nodes the load balancer contains. Each additional 
+    description: How many nodes the load balancer contains. Each additional
       node increases the load balancer's ability to manage more connections.
-      Load balancers can be scaled up or down, and you can change the number of 
-      nodes after creation up to once per hour. This field is currently not 
-      available in the AMS2, NYC2, or SFO1 regions. Use the `size` field to 
+      Load balancers can be scaled up or down, and you can change the number of
+      nodes after creation up to once per hour. This field is currently not
+      available in the AMS2, NYC2, or SFO1 regions. Use the `size` field to
       scale load balancers that reside in these regions.
 
   size:
     type: string
     enum:
-    - lb-small
-    - lb-medium
-    - lb-large
+      - lb-small
+      - lb-medium
+      - lb-large
     deprecated: true
     default: lb-small
     example: lb-small
-    description: This field has been replaced by the `size_unit` field for all 
-      regions except in AMS2, NYC2, and SFO1. Each available load balancer size 
-      now equates to the load balancer having a set number of nodes. 
+    description: This field has been replaced by the `size_unit` field for all
+      regions except in AMS2, NYC2, and SFO1. Each available load balancer size
+      now equates to the load balancer having a set number of nodes.
 
       * `lb-small` = 1 node
 
@@ -55,7 +55,7 @@ properties:
       * `lb-large` = 6 nodes
 
 
-      You can resize load balancers after creation up to once per hour. You 
+      You can resize load balancers after creation up to once per hour. You
       cannot resize a load balancer within the first hour of its creation.
 
   algorithm:
@@ -66,7 +66,7 @@ properties:
       - least_connections
     deprecated: true
     default: round_robin
-    description: This field has been deprecated. You can no longer specify an 
+    description: This field has been deprecated. You can no longer specify an
       algorithm for load balancers.
 
   status:
@@ -90,7 +90,7 @@ properties:
 
   forwarding_rules:
     type: array
-    minimum: 1
+    minItems: 1
     items:
       $ref: 'forwarding_rule.yml'
     description: An array of objects specifying the forwarding rules for a
@@ -138,4 +138,4 @@ properties:
       load balancer.
 
 required:
-- forwarding_rules
+  - forwarding_rules


### PR DESCRIPTION
Includes:

`app_domain_spec.yml`: The `domain` property has `format` and `pattern` values.  These are conflicting during model generation as they both represent a string formatting
`droplet.yml`: The `kernel` property is required and the $ref'd schema has `nullable: true`. The resulting model requires the field and causes validation errors when a value isn't supplied for the property.
`forwarding_rules`: Multiple schemas have this property with the incorrect `minimum` schema property set.

APICLI-1463