### PR TITLE
Volume Snapshots Endpoint Path Typo

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -1372,7 +1372,7 @@ paths:
     post:
       $ref: 'resources/volumes/volumeActions_post.yml'
 
-  /v2/volumes/snapshot/{snapshot_id}:
+  /v2/volumes/snapshots/{snapshot_id}:
     get:
       $ref: 'resources/volumes/volumeSnapshots_get_byId.yml'
     delete:


### PR DESCRIPTION
Currently, the doc has the API  for GETting a snapshot to be routed to: `v2/volumes/snapshot/{snapshot_id}` which will error out:

```
 curl -X GET \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
  "https://api.digitalocean.com/v2/volumes/snapshot/0313270c-18bd-11ed-8e98-0a58ac14683f"
{"id":"not_found","message":"The resource you were accessing could not be found."}% 
```

updating the documentation to point to the right API path will give a successful response:

```
 curl -X GET \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
  "https://api.digitalocean.com/v2/volumes/snapshots/0313270c-18bd"
{"snapshot":{"id":"0313270c-18bd-11ed","name":"cgtest-39466979-12da-484c-9e6c-21afb852faa5","regions":["nyc3"],"created_at":"2022-08-10T14:59:19Z","resource_id":"01f07c08-18bd-11ed-8423-0a58ac146a31","resource_type":"volume","min_disk_size":10,"size_gigabytes":0.0118,"tags":[]}}%              
```                                     