### PR TITLE
Volumes size_gigabytes clarification

### DIFF
--- a/specification/resources/volumes/models/volume_base.yml
+++ b/specification/resources/volumes/models/volume_base.yml
@@ -35,7 +35,9 @@ properties:
 
   size_gigabytes:
     type: integer
-    description: The size of the block storage volume in GiB (1024^3).
+    description: >- 
+      The size of the block storage volume in GiB (1024^3). This field does not apply 
+      when creating a volume from a snapshot.
     example: 10
 
   created_at:


### PR DESCRIPTION
This PR updates the description for the `size_gigabytes` field in Volumes. The field is not applicable when creating a volume from a snapshot.