### PR TITLE
Add missing pagination

### DIFF
--- a/specification/resources/billing/invoices_list.yml
+++ b/specification/resources/billing/invoices_list.yml
@@ -9,6 +9,10 @@ description: >-
 tags:
   - Billing
 
+parameters:
+  - $ref: '../../shared/parameters.yml#/per_page'
+  - $ref: '../../shared/parameters.yml#/page'
+
 responses:
   '200':
     $ref: 'responses/invoices.yml'

--- a/specification/resources/domains/domains_list.yml
+++ b/specification/resources/domains/domains_list.yml
@@ -9,6 +9,10 @@ description: >-
 tags:
   - Domains
 
+parameters:
+  - $ref: '../../shared/parameters.yml#/per_page'
+  - $ref: '../../shared/parameters.yml#/page'
+
 responses:
   '200':
     $ref: 'responses/all_domains_response.yml'

--- a/specification/resources/domains/domains_list_records.yml
+++ b/specification/resources/domains/domains_list_records.yml
@@ -21,6 +21,8 @@ parameters:
   - $ref: 'parameters.yml#/domain_name'
   - $ref: 'parameters.yml#/domain_name_query'
   - $ref: 'parameters.yml#/domain_type_query'
+  - $ref: '../../shared/parameters.yml#/per_page'
+  - $ref: '../../shared/parameters.yml#/page'
 
 responses:
   '200':

--- a/specification/resources/floating_ips/floatingIPs_list.yml
+++ b/specification/resources/floating_ips/floatingIPs_list.yml
@@ -8,6 +8,10 @@ description: To list all of the floating IPs available on your account, send a
 tags:
   - Floating IPs
 
+parameters:
+  - $ref: '../../shared/parameters.yml#/per_page'
+  - $ref: '../../shared/parameters.yml#/page'
+
 responses:
   '200':
     $ref: 'responses/floating_ip_list.yml'

--- a/specification/resources/projects/projects_list.yml
+++ b/specification/resources/projects/projects_list.yml
@@ -7,6 +7,10 @@ description: To list all your projects, send a GET request to `/v2/projects`.
 tags:
   - Projects
 
+parameters:
+  - $ref: '../../shared/parameters.yml#/per_page'
+  - $ref: '../../shared/parameters.yml#/page'
+
 responses:
   '200':
     $ref: 'responses/projects_list.yml'

--- a/specification/resources/projects/projects_list_resources.yml
+++ b/specification/resources/projects/projects_list_resources.yml
@@ -10,6 +10,8 @@ tags:
 
 parameters:
   - $ref: 'parameters.yml#/project_id'
+  - $ref: '../../shared/parameters.yml#/per_page'
+  - $ref: '../../shared/parameters.yml#/page'
 
 responses:
   '200':

--- a/specification/resources/reserved_ips/reservedIPs_list.yml
+++ b/specification/resources/reserved_ips/reservedIPs_list.yml
@@ -8,6 +8,10 @@ description: To list all of the reserved IPs available on your account, send a
 tags:
   - Reserved IPs
 
+parameters:
+  - $ref: '../../shared/parameters.yml#/per_page'
+  - $ref: '../../shared/parameters.yml#/page'
+
 responses:
   '200':
     $ref: 'responses/reserved_ip_list.yml'


### PR DESCRIPTION
Updating multiple endpoints that support pagination that was not documented in the API.

To verify that a specific `list` endpoint supported pagination, I checked if its' associated endpoint in Godo had the following code:

```
	if l := root.Links; l != nil {
		resp.Links = l
	}
	if m := root.Meta; m != nil {
		resp.Meta = m
	}
```
From there, I deduced that the endpoint supported pagination. For example, [here](https://github.com/digitalocean/godo/blob/main/reserved_ips.go#L86-L91)

This will resolve the Pydo issue opened [here](https://github.com/digitalocean/pydo/issues/147).

