### PR TITLE
Spectral Ruleset Addition: Endpoints should always include scopes

### DIFF
--- a/spectral/ruleset.yml
+++ b/spectral/ruleset.yml
@@ -174,3 +174,19 @@ rules:
     message: '{{error}}'
     then:
       function: ensureSnakeCaseWithDigits
+  
+  oas3-operation-security-defined:
+    description: Check operation security is defined
+    severity: "error"
+    given: "$.paths.*.*"
+    then:
+      field: 'security'
+      function: truthy
+
+  oas3-operation-security-scopes-defined:
+    description: Check operation security's bearer_auth is defined
+    severity: "error"
+    given: "$.paths[*][*]..security.*"
+    then:
+      field: 'bearer_auth'
+      function: truthy


### PR DESCRIPTION
APICLI-1274

Now that we have added the required scopes for existing endpoints in our OpenAPI description, we should enforce that new endpoints include them by codifying the requirement with a Spectral rule. 

The following is enforced:
```
# security:
#   - bearer_auth:
#     - ‘read'
```

^will fail: oas3-operation-security-defined


```
security:
  - OAuth2:
      - read
      - write
```

will fail: oas3-operation-security-scopes-defined