### PR TITLE
database user: Support readonly argument for MongoDB user creation.

### DIFF
--- a/specification/resources/databases/databases_add_user.yml
+++ b/specification/resources/databases/databases_add_user.yml
@@ -26,7 +26,16 @@ requestBody:
   content:
     application/json:
       schema:
-        $ref: 'models/database_user.yml'
+        allOf:
+        - $ref: 'models/database_user.yml'
+        - type: object
+          properties:
+            readonly:
+              type: boolean
+              example: true
+              description: |
+                For MongoDB clusters, set to `true` to create a read-only user.
+                This option is not currently supported for other database engines.
       examples:
         Add New User:
           value:


### PR DESCRIPTION
CC: @zbarahal-do, @dbrian57  