### PR TITLE
build(deps): bump vm2 from 3.9.17 to 3.9.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4758,9 +4758,9 @@
       "dev": true
     },
     "node_modules/vm2": {
-      "version": "3.9.17",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
-      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQX3u0Aj3KWiXM0YAHy7i6JEeHrwOnwXbGYgRpAw==",
+      "version": "3.9.19",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
+      "integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.7.0",
@@ -8687,9 +8687,9 @@
       }
     },
     "vm2": {
-      "version": "3.9.17",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
-      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQX3u0Aj3KWiXM0YAHy7i6JEeHrwOnwXbGYgRpAw==",
+      "version": "3.9.19",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
+      "integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
       "dev": true,
       "requires": {
         "acorn": "^8.7.0",


### PR DESCRIPTION
Recreating  https://github.com/digitalocean/openapi/pull/804 so the testing can pass.