### PR TITLE
Fix spelling of untagged

### DIFF
--- a/specification/resources/tags/tags_unassign_resources.yml
+++ b/specification/resources/tags/tags_unassign_resources.yml
@@ -3,7 +3,7 @@ operationId: tags_unassign_resources
 summary: Untag a Resource
 
 description: >-
-  Resources can be tagged by sending a DELETE request to
+  Resources can be untagged by sending a DELETE request to
   `/v2/tags/$TAG_NAME/resources` with an array of json objects containing
   `resource_id` and `resource_type` attributes.
 


### PR DESCRIPTION
Fixes the wording so that we say "untag" instead of "tag".