### PR TITLE
Add support for /databases/options GET

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -700,6 +700,10 @@ paths:
     get:
       $ref: 'resources/billing/invoices_get_summaryByUUID.yml'
 
+  /v2/databases/options:
+    get:
+      $ref: 'resources/databases/databases_list_options.yml'
+
   /v2/databases:
     get:
       $ref: 'resources/databases/databases_list_clusters.yml'

--- a/specification/resources/databases/databases_list_options.yml
+++ b/specification/resources/databases/databases_list_options.yml
@@ -1,0 +1,40 @@
+operationId: databases_list_options
+
+summary: List Database Options
+
+description: >-
+  To list all of the options available for the offered database engines,
+  send a GET request to `/v2/databases/options`.
+
+  The result will be a JSON object with an `options` key.
+
+tags:
+  - Databases
+
+responses:
+  '200':
+    $ref: 'responses/options.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/databases_list_options.yml'
+  - $ref: 'examples/go/databases_list_options.yml'
+
+security:
+  - bearer_auth:
+      - 'read'
+

--- a/specification/resources/databases/examples/curl/databases_list_options.yml
+++ b/specification/resources/databases/examples/curl/databases_list_options.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/databases/options"

--- a/specification/resources/databases/examples/go/databases_list_options.yml
+++ b/specification/resources/databases/examples/go/databases_list_options.yml
@@ -13,5 +13,5 @@ source: |-
       client := godo.NewFromToken(token)
       ctx := context.TODO()
 
-      options, _, err := client.Databases.ListDBOptions(ctx)
+      options, _, err := client.Databases.ListOptions(ctx)
   }

--- a/specification/resources/databases/examples/go/databases_list_options.yml
+++ b/specification/resources/databases/examples/go/databases_list_options.yml
@@ -13,5 +13,5 @@ source: |-
       client := godo.NewFromToken(token)
       ctx := context.TODO()
 
-      rules, _, err := client.Databases.GetDBOptions(ctx)
+      options, _, err := client.Databases.ListDBOptions(ctx)
   }

--- a/specification/resources/databases/examples/go/databases_list_options.yml
+++ b/specification/resources/databases/examples/go/databases_list_options.yml
@@ -1,0 +1,17 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "os"
+
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      token := os.Getenv("DIGITALOCEAN_TOKEN")
+
+      client := godo.NewFromToken(token)
+      ctx := context.TODO()
+
+      rules, _, err := client.Databases.GetDBOptions(ctx)
+  }

--- a/specification/resources/databases/models/database_layout_option.yml
+++ b/specification/resources/databases/models/database_layout_option.yml
@@ -1,0 +1,16 @@
+type: object
+
+properties:
+  num_nodes:
+    type: integer
+    example: 1
+  sizes:
+    type: array
+    items:
+      type: string
+    example:
+      - db-s-1vcpu-1gb
+      - db-s-1vcpu-2gb
+    readOnly: true
+    description: >-
+      An array of objects containing the slugs available with various node counts

--- a/specification/resources/databases/models/database_layout_options.yml
+++ b/specification/resources/databases/models/database_layout_options.yml
@@ -1,0 +1,8 @@
+type: object
+
+properties:
+  layouts:
+    type: array
+    readOnly: true
+    items:
+      $ref: './database_layout_option.yml'

--- a/specification/resources/databases/models/database_layout_options.yml
+++ b/specification/resources/databases/models/database_layout_options.yml
@@ -4,5 +4,8 @@ properties:
   layouts:
     type: array
     readOnly: true
+    description: >-
+      An array of objects, each indicating the node sizes (otherwise referred to as slugs) that are available with various
+      numbers of nodes in the database cluster. Each slugs denotes the node's identifier, CPU, and RAM (in that order).
     items:
       $ref: './database_layout_option.yml'

--- a/specification/resources/databases/models/database_region_options.yml
+++ b/specification/resources/databases/models/database_region_options.yml
@@ -1,0 +1,13 @@
+type: object
+
+properties:
+  regions:
+    type: array
+    items:
+      type: string
+    example:
+      - ams3
+      - blr1
+    readOnly: true
+    description: >-
+      An array of strings containing the names of available regions

--- a/specification/resources/databases/models/database_version_options.yml
+++ b/specification/resources/databases/models/database_version_options.yml
@@ -1,7 +1,7 @@
 type: object
 
 properties:
-  version:
+  versions:
     type: array
     items:
       type: string

