### PR TITLE
Update GET migration endpoint docs to indicate returning most recent OM

### DIFF
--- a/specification/resources/databases/databases_get_migrationStatus.yml
+++ b/specification/resources/databases/databases_get_migrationStatus.yml
@@ -3,9 +3,8 @@ operationId: databases_get_migrationStatus
 summary: Retrieve the Status of an Online Migration
 
 description: >-
-  To retrieve the status of an online migration, send a GET request to
-  `/v2/databases/$DATABASE_ID/online-migration`. If a migration has completed,
-  a 200 OK status is returned with no response body.
+  To retrieve the status of the most recent online migration, send a GET request to
+  `/v2/databases/$DATABASE_ID/online-migration`. 
 
 tags:
   - Databases

--- a/specification/resources/databases/models/online_migration.yml
+++ b/specification/resources/databases/models/online_migration.yml
@@ -3,11 +3,16 @@ type: object
 properties:
   id:
     type: string
-    description: The ID of the currently running migration.
+    description: The ID of the most recent migration.
     example: 77b28fc8-19ff-11eb-8c9c-c68e24557488
   status:
     type: string
     description: The current status of the migration.
+    enum:
+      - running
+      - canceled
+      - error
+      - done
     example: running
   created_at:
     type: string


### PR DESCRIPTION
We are updating this since we changed the GET endpoint for `/v2/databases/$DATABASE_ID/online-migration` to return the most recent online migration, rather than the active migration. This will help users to diagnose issues with the migration and also issue requests to stop the migration.

As a result, this exposes additional states about the migration, so these are also enumerated.

Sample preview test below:

![image](https://user-images.githubusercontent.com/9273337/199295334-c2e0bd89-6eda-4d80-bcfb-01453e7b4972.png)
