### PR TITLE
Fix: failed Generate Main preview workflow

### DIFF
--- a/.github/workflows/spec.main.yml
+++ b/.github/workflows/spec.main.yml
@@ -47,8 +47,9 @@ jobs:
           ${{ secrets.SPACES_PATH }}/DigitalOcean-public.v2.yaml
           --endpoint=${{ secrets.SPACES_ENDPOINT }}
           --acl public-read
-      # the spec that will be associated with the generated Pydo client
       - name: Upload revision spec
+        # this uploads a duplicate of the bundled spec with the short sha
+        # appended to the file name for reference during client generation.
         run: >-
           aws s3 cp tests/openapi-bundled.yaml
           ${{ secrets.SPACES_PATH }}/DigitalOcean-public-${{ steps.vars.outputs.sha_short }}.v2.yaml

--- a/.github/workflows/spec.main.yml
+++ b/.github/workflows/spec.main.yml
@@ -10,7 +10,6 @@ on:
       - 'spectral/**'
 
 jobs:
-
   lint:
     name: Validate style
     runs-on: ubuntu-latest
@@ -45,15 +44,15 @@ jobs:
       - name: Upload Main spec
         run: >-
           aws s3 cp tests/openapi-bundled.yaml
-          ${{ env.SPACES_PATH }}/DigitalOcean-public.v2.yaml
-          --endpoint=${{ env.SPACES_ENDPOINT }}
+          ${{ secrets.SPACES_PATH }}/DigitalOcean-public.v2.yaml
+          --endpoint=${{ secrets.SPACES_ENDPOINT }}
           --acl public-read
-    # the spec that will be associated with the generated Pydo client    
+      # the spec that will be associated with the generated Pydo client
       - name: Upload revision spec
         run: >-
           aws s3 cp tests/openapi-bundled.yaml
-          ${{ env.SPACES_PATH }}/DigitalOcean-public-${{ steps.vars.outputs.sha_short }}.v2.yaml
-          --endpoint=${{ env.SPACES_ENDPOINT }}
+          ${{ secrets.SPACES_PATH }}/DigitalOcean-public-${{ steps.vars.outputs.sha_short }}.v2.yaml
+          --endpoint=${{ secrets.SPACES_ENDPOINT }}
           --acl public-read
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.SPACES_ACCESS_KEY }}


### PR DESCRIPTION
The latest run of the `spec.main.yml` workflow [failed to publish the bundled spec](https://github.com/digitalocean/openapi/actions/runs/3381370539/jobs/5615454389) because it wasn't able to evaluate the `SPACES_PATH` and `SPACES_ENDPOINT` secrets. It turns out these were referenced as `env.SPACES...`. 
This config hasn't changed in quite some time so I'm not sure why it stopped working but this change hopefully resolves it.

