### PR TITLE
Ensure PR status is posted for failed Python client generation.

### DIFF
--- a/.github/workflows/validate-client-generation.yml
+++ b/.github/workflows/validate-client-generation.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           SPEC_FILE=../openapi-bundled.yaml make generate
           make test-mocked
+
       - name: Results
         if: always()
         run: |
@@ -68,7 +69,9 @@ jobs:
             echo "test_result=failure" >> $GITHUB_ENV
             echo "check_description=Failed to validate generated client" >> $GITHUB_ENV
           fi
+
       - name: Update check on PR
+        if: always()
         run: |
           gh api --method POST -H "Accept: application/vnd.github+json" \
             /repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }} \


### PR DESCRIPTION
I happened to notice that if the "Validate Client Generation" fails, the status is never updated and left pending, e.g. in this PR https://github.com/digitalocean/openapi/pull/777.  `if: always()` is needed on the final step.