### PR TITLE
Add Release Support and Rework Client Generation Trigger Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: tagged-release
-
+# this workflow occurs on every release
+# it uploads the bundled spec as an artifact of the release
 on:
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: tagged-release
+
+on:
+  push:
+    tags:
+      - 'v[1-9].[0-9]+.[0-9]+'
+
+jobs:
+  build-release:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Bundle Spec 
+        id: bundle_spec
+        run: make bundle
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} 
+          asset_path: tests/openapi-bundled.yaml
+          asset_name: openapi-bundled.yaml
+          asset_content_type: application/yaml

--- a/.github/workflows/trigger-python-client-gen.yml
+++ b/.github/workflows/trigger-python-client-gen.yml
@@ -1,4 +1,7 @@
 name: Trigger Python Client Generation
+# this workflow triggers a workflow in the pydo repo when a 
+# new release is cut in digitalocean/openapi
+
 on:
   workflow_run:
     workflows: [tagged-release]

--- a/.github/workflows/trigger-python-client-gen.yml
+++ b/.github/workflows/trigger-python-client-gen.yml
@@ -1,7 +1,7 @@
 name: Trigger Python Client Generation
 on:
   workflow_run:
-    workflows: [Spec Main]
+    workflows: [tagged-release]
     types:
       - completed
 
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - name: "Determine tag"
+        run: echo "TAG_RELEASE=`curl  "https://api.github.com/repos/digitalocean/openapi/tags" | jq -r '.[0].name'`" >> $GITHUB_ENV
       - name: trigger-workflow
