### PR TITLE
APPS-7325 - deprecate app component routing/cors config

### DIFF
--- a/specification/resources/apps/models/app_functions_spec.yml
+++ b/specification/resources/apps/models/app_functions_spec.yml
@@ -2,12 +2,17 @@
 
 type: object
 properties:
+  
   cors:
-    $ref: apps_cors_policy.yml
+    allOf:
+      - $ref: apps_cors_policy.yml
+      - description: (Deprecated - Use Ingress Rules instead).
+      - deprecated: true
 
   routes:
     type: array
-    description: A list of HTTP routes that should be routed to this component.
+    description: (Deprecated - Use Ingress Rules instead). A list of HTTP routes that should be routed to this component.
+    deprecated: true
     items:
       $ref: app_route_spec.yml
       

--- a/specification/resources/apps/models/app_route_spec.yml
+++ b/specification/resources/apps/models/app_route_spec.yml
@@ -2,7 +2,7 @@ title: A criterion for routing HTTP traffic to a component.
 type: object
 properties:
   path:
-    description: An HTTP path prefix. Paths must start with / and must be unique across
+    description: (Deprecated - Use Ingress Rules instead). An HTTP path prefix. Paths must start with / and must be unique across
       all components within an app.
     type: string
     example: /api

--- a/specification/resources/apps/models/app_service_spec.yml
+++ b/specification/resources/apps/models/app_service_spec.yml
@@ -5,7 +5,10 @@ allOf:
 - type: object
   properties:
     cors:
-      $ref: apps_cors_policy.yml
+      allOf:
+        - $ref: apps_cors_policy.yml
+        - description: (Deprecated - Use Ingress Rules instead).
+        - deprecated: true
 
     health_check:
       $ref: app_service_spec_health_check.yml
@@ -32,7 +35,8 @@ allOf:
 
     routes:
       type: array
-      description: A list of HTTP routes that should be routed to this component.
+      description: (Deprecated - Use Ingress Rules instead). A list of HTTP routes that should be routed to this component.
+      deprecated: true
       items:
         $ref: app_route_spec.yml
 

--- a/specification/resources/apps/models/app_static_site_spec.yml
+++ b/specification/resources/apps/models/app_static_site_spec.yml
@@ -33,13 +33,17 @@ allOf:
       example: dist/
 
     cors:
-      $ref: apps_cors_policy.yml
+      allOf:
+        - $ref: apps_cors_policy.yml
+        - description: (Deprecated - Use Ingress Rules instead).
+        - deprecated: true
 
     routes:
       type: array
       items:
         $ref: app_route_spec.yml
-      description: A list of HTTP routes that should be routed to this component.
+      description: (Deprecated - Use Ingress Rules instead). A list of HTTP routes that should be routed to this component.
+      deprecated: true
 
 required:
 - name


### PR DESCRIPTION
users should use ingress rules instead

https://do-internal.atlassian.net/browse/APPS-7325