### PR TITLE
Update databases_update_firewall_rules.yml

### DIFF
--- a/specification/resources/databases/examples/curl/databases_update_firewall_rules.yml
+++ b/specification/resources/databases/examples/curl/databases_update_firewall_rules.yml
@@ -3,5 +3,5 @@ source: |-
   curl -X PUT \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-    -d '{"rules": [{"type": "ip_addr","value": "192.168.1.1"},{"type": "droplet","value": "163973392"},{"type": "k8s","value": "ff2a6c52-5a44-4b63-b99c-0e98e7a63d61"},{"type": "tag","value": "backend"]}' \
+    -d '{"rules": [{"type": "ip_addr","value": "192.168.1.1"},{"type": "droplet","value": "163973392"},{"type": "k8s","value": "ff2a6c52-5a44-4b63-b99c-0e98e7a63d61"},{"type": "tag","value": "backend"}]}' \
     "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/firewall"


### PR DESCRIPTION
Resolves PDOCS-1952. Added a missing bracket to the DBaaS firewall cURL example.