### PR TITLE
Fix: Database Patch Config 204 -> 200

### DIFF
--- a/specification/resources/databases/databases_patch_config.yml
+++ b/specification/resources/databases/databases_patch_config.yml
@@ -23,7 +23,7 @@ parameters:
   - $ref: 'parameters.yml#/database_cluster_uuid'
 
 responses:
-  '204':
+  '200':
     $ref: '../../shared/responses/no_content.yml'
 
   '401':


### PR DESCRIPTION
Addresses pydo issue: [databases.patch_config throws an HTTPResponseError upon successful patching](https://github.com/digitalocean/pydo/issues/187)

Documented to return a 204, but actually returns a 200:

```
> PATCH /v2/databases/$CLUSTER_UUID/config HTTP/2
> Host: api.digitalocean.com
> User-Agent: curl/8.1.2
> Accept: */*
> Content-Type: application/json
> Authorization: Bearer $DO_TOKEN
> Content-Length: 161
>
* We are completely uploaded and fine < HTTP/2 200
< date: Fri, 18 Aug 2023 21:19:53 GMT
```