### PR TITLE
Add OpenAPI specification for apps bandwidth usage endpoints

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -651,6 +651,14 @@ paths:
     post:
       $ref: 'resources/apps/apps_revert_rollback.yml'
 
+  /v2/apps/{app_id}/metrics/bandwidth_daily:
+    get:
+      $ref: 'resources/apps/apps_get_metrics_bandwidth_usage.yml'
+
+  /v2/apps/metrics/bandwidth_daily:
+    post:
+      $ref: 'resources/apps/apps_list_metrics_bandwidth_usage.yml'
+
   /v2/cdn/endpoints:
     get:
       $ref: 'resources/cdn/cdn_list_endpoints.yml'

--- a/specification/resources/apps/apps_get_metrics_bandwidth_usage.yml
+++ b/specification/resources/apps/apps_get_metrics_bandwidth_usage.yml
@@ -1,0 +1,44 @@
+operationId: apps_get_metrics_bandwidth_daily
+
+summary: 'Retrieve App Daily Bandwidth Metrics'
+
+description: 'Retrieve daily bandwidth usage metrics for a single app.'
+
+tags:
+  - Apps
+
+parameters:
+  - $ref: parameters.yml#/app_id
+  - name: date
+    description: 'Optional day to query. Only the date component of the timestamp will be considered. Default: yesterday.'
+    in: query
+    schema:
+      type: string
+      format: date-time
+    example: 2023-01-17T00:00:00Z
+
+responses:
+  "200":
+    $ref: responses/get_metrics_bandwidth_usage.yml
+  
+  "401":
+    $ref: ../../shared/responses/unauthorized.yml
+
+  "404":
+    $ref: ../../shared/responses/not_found.yml
+
+  "429":
+    $ref: ../../shared/responses/too_many_requests.yml
+
+  "500":
+    $ref: ../../shared/responses/server_error.yml
+
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+
+x-codeSamples:
+  - $ref: examples/curl/apps_get_metrics_bandwidth_usage.yml
+
+security:
+  - bearer_auth:
+      - read

--- a/specification/resources/apps/apps_list_metrics_bandwidth_usage.yml
+++ b/specification/resources/apps/apps_list_metrics_bandwidth_usage.yml
@@ -1,0 +1,46 @@
+operationId: apps_list_metrics_bandwidth_daily
+
+summary: "Retrieve Multiple Apps' Daily Bandwidth Metrics"
+
+description: 'Retrieve daily bandwidth usage metrics for multiple apps.'
+
+tags:
+  - Apps
+
+requestBody:
+  content:
+    application/json:
+      schema:
+        $ref: models/app_metrics_bandwidth_usage_request.yml
+      example:
+        app_ids:
+          - 4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf
+          - c2a93513-8d9b-4223-9d61-5e7272c81cf5
+        date: 2023-01-17T00:00:00Z
+  required: true
+
+responses:
+  "200":
+    $ref: responses/list_metrics_bandwidth_usage.yml
+  
+  "401":
+    $ref: ../../shared/responses/unauthorized.yml
+
+  "404":
+    $ref: ../../shared/responses/not_found.yml
+
+  "429":
+    $ref: ../../shared/responses/too_many_requests.yml
+
+  "500":
+    $ref: ../../shared/responses/server_error.yml
+
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+
+x-codeSamples:
+  - $ref: examples/curl/apps_list_metrics_bandwidth_usage.yml
+
+security:
+  - bearer_auth:
+      - read

--- a/specification/resources/apps/examples/curl/apps_get_metrics_bandwidth_usage.yml
+++ b/specification/resources/apps/examples/curl/apps_get_metrics_bandwidth_usage.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/apps/{id}/metrics/bandwidth_daily"

--- a/specification/resources/apps/examples/curl/apps_list_metrics_bandwidth_usage.yml
+++ b/specification/resources/apps/examples/curl/apps_list_metrics_bandwidth_usage.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/apps/metrics/bandwidth_daily" \
+    -d '{ "app_ids": ["4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf"] }'

--- a/specification/resources/apps/models/app_metrics_bandwidth_usage.yml
+++ b/specification/resources/apps/models/app_metrics_bandwidth_usage.yml
@@ -1,0 +1,12 @@
+type: object
+properties:
+  app_bandwidth_usage:
+    type: array
+    items:
+      $ref: ../models/app_metrics_bandwidth_usage_details.yml
+    description: 'A list of bandwidth usage details by app.'
+  date:
+    type: string
+    format: date-time
+    description: 'The date for the metrics data.'
+    example: 2023-01-17T00:00:00Z

