### PR TITLE
droplets: Fix various code examples.

### DIFF
--- a/specification/resources/droplets/dropletActions_get.yml
+++ b/specification/resources/droplets/dropletActions_get.yml
@@ -36,9 +36,9 @@ responses:
     $ref: '../../shared/responses/unexpected_error.yml'
 
 x-codeSamples:
-  - $ref: 'examples/curl/dropletActions_list.yml'
-  - $ref: 'examples/go/dropletActions_list.yml'
-  - $ref: 'examples/ruby/dropletActions_list.yml'
+  - $ref: 'examples/curl/dropletActions_get.yml'
+  - $ref: 'examples/go/dropletActions_get.yml'
+  - $ref: 'examples/ruby/dropletActions_get.yml'
 
 security:
   - bearer_auth:

--- a/specification/resources/droplets/droplets_list.yml
+++ b/specification/resources/droplets/droplets_list.yml
@@ -42,9 +42,9 @@ responses:
     $ref: '../../shared/responses/unexpected_error.yml'
 
 x-codeSamples:
-  - $ref: 'examples/curl/droplets_list_snapshots.yml'
-  - $ref: 'examples/go/droplets_list_snapshots.yml'
-  - $ref: 'examples/ruby/droplets_list_snapshots.yml'
+  - $ref: 'examples/curl/droplets_list.yml'
+  - $ref: 'examples/go/droplets_list.yml'
+  - $ref: 'examples/ruby/droplets_list.yml'
 
 security:
   - bearer_auth:

--- a/specification/resources/droplets/droplets_list_associatedResources.yml
+++ b/specification/resources/droplets/droplets_list_associatedResources.yml
@@ -37,7 +37,7 @@ responses:
     $ref: '../../shared/responses/unexpected_error.yml'
 
 x-codeSamples:
-  - $ref: 'examples/curl/dropletActions_list.yml'
+  - $ref: 'examples/curl/droplets_list_associatedResources.yml'
 
 security:
   - bearer_auth:

--- a/specification/resources/droplets/droplets_list_backups.yml
+++ b/specification/resources/droplets/droplets_list_backups.yml
@@ -38,9 +38,9 @@ responses:
     $ref: '../../shared/responses/unexpected_error.yml'
 
 x-codeSamples:
-  - $ref: 'examples/curl/dropletActions_list.yml'
-  - $ref: 'examples/go/dropletActions_list.yml'
-  - $ref: 'examples/ruby/dropletActions_list.yml'
+  - $ref: 'examples/curl/droplets_list_backups.yml'
+  - $ref: 'examples/go/droplets_list_backups.yml'
+  - $ref: 'examples/ruby/droplets_list_backups.yml'
 
 security:
   - bearer_auth:


### PR DESCRIPTION
I just noticed that somehow we've ended up with a number of the Droplet code examples pointing to the wrong thing.