### PR TITLE
Add environment to validate-client-gen PR check

### DIFF
--- a/.github/workflows/spec.pr.yml
+++ b/.github/workflows/spec.pr.yml
@@ -90,12 +90,14 @@ jobs:
     needs:
       - bundle-spec
 
+    environment: PR
+
     steps:
-      - name: Check out digitalocean-client-python repo
+      - name: Check out pydo repo
         uses: actions/checkout@v2
         with:
-          repository: digitalocean/digitalocean-client-python
-          token: ${{ secrets.WORKFLOW_TRIGGER_TOKEN }}
+          repository: digitalocean/pydo
+          token: ${{ secrets.PYDO_GITHUB_TOKEN }}
 
       - name: Install Poetry
         uses: snok/install-poetry@v1.3.1


### PR DESCRIPTION
The `Validate client generation` PR check currently fails on PRs from forks due to not having access to required secrets.

```
Error: Input required and not supplied: token
```

This change configures the workflow job to use a deployment environment. This will make the check require approval by someone in @digitalocean/api-cli for PRs from forks.

For APICLI-1503