### PR TITLE
Add descriptions to redis option + add mysql options

### DIFF
--- a/specification/resources/databases/models/mysql.yml
+++ b/specification/resources/databases/models/mysql.yml
@@ -206,3 +206,51 @@ properties:
     minimum: 600
     maximum: 86400
     example: 600
+  innodb_change_buffer_max_size:
+    description: >-
+      Specifies the maximum size of the InnoDB change buffer as a percentage of the buffer pool.
+    type: integer
+    minimum: 0
+    maximum: 50
+    example: 25
+  innodb_flush_neighbors:
+    description: >-
+      Specifies whether flushing a page from the InnoDB buffer pool also flushes other dirty pages in the same extent.
+        - 0 &mdash; disables this functionality, dirty pages in the same extent are not flushed.
+        - 1 &mdash; flushes contiguous dirty pages in the same extent.
+        - 2 &mdash; flushes dirty pages in the same extent.
+    type: integer
+    enum:
+      - 0
+      - 1
+      - 2
+    example: 0
+  innodb_read_io_threads:
+    description: >-
+      The number of I/O threads for read operations in InnoDB. Changing this parameter will lead to a restart of the MySQL service.
+    type: integer
+    minimum: 1
+    maximum: 64
+    example: 16
+  innodb_write_io_threads:
+    description: >-
+      The number of I/O threads for write operations in InnoDB. Changing this parameter will lead to a restart of the MySQL service.
+    type: integer
+    minimum: 1
+    maximum: 64
+    example: 16
+  innodb_thread_concurrency:
+    description: >-
+      Defines the maximum number of threads permitted inside of InnoDB. A value of 0 (the default) is interpreted as infinite concurrency (no limit). This variable is intended for performance 
+      tuning on high concurrency systems.
+    type: integer
+    minimum: 0
+    maximum: 1000
+    example: 0
+  net_buffer_length: 
+    description: >-
+      Start sizes of connection buffer and result buffer, must be multiple of 1024. Changing this parameter will lead to a restart of the MySQL service.
+    type: integer
+    minimum: 1024
+    maximum: 1048576
+    example: 50

--- a/specification/resources/databases/models/mysql.yml
+++ b/specification/resources/databases/models/mysql.yml
@@ -253,4 +253,4 @@ properties:
     type: integer
     minimum: 1024
     maximum: 1048576
-    example: 50
+    example: 4096

--- a/specification/resources/databases/models/redis.yml
+++ b/specification/resources/databases/models/redis.yml
@@ -55,7 +55,23 @@ properties:
     default: 300
     example: 300
   redis_notify_keyspace_events:
-    description: Set notify-keyspace-events option
+    description: |2-
+      Set notify-keyspace-events option. Requires at least `K` or `E` and accepts any combination of the following options. Setting the parameter to `""` disables notifications.
+      - `K` &mdash; Keyspace events
+      - `E` &mdash; Keyevent events
+      - `g` &mdash; Generic commands (e.g. `DEL`, `EXPIRE`, `RENAME`, ...)
+      - `$` &mdash; String commands
+      - `l` &mdash; List commands
+      - `s` &mdash; Set commands
+      - `h` &mdash; Hash commands
+      - `z` &mdash; Sorted set commands
+      - `t` &mdash; Stream commands
+      - `d` &mdash; Module key type events
+      - `x` &mdash; Expired events
+      - `e` &mdash; Evicted events
+      - `m` &mdash; Key miss events
+      - `n` &mdash; New key events
+      - `A` &mdash; Alias for `"g$lshztxed"`
     type: string
     pattern: ^[KEg\$lshzxeA]*$
     default: ''


### PR DESCRIPTION
Includes several new options for configuring MySQL (`innodb_change_buffer_max_size`, `innodb_flush_neighbors`, `innodb_read_io_threads`, `innodb_write_io_threads`, `innodb_thread_concurrency`, `net_buffer_length`) and adds clarification on a Redis option (`redis_keyspace_events`).

Local - Updated MySQL Adv. Config Docs

<img width="515" alt="Screenshot 2023-09-21 at 6 51 57 PM" src="https://github.com/digitalocean/openapi/assets/127760450/a83c15df-0438-493c-a9b4-5ae6b23b4d3e">

Local - Updated Redis Adv. Config Docs

<img width="515" alt="Screenshot 2023-09-21 at 6 53 15 PM" src="https://github.com/digitalocean/openapi/assets/127760450/4a58b76f-76b2-430d-8111-e6ed7dc64387">