-        run: gh workflow run --repo digitalocean/digitalocean-client-python python-client-gen.yml --ref main -f commit_url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA
+        run: gh workflow run --repo digitalocean/digitalocean-client-python python-client-gen.yml --ref main -f release_version=$TAG_RELEASE 
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_TRIGGER_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+changelog here

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,3 +84,27 @@ These files and directories contain the API specification broken down to
 │   │   │   ├── <response_name>.yml:  Individual response definition
 │   └── tests/:  Placeholder directory for test generation and output
 ```
+
+## Releasing
+
+To cut a release, push a new tag (versioning discussed below).
+
+### Tagging a release
+
+##### Prerequisites
+
+1. Run `make changes` to review the changes since the last
+   release. Based on the changes, decide what kind of release you are
+   doing (bugfix, feature or breaking).
+   `digitalocean/openapi` follows [semantic versioning](https://semver.org), ask if you aren't sure.
+
+2. Tag the release using `BUMP=(bugfix|feature|breaking) make tag`.
+   (Bugfix, feature and breaking are aliases for semver's patch, minor and major.
+   BUMP will also accept `patch`, `minor` and `major`, if you prefer). The command
+   assumes you have a remote repository named `origin` pointing to this
+   repository. If you'd prefer to specify a different remote repository, you can
+   do so by setting `ORIGIN=(preferred remote name)`.
+
+3. The release will trigger a workflow in [digitalocean/pydo](https://github.com/digitalocean/pydo) to update the DigitalOcean Python Client, Pydo, to ensure the spec changes are reflected in the client. The workflow will create a PR to be reviewed by the owners of the Pydo repo. 
+
+The new tag triggers the release.

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ TMP_COLLECTION_PATH ?= tests/postman-temp.json
 
 DO_TOKEN ?= XXXXXX
 
+# ORIGIN is used when testing release code
+ORIGIN ?= origin
+BUMP ?= patch
+
 .PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -68,3 +72,25 @@ autorest-typescript: dev-dependencies bundle
 .PHONY: preview
 preview: dev-dependencies ## Launch the docs preview server (openapi) and watch for file changes
 	SPEC_FILE=${SPEC_FILE} npm run preview
+
+.PHONY: _install_sembump
+_install_sembump:
+	@echo "=> installing/updating sembump tool"
+	@echo ""
+	@GO111MODULE=off go get -u github.com/jessfraz/junk/sembump
+
+.PHONY: tag
+tag: _install_sembump
+	@echo "==> BUMP=${BUMP} tag"
+	@echo ""
+	@ORIGIN=${ORIGIN} scripts/bumpversion.sh
+
+.PHONY: _install_github_release_notes
+_install_github_release_notes:
+	GO111MODULE=off go get -u github.com/digitalocean/github-changelog-generator
+
+.PHONY: changes
+changes: _install_github_release_notes
+	echo "==> list merged PRs since last release"
+	echo ""
+	changes=$(shell scripts/changelog.sh) && cat $$changes && rm -f $$changes

--- a/scripts/bumpversion.sh
+++ b/scripts/bumpversion.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ORIGIN=${ORIGIN:-origin}
+
+# Bump defaults to patch. We provide friendly aliases
+# for patch, minor and major
+BUMP=${BUMP:-patch}
+case "$BUMP" in
+  feature | minor)
+    BUMP="minor"
+    ;;
+  breaking | major)
+    BUMP="major"
+    ;;
+  *)
+    BUMP="patch"
+    ;;
+esac
+
+if [[ $(git status --porcelain) != "" ]]; then
+  echo "Error: repo is dirty. Run git status, clean repo and try again."
+  exit 1
+elif [[ $(git status --porcelain -b | grep -e "ahead" -e "behind") != "" ]]; then
+  echo "Error: repo has unpushed commits. Push commits to remote and try again."
+  exit 1
+fi  
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+version="$("$DIR"/../scripts/version.sh -s)"
+new_version="v$(sembump --kind "$BUMP" "$version")"
+
+echo "Bumping version from v${version} to ${new_version}"
+
+git tag -m "release ${new_version}" -a "$new_version" && git push "${ORIGIN}" tag "$new_version"
+
+echo ""

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+tfile=$(mktemp /tmp/openapi-CHANGELOG-XXXXXX)
+github-changelog-generator -org digitalocean -repo openapi >"$tfile"
+
+GO111MODULE=on go mod tidy
+
+echo "$tfile"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+# do NOT use pipefail in this script, as it will cause problems with the version
+# line
+
+set -e
+
+me=$(basename "$0")
+
+help_message="\
+Usage: $me [<options>]
+Display doctl version
+
+Options:
+
+  -h, --help   Show this help information.
+  -s, --short  major.minor.patch only
+  -i, --image  snap image version
+  -b, --branch branch only
+  -c, --commit commit only
+  --snap, returns the version formated for a snap release
+"
+
+semver() {
+  git tag -l | sort --version-sort | tail -n1 | cut -c 2-
+}
+
+branch() {
+  local branch
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  if [[ $branch != 'main' && $branch != HEAD ]]; then
+    echo "${branch}"
+  fi
+}
+
+commit() {
+  if [[ $(git status --porcelain) != "" ]]; then
+    git rev-parse --short HEAD
+  fi
+}
+
+image() {
+  echo "$(semver)-$(commit)-pre"
+}
+
+snap() {
+  version=$(semver)
+  if [[ $(git tag --points-at) != "" ]]; then
+    echo "v$version"
+  else
+    local_commit=$(git rev-parse --short HEAD)
+    echo "v$version+git$local_commit"
+  fi
+}
+
+ORIGIN=${ORIGIN:-origin}
+set +e
+git fetch --tags "${ORIGIN}" &>/dev/null
+set -e
+
+if [[ "$#" -eq 0 ]]; then
+
+  SNAP_IMAGE=${SNAP_IMAGE:-false}
+  if [[ "${SNAP_IMAGE}" != 'false' ]]; then
+    image
+    exit 0
+  fi
+
+  version=$(semver)
+
+  br=$(branch)
+  if [[ -n "$br" ]]; then
+    version="${version}-${br}"
+  fi
+
+  cm=$(commit)
+  if [[ -n "$cm" ]]; then
+    version="${version}-${cm}"
+  fi
+
+  echo "$version"
+  exit 0
+fi
+
+case "$1" in
+  "-b"|"--branch")
+    version=$(branch)
+    ;;
+
+  "-c"|"--commit")
+    version=$(commit)
+    ;;
+
+  "-s"|"--short")
+    version=$(semver)
+    ;;
+
+  "-i"|"--image")
+    version=$(image)
+    ;;
+
+  "--snap")
+    version=$(snap)
+    ;;
+
+  *)
+    echo "$help_message"
+    exit 0
+    ;;
+esac
+
+echo "$version"


### PR DESCRIPTION
Adding releases to this repo to associate versions of the DO spec to versions of the generated Python Client.

This change does the following to support releases:
- Is consistent with doctl's releasing pattern of following [semantic versioning](https://semver.org/)
- Adds supporting make commands: make changes and make tags
- Adds the bundled spec as an artifact to the release to be picked up by the python client

This change does the following to support triggering the workflow to regenerate the python client:
- Triggers the Python Client repo only on digitalocean/openapi releases

The workflow is depicted below:
![DO Openapi Spec to Pydo Workflow (2)](https://user-images.githubusercontent.com/42972711/196963103-d09499ed-6731-484e-920b-49b3e3b4dfba.png)
