### PR TITLE
kubernetes: add high availability flag to cluster update

### DIFF
--- a/specification/resources/kubernetes/models/cluster.yml
+++ b/specification/resources/kubernetes/models/cluster.yml
@@ -147,7 +147,7 @@ properties:
     example: true
     description: A boolean value indicating whether the control plane
       is run in a highly available configuration in the cluster. Highly available
-      control planes incur less downtime. 
+      control planes incur less downtime. The property cannot be disabled.
 
   registry_enabled:
     type: boolean

--- a/specification/resources/kubernetes/models/cluster_update.yml
+++ b/specification/resources/kubernetes/models/cluster_update.yml
@@ -37,5 +37,13 @@ properties:
       fast and reliable by bringing up new nodes before destroying the outdated
       nodes.
 
+  ha:
+    type: boolean
+    default: false
+    example: true
+    description: A boolean value indicating whether the control plane
+      is run in a highly available configuration in the cluster. Highly available
+      control planes incur less downtime. The property cannot be disabled.
+
 required:
   - name


### PR DESCRIPTION
Also clarify that the property cannot be disabled once enabled.