### PR TITLE
intro: link directly to tokens page to avoid redirect.

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -318,11 +318,11 @@ tags:
       configurations requiring movable addresses.
 
       Floating IPs are bound to a specific region.
-  
+
   - name: Functions
     description: |-
       [Serverless functions](https://docs.digitalocean.com/products/functions) are blocks of code that run on demand without the need to manage any infrastructure.
-      You can develop functions on your local machine and then deploy them to a namespace using `doctl`, the [official DigitalOcean CLI tool](https://docs.digitalocean.com/reference/doctl). 
+      You can develop functions on your local machine and then deploy them to a namespace using `doctl`, the [official DigitalOcean CLI tool](https://docs.digitalocean.com/reference/doctl).
 
       The Serverless Functions API currently only supports creating and managing namespaces.
 
@@ -515,8 +515,8 @@ tags:
 
   - name: Uptime
     description: >-
-        [DigitalOcean Uptime Checks](https://docs.digitalocean.com/products/uptime/) provide the ability to monitor your endpoints from around the world, and alert you when they're slow, unavailable, or SSL certificates are expiring. 
-        
+        [DigitalOcean Uptime Checks](https://docs.digitalocean.com/products/uptime/) provide the ability to monitor your endpoints from around the world, and alert you when they're slow, unavailable, or SSL certificates are expiring.
+
         To interact with Uptime, you will generally send requests to the Uptime endpoint at `/v2/uptime/`.
 
   - name: VPCs
@@ -595,7 +595,7 @@ paths:
     post:
       $ref: 'resources/apps/apps_cancel_deployment.yml'
 
-  /v2/apps/{app_id}/deployments/{deployment_id}/components/{component_name}/logs: 
+  /v2/apps/{app_id}/deployments/{deployment_id}/components/{component_name}/logs:
     get:
       $ref: 'resources/apps/apps_get_logs.yml'
 
@@ -1528,7 +1528,7 @@ components:
         authorization. OAuth allows you to delegate access to your account in full
         or in read-only mode.
 
-        You can generate an OAuth token by visiting the [Apps & API](https://cloud.digitalocean.com/settings/api/tokens)
+        You can generate an OAuth token by visiting the [Apps & API](https://cloud.digitalocean.com/account/api/tokens)
         section of the DigitalOcean control panel for your account.
 
         An OAuth token functions as a complete authentication request. In effect, it


### PR DESCRIPTION
Just happened to notice that we link to the old URL for the tokens page in the control panel. This updates it to avoid the redirect.