### PR TITLE
databases: version attributes should be read-only.

### DIFF
--- a/specification/resources/databases/models/database_cluster.yml
+++ b/specification/resources/databases/models/database_cluster.yml
@@ -115,12 +115,14 @@ properties:
   version_end_of_life:
     type: string
     example: '2023-11-09T00:00:00Z'
+    readOnly: true
     description: >-
       A timestamp referring to the date when the particular version will no longer be supported. If null, the version
       does not have an end of life timeline.
   version_end_of_availability:
     type: string
     example: '2023-05-09T00:00:00Z'
+    readOnly: true
     description: >-
       A timestamp referring to the date when the particular version will no longer be available for creating new
       clusters. If null, the version does not have an end of availability timeline.


### PR DESCRIPTION
`version_end_of_life` and `version_end_of_availability` do not seem to be valid attributes for POST requests to create new database clusters. As such, they should be marked `readOnly: true`