--- a/specification/resources/apps/models/app_metrics_bandwidth_usage_details.yml
+++ b/specification/resources/apps/models/app_metrics_bandwidth_usage_details.yml
@@ -1,0 +1,12 @@
+type: object
+properties:
+  app_id:
+    type: string
+    description: 'The ID of the app.'
+    example: 4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf
+  bandwidth_bytes:
+    type: string
+    format: uint64
+    description: 'The used bandwidth amount in bytes.'
+    example: '513668'
+description: 'Bandwidth usage for an app.'

--- a/specification/resources/apps/models/app_metrics_bandwidth_usage_request.yml
+++ b/specification/resources/apps/models/app_metrics_bandwidth_usage_request.yml
@@ -1,0 +1,18 @@
+type: object
+properties:
+  app_ids:
+    type: array
+    items:
+      type: string
+    description: 'A list of app IDs to query bandwidth metrics for.'
+    maxItems: 100
+    example:
+      - 4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf
+      - c2a93513-8d9b-4223-9d61-5e7272c81cf5
+  date:
+    type: string
+    format: date-time
+    description: 'Optional day to query. Only the date component of the timestamp will be considered. Default: yesterday.'
+    example: 2023-01-17T00:00:00Z
+required:
+  - app_ids

--- a/specification/resources/apps/responses/examples.yml
+++ b/specification/resources/apps/responses/examples.yml
@@ -618,3 +618,19 @@ alert:
           status: SUCCESS
           started_at: 2020-07-28T18:00:00Z
           ended_at: 2020-07-28T18:00:00Z
+
+app_bandwidth_usage:
+  value:
+    app_bandwidth_usage:
+      - app_id: 4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf
+        bandwidth_bytes: '513668'
+    date: 2023-01-17T00:00:00Z
+
+app_bandwidth_usage_multiple:
+  value:
+    app_bandwidth_usage:
+      - app_id: 4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf
+        bandwidth_bytes: '513668'
+      - app_id: c2a93513-8d9b-4223-9d61-5e7272c81cf5
+        bandwidth_bytes: '254847'
+    date: 2023-01-17T00:00:00Z

--- a/specification/resources/apps/responses/get_metrics_bandwidth_usage.yml
+++ b/specification/resources/apps/responses/get_metrics_bandwidth_usage.yml
@@ -1,0 +1,17 @@
+description: 'A JSON object with a `app_bandwidth_usage` key'
+
+content:
+  application/json:
+    schema:
+      $ref: ../models/app_metrics_bandwidth_usage.yml
+    examples:
+      app_bandwidth_usage:
+        $ref: examples.yml#/app_bandwidth_usage
+
+headers:
+  ratelimit-limit:
+    $ref: ../../../shared/headers.yml#/ratelimit-limit
+  ratelimit-remaining:
+    $ref: ../../../shared/headers.yml#/ratelimit-remaining
+  ratelimit-reset:
+    $ref: ../../../shared/headers.yml#/ratelimit-reset

--- a/specification/resources/apps/responses/list_metrics_bandwidth_usage.yml
+++ b/specification/resources/apps/responses/list_metrics_bandwidth_usage.yml
@@ -1,0 +1,17 @@
+description: 'A JSON object with a `app_bandwidth_usage` key'
+
+content:
+  application/json:
+    schema:
+      $ref: ../models/app_metrics_bandwidth_usage.yml
+    examples:
+      app_bandwidth_usage:
+        $ref: examples.yml#/app_bandwidth_usage_multiple
+
+headers:
+  ratelimit-limit:
+    $ref: ../../../shared/headers.yml#/ratelimit-limit
+  ratelimit-remaining:
+    $ref: ../../../shared/headers.yml#/ratelimit-remaining
+  ratelimit-reset:
+    $ref: ../../../shared/headers.yml#/ratelimit-reset


### PR DESCRIPTION
Updates OpenAPI specification with the new apps bandwidth usage-related endpoints:

```
POST /v2/apps/metrics/bandwidth_daily
GET  /v2/apps/{app_id}/metrics/bandwidth_daily
```