### PR TITLE
DBAAS-3885: Include updatePool

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -821,6 +821,8 @@ paths:
   /v2/databases/{database_cluster_uuid}/pools/{pool_name}:
     get:
       $ref: 'resources/databases/databases_get_connectionPool.yml'
+    put:
+      $ref: 'resources/databases/databases_update_connectionPool.yml'
     delete:
       $ref: 'resources/databases/databases_delete_connectionPool.yml'
 

--- a/specification/resources/databases/databases_update_connectionPool.yml
+++ b/specification/resources/databases/databases_update_connectionPool.yml
@@ -9,6 +9,18 @@ description: >-
 tags:
   - Databases
 
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: 'models/connection_pool_update.yml'
+      example:
+        mode: transaction
+        size: 10
+        db: defaultdb
+        user: doadmin
+
 parameters:
   - $ref: 'parameters.yml#/database_cluster_uuid'
   - $ref: 'parameters.yml#/pool_name'
@@ -34,6 +46,7 @@ responses:
 
 x-codeSamples:
   - $ref: 'examples/curl/databases_update_connectionPool.yml'
+  - $ref: 'examples/go/databases_update_connectionPool.yml'
 
 security:
   - bearer_auth:

--- a/specification/resources/databases/databases_update_connectionPool.yml
+++ b/specification/resources/databases/databases_update_connectionPool.yml
@@ -1,0 +1,41 @@
+operationId: databases_update_connectionPool
+
+summary: Update Connection Pools (PostgreSQL)
+
+description: >-
+  To update a connection pool for a PostgreSQL database cluster, send a PUT request to 
+  `/v2/databases/$DATABASE_ID/pools/$POOL_NAME`.
+
+tags:
+  - Databases
+
+parameters:
+  - $ref: 'parameters.yml#/database_cluster_uuid'
+  - $ref: 'parameters.yml#/pool_name'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/databases_update_connectionPool.yml'
+
+security:
+  - bearer_auth:
+    - 'read'
+

--- a/specification/resources/databases/examples/curl/databases_update_connectionPool.yml
+++ b/specification/resources/databases/examples/curl/databases_update_connectionPool.yml
@@ -5,6 +5,3 @@ source: |-
   -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
   -d '{"mode": "transaction", "size": 15, "db": "defaultdb", "user": "doadmin"}' \
   "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/pools/backend-pool" 
-
-
-

--- a/specification/resources/databases/examples/curl/databases_update_connectionPool.yml
+++ b/specification/resources/databases/examples/curl/databases_update_connectionPool.yml
@@ -1,0 +1,10 @@
+lang: cURL
+source: |-
+  curl -X PUT \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+  -d '{"mode": "transaction", "size": 15, "db": "defaultdb", "user": "doadmin"}' \
+  "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/pools/backend-pool" 
+
+
+

--- a/specification/resources/databases/examples/go/databases_update_connectionPool.yml
+++ b/specification/resources/databases/examples/go/databases_update_connectionPool.yml
@@ -1,0 +1,23 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      pat := "mytoken"
+
+      client := godo.NewFromToken(pat)
+      ctx := context.TODO()
+
+      updateReq := &godo.DatabaseUpdatePoolRequest{
+          User:     "doadmin",
+          Size:     15,
+          Database: "defaultdb",
+          Mode:     "transaction",
+      }
+
+      _, err := client.Databases.UpdatePool(ctx, "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30", "backend-pool", updateReq)
+
+  }

--- a/specification/resources/databases/models/connection_pool_update.yml
+++ b/specification/resources/databases/models/connection_pool_update.yml
@@ -1,0 +1,35 @@
+type: object
+
+properties:
+  mode:
+    type: string
+    description: >-
+      The PGBouncer transaction mode for the connection pool. The allowed
+      values are session, transaction, and statement.
+    example: transaction
+  size:
+    type: integer
+    format: int32
+    description: >-
+      The desired size of the PGBouncer connection pool. The maximum allowed
+      size is determined by the size of the cluster's primary node. 25 backend
+      server connections are allowed for every 1GB of RAM. Three are reserved
+      for maintenance. For example, a primary node with 1 GB of RAM allows for
+      a maximum of 22 backend server connections while one with 4 GB would
+      allow for 97. Note that these are shared across all connection pools in
+      a cluster.
+    example: 10
+  db:
+    type: string
+    description: The database for use with the connection pool.
+    example: defaultdb
+  user:
+    type: string
+    description: >-
+      The name of the user for use with the connection pool. When excluded,
+      all sessions connect to the database as the inbound user.
+    example: doadmin
+required:
+  - mode
+  - size
+  - db


### PR DESCRIPTION
Includes `updatePool`, which allows PostgreSQL pools to be updated via API (`/v2/databases/$database_cluster_uuid/pools/$pool_name`)