### PR TITLE
Removed underscore from Volumes example 

### DIFF
--- a/specification/resources/volumes/volumes_create.yml
+++ b/specification/resources/volumes/volumes_create.yml
@@ -28,7 +28,7 @@ requestBody:
         ext4 volume:
           value:
             size_gigabytes: 10
-            name: ext4_example
+            name: ext4-example
             description: Block store for examples
             region: nyc1
             filesystem_type: ext4


### PR DESCRIPTION
You can't use underscores in a volume name. I've updated the volume create example to reflect this.