### PR TITLE
Database User ACLS - make 'id' optional

### DIFF
--- a/specification/resources/databases/databases_add_user.yml
+++ b/specification/resources/databases/databases_add_user.yml
@@ -60,14 +60,11 @@ requestBody:
             name: app-03
             settings:
               acl:
-              - id: acl128aaaa99239
-                permission: produceconsume
+              - permission: produceconsume
                 topic: customer-events
-              - id: acl293098flskdf
-                permission: produce
+              - permission: produce
                 topic: customer-events.*
-              - id: acl128ajei20123
-                permission: consume
+              - permission: consume
                 topic: customer-events
 
 responses:

--- a/specification/resources/databases/models/user_settings.yml
+++ b/specification/resources/databases/models/user_settings.yml
@@ -29,7 +29,6 @@ properties:
             and 'produce' permission. 'admin' allows for 'produceconsume' as
             well as any operations to administer the topic (delete, update).
       required:
-        - id
         - topic
         - permission
     description: >-


### PR DESCRIPTION
`id` is not required to be provided when creating Kafka user acls. This property is computed and provided back in the response.