### PR TITLE
Update poetry version used in Python client validation

### DIFF
--- a/.github/workflows/validate-client-generation.yml
+++ b/.github/workflows/validate-client-generation.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1.3.1
         with:
-          version: 1.1.13
+          version: 1.6.1
           virtualenvs-path: .venv
           virtualenvs-create: true
           virtualenvs-in-project: true


### PR DESCRIPTION
Updates the poetry version used in Python client validation to match the one used by pydo itself.

See: https://github.com/digitalocean/pydo/pull/237

Resolves errors like:

```
  The lock file is not compatible with the current version of Poetry.
  Upgrade Poetry to be able to read the lock file or, alternatively, regenerate the lock file with the `poetry lock` command.
```

https://github.com/digitalocean/openapi/actions/runs/6526929286/job/17721187808#step:7:13