### PR TITLE
Add "Upload Pydo Spec" in Makefile

### DIFF
--- a/.github/workflows/spec.main.yml
+++ b/.github/workflows/spec.main.yml
@@ -49,7 +49,7 @@ jobs:
           --endpoint=${{ env.SPACES_ENDPOINT }}
           --acl public-read
     # the spec that will be associated with the generated Pydo client    
-      - name: Upload Pydo spec
+      - name: Upload revision spec
         run: >-
           aws s3 cp tests/openapi-bundled.yaml
           ${{ env.SPACES_PATH }}/DigitalOcean-public-${{ steps.vars.outputs.sha_short }}.v2.yaml

--- a/.github/workflows/spec.main.yml
+++ b/.github/workflows/spec.main.yml
@@ -37,8 +37,11 @@ jobs:
         with:
           name: openapi-bundled
           path: tests/openapi-bundled.yaml
-      - name: Add SHORT_SHA env property with commit short sha
-        run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
+      - name: Set outputs
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Check outputs
+        run: echo ${{ steps.vars.outputs.sha_short }}
       - name: Upload Main spec
         run: >-
           aws s3 cp tests/openapi-bundled.yaml
@@ -49,7 +52,7 @@ jobs:
       - name: Upload Pydo spec
         run: >-
           aws s3 cp tests/openapi-bundled.yaml
-          ${{ env.SPACES_PATH }}/DigitalOcean-public-${SHORT_SHA}.v2.yaml
+          ${{ env.SPACES_PATH }}/DigitalOcean-public-${{ steps.vars.outputs.sha_short }}.v2.yaml
           --endpoint=${{ env.SPACES_ENDPOINT }}
           --acl public-read
         env:

--- a/.github/workflows/spec.main.yml
+++ b/.github/workflows/spec.main.yml
@@ -37,11 +37,19 @@ jobs:
         with:
           name: openapi-bundled
           path: tests/openapi-bundled.yaml
-
+      - name: Add SHORT_SHA env property with commit short sha
+        run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
       - name: Upload Main spec
         run: >-
           aws s3 cp tests/openapi-bundled.yaml
           ${{ env.SPACES_PATH }}/DigitalOcean-public.v2.yaml
+          --endpoint=${{ env.SPACES_ENDPOINT }}
+          --acl public-read
+    # the spec that will be associated with the generated Pydo client    
+      - name: Upload Pydo spec
+        run: >-
+          aws s3 cp tests/openapi-bundled.yaml
+          ${{ env.SPACES_PATH }}/DigitalOcean-public-${SHORT_SHA}.v2.yaml
           --endpoint=${{ env.SPACES_ENDPOINT }}
           --acl public-read
         env:

--- a/.github/workflows/trigger-python-client-gen.yml
+++ b/.github/workflows/trigger-python-client-gen.yml
@@ -11,7 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - name: Set outputs
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Check outputs
+        run: echo ${{ steps.vars.outputs.sha_short }}
       - name: trigger-workflow
-        run: gh workflow run --repo digitalocean/digitalocean-client-python python-client-gen.yml --ref main -f commit_url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA
+        run: gh workflow run --repo digitalocean/digitalocean-client-python python-client-gen.yml --ref main -f github_short_sha=${{ steps.vars.outputs.sha_short }}
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_TRIGGER_TOKEN }}

--- a/.github/workflows/trigger-python-client-gen.yml
+++ b/.github/workflows/trigger-python-client-gen.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Check outputs
         run: echo ${{ steps.vars.outputs.sha_short }}
       - name: trigger-workflow
-        run: gh workflow run --repo digitalocean/digitalocean-client-python python-client-gen.yml --ref main -f github_short_sha=${{ steps.vars.outputs.sha_short }}
+        run: gh workflow run --repo digitalocean/digitalocean-client-python python-client-gen.yml --ref main -f openapi_short_sha=${{ steps.vars.outputs.sha_short }}
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_TRIGGER_TOKEN }}

--- a/ADR.md
+++ b/ADR.md
@@ -1,0 +1,8 @@
+# Architecture Decision Record for Openapi
+
+## Title: Having No Releases for DO Specification
+## Date: 10/31/2022
+## Description
+We will not be supporting releases for the official DO Specification.
+## Additional Context
+Created a PR that supported adding releases to the specification (here)[https://github.com/digitalocean/openapi]. After much consideration, we've decided to not move forward with supporting releases. We originally thought to support it to easily associate the versioned specification to the generated python client, Pydo, but decided it was a bit of an overkill.  


### PR DESCRIPTION
Reworked the workflow a bit to upload a specific bundled spec tied to a commit for the Pydo workflow to pick up. 
Workflow is as follows: 
![DO Openapi Spec to Pydo Workflow (5)](https://user-images.githubusercontent.com/42972711/199155766-089fc1c6-2321-411f-b251-f9beb31e3e20.png)


Sister PR to this one: https://github.com/digitalocean/digitalocean-client-python/pull/103