### PR TITLE
volumes: filesystem_type is not required.

### DIFF
--- a/specification/resources/volumes/models/attributes.yml
+++ b/specification/resources/volumes/models/attributes.yml
@@ -1,7 +1,5 @@
 volume_write_file_system_type:
   type: object
-  required:
-    - filesystem_type
   properties:
     filesystem_type:
       type: string
@@ -15,11 +13,6 @@ volume_write_file_system_type:
         or after April 26, 2018.
         Attaching pre-formatted volumes to other Droplets is not recommended.
       example: ext4
-  discriminator:
-    propertyName: filesystem_type
-    mapping:
-      EXT4: "./volumes_ext4.yml"
-      XFS: "./volumes_xfs.yml"
 
 volume_write_file_system_label:
   type: string

--- a/specification/resources/volumes/models/volumes_ext4.yml
+++ b/specification/resources/volumes/models/volumes_ext4.yml
@@ -14,4 +14,3 @@ allOf:
       - name
       - size_gigabytes
       - region
-      - filesystem_type

--- a/specification/resources/volumes/models/volumes_xfs.yml
+++ b/specification/resources/volumes/models/volumes_xfs.yml
@@ -14,4 +14,3 @@ allOf:
       - name
       - size_gigabytes
       - region
-      - filesystem_type

--- a/specification/resources/volumes/volumes_create.yml
+++ b/specification/resources/volumes/volumes_create.yml
@@ -24,11 +24,6 @@ requestBody:
         anyOf:
           - $ref: 'models/volumes_ext4.yml'
           - $ref: 'models/volumes_xfs.yml'
-        discriminator:
-          propertyName: filesystem_type
-          mapping:
-            ext4: 'models/volumes_ext4.yml'
-            xfs: 'models/volumes_xfs.yml'
       examples:
         ext4 volume:
           value:


### PR DESCRIPTION
As pointed out in https://github.com/digitalocean/openapi/pull/737 `filesystem_type` is not actually required for creating a volume. As is, making it not required causes issues with client generation due to our use of a discriminator:

```
error   | DiscriminatorNotRequired | Semantic violation: Discriminator must be a required property. (components > schemas > volumewrite_file_systemtype)
  discriminator: {
  propertyName: 'filesystem_type',
  mapping: {
    EXT4: '#/components/schemas/volumes_ext4',
    XFS: '#/components/schemas/volumes_xfs'
  }
}
```

The discriminator is only being used to change the character constrains for `filesystem_label`. An XFS volume can have a 16 character label while an EXT4 once can only have 12 characters. We can simplify this and just relay on `anyOf` for the same purpose. It does change the display, but allows for an accurate discription of the API.

Current:

![image](https://user-images.githubusercontent.com/46943/200007856-4efc23cb-9fe0-4d62-aeb8-766659d899dd.png)


Proposed change:

![image](https://user-images.githubusercontent.com/46943/200008537-92f75863-f86e-4383-b389-13e7be910e61.png)
