### PR TITLE
Add uptime group prefix

### DIFF
--- a/specification/resources/uptime/create_check.yml
+++ b/specification/resources/uptime/create_check.yml
@@ -1,4 +1,4 @@
-operationId: check_create
+operationId: uptime_check_create
 
 summary: Create a New Check
 

--- a/specification/resources/uptime/delete_check.yml
+++ b/specification/resources/uptime/delete_check.yml
@@ -1,4 +1,4 @@
-operationId: check_delete
+operationId: uptime_check_delete
 
 summary: Delete a Check
 
@@ -36,7 +36,6 @@ responses:
 
 x-codeSamples:
   - $ref: 'examples/curl/check_delete.yml'
-
 
 security:
   - bearer_auth:

--- a/specification/resources/uptime/get_check.yml
+++ b/specification/resources/uptime/get_check.yml
@@ -1,4 +1,4 @@
-operationId: check_get
+operationId: uptime_check_get
 
 summary: Retrieve an Existing Check
 

--- a/specification/resources/uptime/get_check_state.yml
+++ b/specification/resources/uptime/get_check_state.yml
@@ -1,8 +1,9 @@
-operationId: check_state_get
+operationId: uptime_check_state_get
 
 summary: Retrieve Check State
 
-description: To show information about an existing check's state, send a GET request to
+description:
+  To show information about an existing check's state, send a GET request to
   `/v2/uptime/checks/$CHECK_ID/state`.
 
 tags:
@@ -29,7 +30,6 @@ responses:
 
   default:
     $ref: '../../shared/responses/unexpected_error.yml'
-
 
 x-codeSamples:
   - $ref: 'examples/curl/check_state_get.yml'

--- a/specification/resources/uptime/list_alerts.yml
+++ b/specification/resources/uptime/list_alerts.yml
@@ -1,4 +1,4 @@
-operationId: check_alerts_list
+operationId: uptime_check_alerts_list
 
 summary: List All Alerts
 
@@ -38,4 +38,3 @@ x-codeSamples:
 security:
   - bearer_auth:
       - 'read'
-

--- a/specification/resources/uptime/list_checks.yml
+++ b/specification/resources/uptime/list_checks.yml
@@ -1,8 +1,9 @@
-operationId: checks_list
+operationId: uptime_checks_list
 
 summary: List All Checks
 
-description: To list all of the Uptime checks on your account, send a GET request
+description:
+  To list all of the Uptime checks on your account, send a GET request
   to `/v2/uptime/checks`.
 
 tags:
@@ -31,11 +32,9 @@ responses:
   default:
     $ref: '../../shared/responses/unexpected_error.yml'
 
-
 x-codeSamples:
   - $ref: 'examples/curl/check_list.yml'
 
 security:
   - bearer_auth:
       - 'read'
-

--- a/specification/resources/uptime/update_check.yml
+++ b/specification/resources/uptime/update_check.yml
@@ -1,4 +1,4 @@
-operationId: check_update
+operationId: uptime_check_update
 
 summary: Update a Check
 


### PR DESCRIPTION
Adds the appropriate prefix to some uptime operation IDs to address some errors in client generation.

unblocks  [digitalocean/digitalocean-client-python#97](https://github.com/digitalocean/digitalocean-client-python/pull/97) (APICLI-1983)