--- a/specification/resources/databases/models/database_version_options.yml
+++ b/specification/resources/databases/models/database_version_options.yml
@@ -1,0 +1,13 @@
+type: object
+
+properties:
+  version:
+    type: array
+    items:
+      type: string
+    example:
+      - '4.4'
+      - '5.0'
+    readOnly: true
+    description: >-
+      An array of strings containing the names of available regions

--- a/specification/resources/databases/models/options.yml
+++ b/specification/resources/databases/models/options.yml
@@ -1,0 +1,26 @@
+type: object
+
+properties:
+  options:
+    type: object
+    properties:
+      mongodb:
+        allOf:
+        - $ref: './database_region_options.yml'
+        - $ref: './database_version_options.yml'
+        - $ref: './database_layout_options.yml'
+      pg:
+        allOf:
+          - $ref: './database_region_options.yml'
+          - $ref: './database_version_options.yml'
+          - $ref: './database_layout_options.yml'
+      mysql:
+        allOf:
+          - $ref: './database_region_options.yml'
+          - $ref: './database_version_options.yml'
+          - $ref: './database_layout_options.yml'
+      redis:
+        allOf:
+          - $ref: './database_region_options.yml'
+          - $ref: './database_version_options.yml'
+          - $ref: './database_layout_options.yml'

--- a/specification/resources/databases/responses/options.yml
+++ b/specification/resources/databases/responses/options.yml
@@ -1,0 +1,34 @@
+description: A JSON string with a key of `options`.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/options.yml'
+    example:
+      options:
+        mongodb:
+          regions:
+            - ams3
+            - blr1
+          versions:
+            - 4.4
+            - 5.0
+          layouts:
+            - num_nodes: 1
+              sizes:
+                - db-s-1vcpu-1gb
+                - db-s-1vcpu-2gb
+            - num_nodes: 2
+              sizes:
+                - db-s-1vcpu-1gb
+                - db-s-1vcpu-2gb
+                - db-s-2vcpu-4gb
+                - db-s-4vcpu-8gb

--- a/specification/resources/databases/responses/options.yml
+++ b/specification/resources/databases/responses/options.yml
@@ -19,8 +19,68 @@ content:
             - ams3
             - blr1
           versions:
-            - 4.4
-            - 5.0
+            - '4.4'
+            - '5.0'
+          layouts:
+            - num_nodes: 1
+              sizes:
+                - db-s-1vcpu-1gb
+                - db-s-1vcpu-2gb
+            - num_nodes: 3
+              sizes:
+                - db-s-1vcpu-1gb
+                - db-s-1vcpu-2gb
+                - db-s-2vcpu-4gb
+                - db-s-4vcpu-8gb
+        mysql:
+          regions:
+            - ams3
+            - blr1
+          versions:
+            - '8'
+          layouts:
+            - num_nodes: 1
+              sizes:
+                - db-s-1vcpu-1gb
+                - db-s-1vcpu-2gb
+            - num_nodes: 2
+              sizes:
+                - db-s-1vcpu-1gb
+                - db-s-1vcpu-2gb
+                - db-s-2vcpu-4gb
+                - db-s-4vcpu-8gb
+            - num_nodes: 3
+              sizes:
+                - db-s-1vcpu-1gb
+                - db-s-1vcpu-2gb
+                - db-s-2vcpu-4gb
+                - db-s-4vcpu-8gb
+        pg:
+          regions:
+            - ams3
+            - blr1
+          versions:
+            - '11'
+            - '12'
+            - '13'
+            - '14'
+          layouts:
+            - num_nodes: 1
+              sizes:
+                - db-s-1vcpu-1gb
+                - db-s-1vcpu-2gb
+            - num_nodes: 2
+              sizes:
+                - db-s-1vcpu-1gb
+                - db-s-1vcpu-2gb
+                - db-s-2vcpu-4gb
+                - db-s-4vcpu-8gb
+        redis:
+          regions:
+            - ams3
+            - blr1
+          versions:
+            - '6'
           layouts:
             - num_nodes: 1
               sizes:


### PR DESCRIPTION
**What**

- Adds documentation on `/databases/option` endpoint which returns regions, versions, slugs, etc that are available for the various engines we support.

**Why**

- Provides details to clients who would like to know the available options for databases

**Evidence**

![image](https://user-images.githubusercontent.com/9273337/183753978-5b4b3cbd-2101-4221-9281-74d9193f32ee.png)
