### PR TITLE
fix: make period a required field for uptime alert

### DIFF
--- a/specification/resources/uptime/create_alert.yml
+++ b/specification/resources/uptime/create_alert.yml
@@ -34,6 +34,7 @@ requestBody:
           - name
           - type
           - notifications
+          - period
 
 responses:
   '201':

--- a/specification/resources/uptime/update_alert.yml
+++ b/specification/resources/uptime/update_alert.yml
@@ -22,6 +22,12 @@ requestBody:
         allOf:
           - $ref: 'models/alert.yml#/alert_updatable'
 
+        required:
+          - name
+          - type
+          - notifications
+          - period
+
 responses:
   '200':
     $ref: 'responses/existing_alert.yml'


### PR DESCRIPTION
Hi, I am working https://github.com/digitalocean/doctl/issues/1419 as part of #hacktoberfest and discovered `period` is not defined as a required field in the spec.

If I attempt to post a request without `period` then I receive
```json
{
    "id": "Internal Server Error",
    "message": "Server Error"
}
```

The field is also required on the UI.
![uptime-alert-screenshot](https://github.com/digitalocean/openapi/assets/10135646/ab5ef397-ebe3-40eb-84ca-e560cb0b2ac2)

