### PR TITLE
Linting: Increase Incorrect OperationId Naming Severity to Error

### DIFF
--- a/specification/resources/uptime/create_alert.yml
+++ b/specification/resources/uptime/create_alert.yml
@@ -1,4 +1,4 @@
-operationId: uptime_alert_create
+operationId: uptime_create_alert
 
 summary: Create a New Alert
 

--- a/specification/resources/uptime/create_check.yml
+++ b/specification/resources/uptime/create_check.yml
@@ -1,4 +1,4 @@
-operationId: uptime_check_create
+operationId: uptime_create_check
 
 summary: Create a New Check
 

--- a/specification/resources/uptime/delete_alert.yml
+++ b/specification/resources/uptime/delete_alert.yml
@@ -1,4 +1,4 @@
-operationId: uptime_alert_delete
+operationId: uptime_delete_alert
 
 summary: Delete an Alert
 

--- a/specification/resources/uptime/delete_check.yml
+++ b/specification/resources/uptime/delete_check.yml
@@ -1,4 +1,4 @@
-operationId: uptime_check_delete
+operationId: uptime_delete_check
 
 summary: Delete a Check
 

--- a/specification/resources/uptime/get_alert.yml
+++ b/specification/resources/uptime/get_alert.yml
@@ -1,4 +1,4 @@
-operationId: uptime_alert_get
+operationId: uptime_get_alert
 
 summary: Retrieve an Existing Alert
 

--- a/specification/resources/uptime/get_check.yml
+++ b/specification/resources/uptime/get_check.yml
@@ -1,4 +1,4 @@
-operationId: uptime_check_get
+operationId: uptime_get_check
 
 summary: Retrieve an Existing Check
 

--- a/specification/resources/uptime/get_check_state.yml
+++ b/specification/resources/uptime/get_check_state.yml
@@ -1,4 +1,4 @@
-operationId: uptime_check_state_get
+operationId: uptime_get_checkState
 
 summary: Retrieve Check State
 

--- a/specification/resources/uptime/list_alerts.yml
+++ b/specification/resources/uptime/list_alerts.yml
@@ -1,4 +1,4 @@
-operationId: uptime_check_alerts_list
+operationId: uptime_list_alerts
 
 summary: List All Alerts
 

--- a/specification/resources/uptime/list_checks.yml
+++ b/specification/resources/uptime/list_checks.yml
@@ -1,4 +1,4 @@
-operationId: uptime_checks_list
+operationId: uptime_list_checks
 
 summary: List All Checks
 

--- a/specification/resources/uptime/update_alert.yml
+++ b/specification/resources/uptime/update_alert.yml
@@ -1,4 +1,4 @@
-operationId: uptime_alert_update
+operationId: uptime_update_alert
 
 summary: Update an Alert
 

--- a/specification/resources/uptime/update_check.yml
+++ b/specification/resources/uptime/update_check.yml
@@ -1,4 +1,4 @@
-operationId: uptime_check_update
+operationId: uptime_update_check
 
 summary: Update a Check
 

--- a/spectral/bundled.spectral.yml
+++ b/spectral/bundled.spectral.yml
@@ -10,3 +10,4 @@ rules:
   contact-properties: off
   operation-singular-tag: off
   endpoint-must-be-ref: off
+  

--- a/spectral/functions/validateOpIDNaming.js
+++ b/spectral/functions/validateOpIDNaming.js
@@ -9,9 +9,9 @@ const DELETE = ["delete", "destroy", "remove", "purge", "untag", "unassign"];
 const GET = ["get", "list"];
 const PATCH = ["patch"];
 const POST = ["create", "post", "add", "tag", "install", "reset", "upgrade",
-  "recycle", "run", "retry", "validate", "assign", "unassign", "cancel",
+  "recycle", "run", "retry", "validate", "assign", "unassign", "cancel", "list",
   "destroy", "delete", "update", "attach", "revert", "commit"];
-const PUT = ["update"];
+const PUT = ["update", "promote"];
 
 const articles = ["_a_", "_an_", "_the_"]
 

--- a/spectral/ruleset.yml
+++ b/spectral/ruleset.yml
@@ -134,7 +134,7 @@ rules:
     description: operationIds must follow naming conventions for method
     type: style
     given: '$.paths[*][*]'
-    severity: warn
+    severity: error
     message: '{{error}}'
     then:
       function: validateOpIDNaming


### PR DESCRIPTION
Increasing the spectral rule `operationid-must-follow-new-naming-conventions` from a warning to an error. This introduces a breaking change to Pydo as the `uptime` endpoints were not respecting the naming convention. We have two options we can take:

1) Accept the breaking changes and cut a new release of Pydo. Pydo hasn't had a 1.0 release, so could be fine.


2) Override the uptime checks paths to ignore the operationId naming convention as such:

```
  overrides:
  - files: ['**#/paths/~1v2~1uptime~1checks']
    rules:
      operationid-must-follow-new-naming-conventions: "off
```


Though slightly more disruptive, I prefer option 1. We are at an early stage in Pydo where a breaking change wouldn't be extremely impactful. Plus, I think the changes to the `uptime` functions feel better and are more consistent with the rest of the paths.