### PR TITLE
add ratelimit to cdn Endpoints

### DIFF
--- a/specification/description.yml
+++ b/specification/description.yml
@@ -234,6 +234,10 @@ introduction: |
 
   *   Only 12 `POST` requests to the `/v2/floating_ips` endpoint to create Floating IPs can be made per 60 seconds.
   *   Only 10 `GET` requests to the `/v2/account/keys` endpoint to list SSH keys can be made per 60 seconds.
+  *   Only 5 requests to any and all `v2/cdn/endpoints` can be made per 10 seconds. This includes `v2/cdn/endpoints`, 
+      `v2/cdn/endpoints/$ENDPOINT_ID`, and `v2/cdn/endpoints/$ENDPOINT_ID/cache`.
+  *   Only 50 strings within the `files` json struct in the `v2/cdn/endpoints/$ENDPOINT_ID/cache` [payload](https://docs.digitalocean.com/reference/api/api-reference/#operation/cdn_purge_cache) 
+      can be requested every 20 seconds.
 
   ### Sample Rate Limit Headers
 

--- a/specification/resources/cdn/cdn_purge_cache.yml
+++ b/specification/resources/cdn/cdn_purge_cache.yml
@@ -8,7 +8,8 @@ description: |
   a `files` attribute containing a list of cached file paths to be purged. A
   path may be for a single file or may contain a wildcard (`*`) to recursively
   purge all files under a directory. When only a wildcard is provided, all
-  cached files will be purged.
+  cached files will be purged. There is a rate limit of 50 files per 20 seconds 
+  that can be purged.
 
 tags:
   - CDN Endpoints


### PR DESCRIPTION
This PR adds documentation for the CDN Endpoint rate limits which are different than the regular rate limiting done by the DO api. 