### PR TITLE
Add project_id field to LBaaS Docs, removed required tag Storage

### DIFF
--- a/specification/resources/load_balancers/examples.yml
+++ b/specification/resources/load_balancers/examples.yml
@@ -16,6 +16,7 @@ load_balancer_basic_create_request:
     droplet_ids:
     - 3164444
     - 3164445
+    project_id: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
 
 load_balancer_ssl_termination_create_request:
   description: Terminating SSL at the load balancer using a managed SSL
@@ -108,3 +109,4 @@ load_balancer_update_request:
     enable_proxy_protocol: true
     enable_backend_keepalive: true
     vpc_uuid: c33931f2-a26a-4e61-b85c-4e95a2ec431b
+    project_id: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30

--- a/specification/resources/load_balancers/models/load_balancer_base.yml
+++ b/specification/resources/load_balancers/models/load_balancer_base.yml
@@ -14,6 +14,14 @@ properties:
     example: example-lb-01
     description: A human-readable name for a load balancer instance.
 
+  project_id:
+    type: string
+    example: 4de7ac8b-495b-4884-9a69-1050c6793cd6
+    description: The ID of the project that the load balancer is associated with. 
+      If no ID is provided at creation, the load balancer associates with the user's 
+      default project. If an invalid project ID is provided, the load balancer will 
+      not be created.
+
   ip:
     type: string
     pattern: '^$|^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'

--- a/specification/resources/load_balancers/responses/examples.yml
+++ b/specification/resources/load_balancers/responses/examples.yml
@@ -65,6 +65,7 @@ load_balancer_basic_response:
       enable_backend_keepalive: false
       vpc_uuid: c33931f2-a26a-4e61-b85c-4e95a2ec431b
       disable_lets_encrypt_dns_records: false
+      project_id: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
 
 load_balancer_ssl_termination_response:
   value:
@@ -187,6 +188,7 @@ load_balancer_using_tag_response:
       enable_backend_keepalive: false
       vpc_uuid: c33931f2-a26a-4e61-b85c-4e95a2ec431b
       disable_lets_encrypt_dns_records: false
+      project_id: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
 
 load_balancer_sticky_sessions_and_health_check_response:
   value:
@@ -250,6 +252,7 @@ load_balancer_sticky_sessions_and_health_check_response:
       enable_backend_keepalive: false
       vpc_uuid: c33931f2-a26a-4e61-b85c-4e95a2ec431b
       disable_lets_encrypt_dns_records: false
+      project_id: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
 
 load_balancer_update_response:
   value:
@@ -318,6 +321,7 @@ load_balancer_update_response:
       enable_backend_keepalive: true
       vpc_uuid: c33931f2-a26a-4e61-b85c-4e95a2ec431b
       disable_lets_encrypt_dns_records: false
+      project_id: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
 
 load_balancers_all:
   value:
@@ -447,6 +451,7 @@ load_balancers_all:
       enable_backend_keepalive: false
       vpc_uuid: 587d698c-de84-11e8-80bc-3cfdfea9fcd1
       disable_lets_encrypt_dns_records: false
+      project_id: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
     links: {}
     meta:
       total: 2

--- a/specification/resources/volumes/models/attributes.yml
+++ b/specification/resources/volumes/models/attributes.yml
@@ -1,7 +1,5 @@
 volume_write_file_system_type:
   type: object
-  required:
-    - filesystem_type
   properties:
     filesystem_type:
       type: string

--- a/specification/resources/volumes/models/volumes_ext4.yml
+++ b/specification/resources/volumes/models/volumes_ext4.yml
@@ -14,4 +14,3 @@ allOf:
       - name
       - size_gigabytes
       - region
-      - filesystem_type


### PR DESCRIPTION
Resolved [PDOCS-1676](https://jira.internal.digitalocean.com/browse/PDOCS-1676) and PDOCS-1655. I've added the `project_id` field to the LBaaS docs and have removed the required tag from the Block Storage `filesystem_type` attribute.