### PR TITLE
apps: Add all supported regions.

### DIFF
--- a/specification/resources/apps/models/app_spec.yml
+++ b/specification/resources/apps/models/app_spec.yml
@@ -18,6 +18,12 @@ properties:
     - ams
     - nyc
     - fra
+    - sfo
+    - sgp
+    - blr
+    - tor
+    - lon
+    - syd
     example: nyc
 
   domains:


### PR DESCRIPTION
```
$ doctl apps list-regions 
Region    Label            Continent        Data Centers    Is Disabled?    Reason (if disabled)    Is Default?
ams       Amsterdam        Europe           [ams3]          false                                   false
nyc       New York         North America    [nyc1 nyc3]     false                                   true
fra       Frankfurt        Europe           [fra1]          false                                   false
sfo       San Francisco    North America    [sfo3]          false                                   false
sgp       Singapore        Asia             [sgp1]          false                                   false
blr       Bangalore        Asia             [blr1]          false                                   false
tor       Toronto          North America    [tor1]          false                                   false
lon       London           Europe           [lon1]          false                                   false
syd       Sydney           Australia        [syd1]          false                                   false
```