### PR TITLE
Fix client gen: Add schema to App yaml responses

### DIFF
--- a/specification/resources/apps/apps_create.yml
+++ b/specification/resources/apps/apps_create.yml
@@ -2,11 +2,13 @@ operationId: apps_create
 
 summary: Create a New App
 
-description: Create a new app by submitting an app specification. For documentation
-  on app specifications (`AppSpec` objects), please refer to [the product documentation](https://docs.digitalocean.com/products/app-platform/reference/app-spec/).
+description:
+  Create a new app by submitting an app specification. For documentation
+  on app specifications (`AppSpec` objects), please refer to [the product
+  documentation](https://docs.digitalocean.com/products/app-platform/reference/app-spec/).
 
 tags:
-- Apps
+  - Apps
 
 parameters:
   - $ref: parameters.yml#/accept
@@ -34,6 +36,8 @@ requestBody:
               routes:
                 - path: /api
     application/yaml:
+      schema:
+        $ref: models/apps_create_app_request.yml
       example: |
         spec:
           name: web-app
@@ -53,16 +57,16 @@ requestBody:
   required: true
 
 responses:
-  "200":
+  '200':
     $ref: responses/new_app.yml
 
-  "401":
+  '401':
     $ref: ../../shared/responses/unauthorized.yml
 
-  "429":
-    $ref: "../../shared/responses/too_many_requests.yml"
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
 
-  "500":
+  '500':
     $ref: ../../shared/responses/server_error.yml
 
   default:
@@ -73,4 +77,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'write'
+      - 'write'

--- a/specification/resources/apps/responses/new_app.yml
+++ b/specification/resources/apps/responses/new_app.yml
@@ -8,8 +8,9 @@ content:
       app:
         $ref: examples.yml#/app
   application/yaml:
+    schema:
+      $ref: ../models/app_response.yml
     example: |
-      ---
       app:
         id: c2a93513-8d9b-4223-9d61-5e7272c81cf5
         owner_uuid: a4e16f25-cdd1-4483-b246-d77f283c9209
@@ -121,7 +122,6 @@ content:
         tier_slug: basic
         live_url_base: https://sample-golang-zyhgn.ondigitalocean.app
         live_domain: sample-golang-zyhgn.ondigitalocean.app
-
 
 headers:
   ratelimit-limit:

--- a/spectral/functions/ensureSchemaHasType.js
+++ b/spectral/functions/ensureSchemaHasType.js
@@ -1,0 +1,32 @@
+/*
+ * Ensures all schemas have a type defined
+ *
+ * Based on:
+ * https://github.com/box/box-openapi/blob/184889a4b5b6156e0e2719bd513d93f994c6c50e/src/spectral/ensureSchemaHasType.js
+ */
+
+function hasTypeOrRef(contentType) {
+    const allowed = ['type', '$ref', 'anyOf', 'allOf', 'oneOf'];
+    for (const key in allowed) {
+        if (schema.hasOwnProperty(key)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+module.exports = (contentType, _, context) => {
+    let path = context.path.join('.')
+    if (!contentType.schema) {
+        return [{
+            message: `missing schema for ${path}`
+        }]
+    }
+    let schema = contentType.schema;
+    if (schema.oneOf || schema.allOf || schema.anyOf) { return };
+    if (!schema.type && !schema['$ref']) {
+        return [{
+            message: `schema must have 'type' or '$ref': ${path}`
+        }]
+    }
+}

--- a/spectral/ruleset.yml
+++ b/spectral/ruleset.yml
@@ -1,8 +1,20 @@
 functions:
   - ensurePropertiesExample
   - ensureAllArraysHaveItemTypes
+  - ensureSchemaHasType
   - ensureSnakeCaseWithDigits
   - validateOpIDNaming
+
+overrides:
+  - files:
+      - 'tests/openapi-bundled.yaml'
+    rules:
+      endpoint-must-be-ref: off
+  - files:
+      - 'specification/resources/apps/apps_create.yml#/requestBody/content/application~1yaml'
+      - 'tests/openapi-bundled.yaml#/paths/~1v2~1apps/post/requestBody/content/application~1yaml'
+    rules:
+      oas3-valid-media-example: off
 
 rules:
   ratelimit-headers:
@@ -174,19 +186,28 @@ rules:
     message: '{{error}}'
     then:
       function: ensureSnakeCaseWithDigits
-  
+
   oas3-operation-security-defined:
     description: Check operation security is defined
-    severity: "error"
-    given: "$.paths.*.*"
+    severity: 'error'
+    given: '$.paths.*.*'
     then:
       field: 'security'
       function: truthy
 
   oas3-operation-security-scopes-defined:
     description: Check operation security's bearer_auth is defined
-    severity: "error"
-    given: "$.paths[*][*]..security.*"
+    severity: 'error'
+    given: '$.paths[*][*]..security.*'
     then:
       field: 'bearer_auth'
       function: truthy
+
+  application-content-must-have-type-or-ref:
+    description: application/* content must have a type
+    given: $..content[*]
+    severity: error
+    recommended: true
+    message: '{{error}}'
+    then:
+      function: ensureSchemaHasType


### PR DESCRIPTION
Client generation has been failing with the following error:

```
warning | Modeler/MissingType | The schema 'region-features' has no type or format information whatsoever. Location:
   file:///Users/cgarza/dev/external/digitalocean-client-python/DigitalOcean-public.v2.yaml#/components/schemas/region-features
warning | Modeler/MissingType | The schema 'region-sizes' has no type or format information whatsoever. Location:
   file:///Users/cgarza/dev/external/digitalocean-client-python/DigitalOcean-public.v2.yaml#/components/schemas/region-sizes
fatal   | TypeError: Cannot read properties of undefined (reading 'type')
fatal   | Process() cancelled due to failure
error   |   Error: Plugin modelerfour reported failure.
error   | Autorest completed with an error. If you think the error message is unclear, or is a bug, please declare an issues at https://github.com/Azure/autorest/issues with the error message you are seeing.
make: *** [generate] Error 1
```

I was able to track it down to the changes in #732 adding the `application/yaml` content type responses in the App create request. I believe autorest requires a type for any `application/*` content.

Unfortunately, adding the schema triggers the `oas3-valid-media-example` rule to error with `"example" property type must be object ` for:  
* `components.responses.new_app.content.text/yaml.example` 
* `paths./v2/apps.post.requestBody.content.application/yaml.example`

Also, running `make lint` has been inconsistent when checking the ref'd spec. Sometimes it will fail with the following and others, without changing anything, it wont.

```
/Users/cgarza/dev/external/openapi/specification/resources/apps/apps_create.yml
 41:16  error  oas3-valid-media-example  "example" property type must be object  requestBody.content.application/yaml.example
```