### PR TITLE
Update notification.yml

### DIFF
--- a/specification/resources/uptime/models/notification.yml
+++ b/specification/resources/uptime/models/notification.yml
@@ -5,7 +5,7 @@ required:
   - email
 properties:
   email:
-    description: "An email to notify on an alert trigger."
+    description: "An email to notify on an alert trigger. The Email has to be one that is verified on that DigitalOcean account."
     example:
       - "bob@example.com"
     type: array


### PR DESCRIPTION
Trying to use an email that is not associated with the account will result in an error:

```
 curl -X POST \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
  -d '{"name":"Landing page degraded performance","type":"latency","threshold":300,"comparison":"greater_than","notifications":{"email":["bob@gmail.com"],"slack":[{"channel":"Production Alerts","url":"https://hooks.slack.com/services/T1234567/AAAAAAAA/ZZZZZZ"}]},"period":"2m"}' \
  "https://api.digitalocean.com/v2/uptime/checks/dd70-40ed-b307-/alerts"
{"id":"bad_request","message":"invalid value for field 'notifications.email[0]': invalid email 'bob@gmail.com'","request_id":"dfd99e62bfdb"}
```