### PR TITLE
remove `user` as a required field in connection pool model

### DIFF
--- a/specification/resources/databases/models/connection_pool.yml
+++ b/specification/resources/databases/models/connection_pool.yml
@@ -30,7 +30,9 @@ properties:
     example: defaultdb
   user:
     type: string
-    description: The name of the user for use with the connection pool.
+    description: >-
+      The name of the user for use with the connection pool. When excluded,
+      all sessions connect to the database as the inbound user.
     example: doadmin
   connection:
     allOf:

--- a/specification/resources/databases/models/connection_pool.yml
+++ b/specification/resources/databases/models/connection_pool.yml
@@ -45,4 +45,3 @@ required:
   - mode
   - size
   - db
-  - user


### PR DESCRIPTION
**What/Why**

The API allows pools to be created without a user specified.  This PR modifies the `pool` resource and removes `user` as a required field.  

**Evidence**

```bash
curl -i -X POST -H "Content-Type: application/json" \
    -H "Authorization: Bearer ${DO_AUTH_TOKEN}" \
    -d '{"name": "a-new-conn-pool","mode": "transaction","size": 10,"db": "defaultdb"}' "https://api.digitalocean.com/v2/databases/$DB_UUID/pools"
```

```
HTTP/2 201 
date: Tue, 16 Aug 2022 15:56:41 GMT
content-type: application/json; charset=utf-8
content-length: 720
ratelimit-limit: 5000
ratelimit-remaining: 4986
ratelimit-reset: 1660666846
x-gateway: Edge-Gateway
x-request-id: 6ba28d92-4a40-41b0-80bd-c5ac4abcb8ca
x-response-from: service
cf-cache-status: DYNAMIC
```
<img width="1206" alt="Screen Shot 2022-08-16 at 12 13 46 PM" src="https://user-images.githubusercontent.com/22375448/184928164-4b7a3c73-b4ad-41ec-9303-26a0bc072fcb.png">

