### PR TITLE
Update Container Registry Endpoint Paths

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -1338,19 +1338,19 @@ paths:
     get:
       $ref: 'resources/registry/registry_list_repositoriesV2.yml'
 
-  /v2/registry/{registry_name}/{repository_name}/tags:
+  /v2/registry/{registry_name}/repositories/{repository_name}/tags:
     get:
       $ref: 'resources/registry/registry_list_repositoryTags.yml'
 
-  /v2/registry/{registry_name}/{repository_name}/tags/{repository_tag}:
+  /v2/registry/{registry_name}/repositories/{repository_name}/tags/{repository_tag}:
     delete:
       $ref: 'resources/registry/registry_delete_repositoryTag.yml'
 
-  /v2/registry/{registry_name}/{repository_name}/digests:
+  /v2/registry/{registry_name}/repositories/{repository_name}/digests:
     get:
       $ref: 'resources/registry/registry_list_repositoryManifests.yml'
 
-  /v2/registry/{registry_name}/{repository_name}/digests/{manifest_digest}:
+  /v2/registry/{registry_name}/repositories/{repository_name}/digests/{manifest_digest}:
     delete:
       $ref: 'resources/registry/registry_delete_repositoryManifest.yml'
 


### PR DESCRIPTION
We had a Pydo user [open a github issue](https://github.com/digitalocean/pydo/issues/173) regarding the [list registry repository tags endpoint](https://docs.digitalocean.com/reference/api/api-reference/#operation/registry_list_repositoryTags). 

Turns out the client wasn't working because we were documenting the wrong endpoint path for the container registry endpoints, resulting in a "Not Found" 404 error.