### PR TITLE
client gen trigger: checkout code before setting output.

### DIFF
--- a/.github/workflows/trigger-python-client-gen.yml
+++ b/.github/workflows/trigger-python-client-gen.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - name: Check out code
+        uses: actions/checkout@v2
       - name: Set outputs
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"


### PR DESCRIPTION
The "Trigger Python Client Generation" workflow is failing. The `openapi_short_sha` is empty. 

https://github.com/digitalocean/openapi/actions/workflows/trigger-python-client-gen.yml