### PR TITLE
kubernetes: fix /credentials endpoint URL

### DIFF
--- a/specification/resources/kubernetes/kubernetes_get_credentials.yml
+++ b/specification/resources/kubernetes/kubernetes_get_credentials.yml
@@ -16,7 +16,7 @@ description: |
 
   Clusters supporting token-based authentication may define an expiration by
   passing a duration in seconds as a query parameter to
-  `/v2/kubernetes/clusters/$K8S_CLUSTER_ID/kubeconfig?expiry_seconds=$DURATION_IN_SECONDS`.
+  `/v2/kubernetes/clusters/$K8S_CLUSTER_ID/credentials?expiry_seconds=$DURATION_IN_SECONDS`.
   If not set or 0, then the token will have a 7 day expiry. The query parameter
   has no impact in certificate-based authentication.
 
@@ -55,4 +55,3 @@ x-codeSamples:
 security:
   - bearer_auth:
     - 'read'
-


### PR DESCRIPTION
Copy-paste mistake from the /kubeconfig endpoint URL.