### PR TITLE
apps: update create app docs and the app example

### DIFF
--- a/specification/resources/apps/models/app.yml
+++ b/specification/resources/apps/models/app.yml
@@ -52,6 +52,11 @@ properties:
     title: The ID of the account to which the application belongs
     type: string
     example: 4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf
+  project_id:
+    readOnly: true
+    type: string
+    example: 88b72d1a-b78a-4d9f-9090-b53c4399073f
+    title: The id of the project for the app. This will be empty if there is a fleet (project) lookup failure.
   region:
     $ref: apps_region.yml
   spec:

--- a/specification/resources/apps/models/apps_create_app_request.yml
+++ b/specification/resources/apps/models/apps_create_app_request.yml
@@ -1,6 +1,9 @@
 properties:
   spec:
     $ref: app_spec.yml
+  project_id:
+    type: string
+    description: The UUID of the project the app should be assigned.
 required:
 - spec
 type: object

--- a/specification/resources/apps/responses/examples.yml
+++ b/specification/resources/apps/responses/examples.yml
@@ -201,6 +201,7 @@ app:
       tier_slug: basic
       live_url_base: https://sample-golang-zyhgn.ondigitalocean.app
       live_domain: sample-golang-zyhgn.ondigitalocean.app
+      project_id: 88b72d1a-b78a-4d9f-9090-b53c4399073f
 
 deployments:
   value:


### PR DESCRIPTION
We just added project_id as a parameter to the CreateApp RPC, so this PR updates the documentation to reflect that. project_id also comes back on the newly created App so that's documented now too.