### PR TITLE
Kubernetes: improve description and semantics on labels

### DIFF
--- a/specification/resources/kubernetes/models/node_pool.yml
+++ b/specification/resources/kubernetes/models/node_pool.yml
@@ -66,8 +66,10 @@ kubernetes_node_pool_base:
       type: object
       nullable: true
       example: null
-      description: An object containing a set of Kubernetes labels. The keys and
-        are values are both user-defined.
+      description: An array of labels to apply to all nodes in a pool. Labels
+        will automatically be applied to all existing nodes and any subsequent
+        nodes added to the pool. Note that when a label is removed, it is not
+        deleted from the nodes in the pool.
 
     taints:
       type: array
@@ -75,7 +77,7 @@ kubernetes_node_pool_base:
         $ref: "#/kubernetes_node_pool_taint"
       description: An array of taints to apply to all nodes in a pool. Taints
         will automatically be applied to all existing nodes and any subsequent
-        nodes added to the pool. When a taint is removed, it is removed from
+        nodes added to the pool. When a taint is removed, it is deleted from
         all nodes in the pool.
 
     auto_scale:

--- a/specification/resources/kubernetes/models/node_pool.yml
+++ b/specification/resources/kubernetes/models/node_pool.yml
@@ -66,10 +66,10 @@ kubernetes_node_pool_base:
       type: object
       nullable: true
       example: null
-      description: An array of labels to apply to all nodes in a pool. Labels
-        will automatically be applied to all existing nodes and any subsequent
-        nodes added to the pool. Note that when a label is removed, it is not
-        deleted from the nodes in the pool.
+      description: An object of key/value mappings specifying labels to apply
+        to all nodes in a pool. Labels will automatically be applied to all
+        existing nodes and any subsequent nodes added to the pool. Note that
+        when a label is removed, it is not deleted from the nodes in the pool.
 
     taints:
       type: array


### PR DESCRIPTION
Make it clear that labels are not automatically removed from the corresponding Node objects if it is deleted in the API.