### PR TITLE
Removes unnecessary `allOf` for eviction policy

### DIFF
--- a/.github/workflows/spec.pr.yml
+++ b/.github/workflows/spec.pr.yml
@@ -12,7 +12,6 @@ on:
       - 'spectral/**'
 
 jobs:
-
   lint:
     name: Validate spec
     runs-on: ubuntu-latest
@@ -21,12 +20,35 @@ jobs:
       - name: Run linter
         run: make lint
 
+  bundle-spec:
+    name: Bundle Spec
+    runs-on: ubuntu-latest
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
+      - name: Bundle
+        run: make bundle
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: openapi-bundled
+          path: tests/openapi-bundled.yaml
+
   generate-preview:
     # As this job needs access to secrets, skip it if the PR comes from a fork.
     if: github.event.pull_request.head.repo.full_name == github.repository
     name: Generate Preview
     runs-on: ubuntu-latest
-    needs: lint
+
+    needs: bundle-spec
+
     steps:
       - uses: actions/checkout@v2
 
@@ -64,3 +86,26 @@ jobs:
           state: success
           sha: ${{ github.event.pull_request.head.sha }}
           target_url: https://api-engineering.nyc3.digitaloceanspaces.com/spec-ci/redoc-index.html?pr=${{ github.event.number }}
+
+  validate-client-gen:
+    name: Validate client generation
+    runs-on: ubuntu-latest
+
+    needs:
+      - bundle-spec
+
+    steps:
+      - name: Check out digitalocean-client-python repo
+        uses: actions/checkout@v2
+        with:
+          repository: digitalocean/digitalocean-client-python
+          token: ${{ secrets.WORKFLOW_TRIGGER_TOKEN }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: openapi-bundled
+
+      - run: head -n 3 openapi-bundled.yaml
+
+      - name: Generate Python client
+        run: SPEC_FILE=openapi-bundled.yaml make generate

--- a/specification/resources/databases/databases_update_evictionPolicy.yml
+++ b/specification/resources/databases/databases_update_evictionPolicy.yml
@@ -23,9 +23,7 @@ requestBody:
           - eviction_policy
         properties:
           eviction_policy:
-            allOf:
-              - $ref: 'models/eviction_policy_model.yml'
-            example: noeviction
+            $ref: 'models/eviction_policy_model.yml'
       example:
         eviction_policy: allkeys_lru
 
@@ -54,4 +52,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'write'
+      - 'write'

--- a/specification/resources/databases/models/eviction_policy_model.yml
+++ b/specification/resources/databases/models/eviction_policy_model.yml
@@ -15,3 +15,4 @@ description: |2-
   - `volatile_lru`: Evict keys with expiration only, least recently used (LRU) first.
   - `volatile_random`: Evict keys with expiration only in a random order.
   - `volatile_ttl`: Evict keys with expiration only, shortest time-to-live (TTL) first.
+example: allkeys_lru

--- a/specification/resources/databases/models/redis.yml
+++ b/specification/resources/databases/models/redis.yml
@@ -2,10 +2,7 @@ type: object
 
 properties:
   redis_maxmemory_policy:
-    allOf:
-      - $ref: 'eviction_policy_model.yml'
-    default: noeviction
-    example: allkeys-lru
+    $ref: 'eviction_policy_model.yml'
   redis_pubsub_client_output_buffer_limit:
     description: >-
       Set output buffer limit for pub / sub clients in MB. The value is the hard

--- a/specification/resources/databases/responses/eviction_policy_response.yml
+++ b/specification/resources/databases/responses/eviction_policy_response.yml
@@ -15,6 +15,4 @@ content:
         - eviction_policy
       properties:
         eviction_policy:
-          allOf:
-            - $ref: '../models/eviction_policy_model.yml'
-          example: noeviction
+          $ref: '../models/eviction_policy_model.yml'


### PR DESCRIPTION
The current definition works but causes errors during client generation. 

![image](https://user-images.githubusercontent.com/8887224/182723551-1b044f16-e699-4776-ad99-7a4c0a95dcf6.png)

It seems the refs to the eviction_policy_model was wrapped in unnecessary `allOf`. This simplifies the refs and fixes the generation errors.

I also added a job to the pr workflow that generates a client using the spec from the PR changes.