### PR TITLE
apps: add deploy_on_push.enabled to image source spec.

### DIFF
--- a/specification/resources/apps/models/apps_image_source_spec.yml
+++ b/specification/resources/apps/models/apps_image_source_spec.yml
@@ -30,3 +30,11 @@ properties:
     type: string
     description: The image digest. Cannot be specified if tag is provided.
     example: sha256:795e91610e9cccb7bb80893fbabf9c808df7d52ae1f39cd1158618b4a33041ac
+
+  deploy_on_push:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        description: Whether to automatically deploy new images. Can only be used for images hosted in DOCR and can only be used with an image tag, not a specific digest.
+        example: true


### PR DESCRIPTION
`deploy_on_push.enabled` is missing from the image source spec. It's already supported in godo, Terraform, etc but somehow missing here. 

https://docs.digitalocean.com/products/app-platform/reference/app-spec/#ref-services-image-deploy_on_push-enabled

https://github.com/digitalocean/godo/blob/f18d9300107d83abfabf15123861a96d0151498a/apps.gen.go#L982