### PR TITLE
Add More Rate Limit Remaining Context

### DIFF
--- a/specification/description.yml
+++ b/specification/description.yml
@@ -227,7 +227,9 @@ introduction: |
 
   If the `ratelimit-remaining` reaches zero, subsequent requests will receive
   a 429 error code until the request reset has been reached. You can see the
-  format of the response in the examples.
+  format of the response in the examples. `ratelimit-remaining` reaching zero 
+  can also indicate that the 250 requests per minute limit was met, even if 
+  the 5,000 requests per hour limit was not. 
 
   **Note:** The following endpoints have special rate limit requirements that
   are independent of the limits defined above.


### PR DESCRIPTION
Documenting that `Ratelimit-Remaining` reaching zero can also indicate that the 250 requests per minute limit was met, even if the 5,000 requests per hour limit was not. That way, users know they can hit a `Ratelimit-Remaining: 0` even if they haven't used up all 5,000 requests per hour.

Totally open to keeping this undocumented as well if this is common practice. 