### PR TITLE
Add readonly field for MongoDB

### DIFF
--- a/specification/resources/databases/databases_add_user.yml
+++ b/specification/resources/databases/databases_add_user.yml
@@ -38,6 +38,11 @@ requestBody:
             mysql_settings:
               auth_plugin: mysql_native_password
 
+        Add New Read Only User (MongoDB Only):
+          value:
+            name: my-readonly
+            readonly: true
+
 responses:
   '201':
     $ref: 'responses/user.yml'


### PR DESCRIPTION
Support for creating MongoDB read only users - merge is dependent on feature flag enablement.