### PR TITLE
Install Poetry for client generation workflow.

### DIFF
--- a/.github/workflows/spec.pr.yml
+++ b/.github/workflows/spec.pr.yml
@@ -97,6 +97,15 @@ jobs:
           repository: digitalocean/digitalocean-client-python
           token: ${{ secrets.WORKFLOW_TRIGGER_TOKEN }}
 
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.3.1
+        with:
+          version: 1.1.13
+          virtualenvs-path: .venv
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: false
+
       - uses: actions/download-artifact@v3
         with:
           name: openapi-bundled


### PR DESCRIPTION
With https://github.com/digitalocean/pydo/pull/114, the generation workflow now calls `poetry`, but we don't install it here. This leads to the workflow failing:

https://github.com/digitalocean/openapi/actions/runs/3413655909/jobs/5680646383#step:5:615