### PR TITLE
Remove 'on/pull_request/paths:' in workflow

### DIFF
--- a/.github/workflows/spec.pr.yml
+++ b/.github/workflows/spec.pr.yml
@@ -5,11 +5,7 @@ name: Spec PR
 # The name of the uploaded file will be prefixed with the PR number.
 # e.g. `spec-ci/previews/123-spec.yaml
 
-on:
-  pull_request:
-    paths:
-      - 'specification/**'
-      - 'spectral/**'
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/spec.pr.yml
+++ b/.github/workflows/spec.pr.yml
@@ -5,7 +5,7 @@ name: Spec PR
 # The name of the uploaded file will be prefixed with the PR number.
 # e.g. `spec-ci/previews/123-spec.yaml
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   lint:

--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -19,7 +19,7 @@ servers:
     description: production
 
 tags:
-  - name: 1-Click Applications
+  - name: 1-Click Applications DELETE-ME
     description: |-
       1-Click applications are pre-built Droplet images or Kubernetes apps with software,
       features, and configuration details already set up for you. They can be found in the

--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -19,7 +19,7 @@ servers:
     description: production
 
 tags:
-  - name: 1-Click Applications DELETE-ME
+  - name: 1-Click Applications
     description: |-
       1-Click applications are pre-built Droplet images or Kubernetes apps with software,
       features, and configuration details already set up for you. They can be found in the


### PR DESCRIPTION
Learned in Github Actions Office Hours that it is a known bug, that github has documented [here](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks), for PRs that change files outside of paths specified in a workflow to choke the gh actions checks. 

Suggested we remove it since it's not an expensive check

also made minor change to spec to have this PR work lol