### PR TITLE
uptime checks: Mark additional fields as required.

### DIFF
--- a/specification/resources/uptime/create_check.yml
+++ b/specification/resources/uptime/create_check.yml
@@ -23,6 +23,9 @@ requestBody:
           - name
           - method
           - target
+          - regions
+          - type
+          - enabled
 
 responses:
   '201':

--- a/specification/resources/uptime/models/check.yml
+++ b/specification/resources/uptime/models/check.yml
@@ -60,11 +60,3 @@ check_updatable:
       example: true
       default: true
       description: A boolean value indicating whether the check is enabled/disabled.
-
-
-
-check_create:
-  type: object
-  properties:
-
-


### PR DESCRIPTION
While testing this endpoint, I found that there are additional fields that should be marked as required for creates.

```
$ curl -X POST \
>   -H "Content-Type: application/json" \
>   -H "Authorization: Bearer $DO_TOKEN" \
>   -d '{"name":"Landing page check","type":"https","target":"https://www.landingpage.com","regions":["us_east","eu_west"]}' \
>   "https://api.digitalocean.com/v2/uptime/checks"
{"id":"bad_request","message":"missing required field 'enabled'","request_id":"8cd119fa-89d3-488c-85fe-610217d58642"}

$ curl -X POST   -H "Content-Type: application/json"   -H "Authorization: Bearer $DO_TOKEN"   -d '{"name":"Landing page check","type":"https","target":"https://www.landingpage.com","enabled":true}'   "https://api.digitalocean.com/v2/uptime/checks"
{"id":"bad_request","message":"missing required field 'regions'","request_id":"456175a7-22f6-4efc-a5d4-f5905147edfc"}

$ curl -X POST   -H "Content-Type: application/json"   -H "Authorization: Bearer $DO_TOKEN"   -d '{"name":"Landing page check","target":"https://www.landingpage.com","regions":["us_east","eu_west"],"enabled":true}'   "https://api.digitalocean.com/v2/uptime/checks"
{"id":"bad_request","message":"missing required field 'type'","request_id":"06a6795e-6d38-4d90-9d0c-bb3c7aa759c2"}
```