### PR TITLE
Add ignore_dbs to online migration docs

### DIFF
--- a/specification/resources/databases/databases_update_onlineMigration.yml
+++ b/specification/resources/databases/databases_update_onlineMigration.yml
@@ -31,7 +31,7 @@ requestBody:
           username: doadmin
           password: paakjnfe10rsrsmf
         disable_ssl: false
-        ignore_dbs: "['db0','db1']"
+        ignore_dbs: ["db0","db1"]
 
 responses:
   "200":

--- a/specification/resources/databases/databases_update_onlineMigration.yml
+++ b/specification/resources/databases/databases_update_onlineMigration.yml
@@ -13,7 +13,7 @@ tags:
   - Databases
 
 parameters:
-  - $ref: 'parameters.yml#/database_cluster_uuid'
+  - $ref: "parameters.yml#/database_cluster_uuid"
 
 requestBody:
   required: true
@@ -21,7 +21,7 @@ requestBody:
   content:
     application/json:
       schema:
-          $ref: 'models/source_database.yml'
+        $ref: "models/source_database.yml"
 
       example:
         source:
@@ -31,30 +31,31 @@ requestBody:
           username: doadmin
           password: paakjnfe10rsrsmf
         disable_ssl: false
+        ignore_dbs: "['db0','db1']"
 
 responses:
-  '200':
-    $ref: 'responses/online_migration.yml'
+  "200":
+    $ref: "responses/online_migration.yml"
 
-  '401':
-    $ref: '../../shared/responses/unauthorized.yml'
+  "401":
+    $ref: "../../shared/responses/unauthorized.yml"
 
-  '404':
-    $ref: '../../shared/responses/not_found.yml'
+  "404":
+    $ref: "../../shared/responses/not_found.yml"
 
-  '429':
-    $ref: '../../shared/responses/too_many_requests.yml'
+  "429":
+    $ref: "../../shared/responses/too_many_requests.yml"
 
-  '500':
-    $ref: '../../shared/responses/server_error.yml'
+  "500":
+    $ref: "../../shared/responses/server_error.yml"
 
   default:
-    $ref: '../../shared/responses/unexpected_error.yml'
+    $ref: "../../shared/responses/unexpected_error.yml"
 
 x-codeSamples:
-  - $ref: 'examples/curl/databases_update_onlineMigration.yml'
-  - $ref: 'examples/python/databases_update_onlineMigration.yml'
+  - $ref: "examples/curl/databases_update_onlineMigration.yml"
+  - $ref: "examples/python/databases_update_onlineMigration.yml"
 
 security:
   - bearer_auth:
-    - 'write'
+      - "write"

--- a/specification/resources/databases/examples/curl/databases_update_onlineMigration.yml
+++ b/specification/resources/databases/examples/curl/databases_update_onlineMigration.yml
@@ -3,5 +3,5 @@ source: |-
   curl -X PUT \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-  -d '{"source":{"host":"source-do-user-6607903-0.b.db.ondigitalocean.com","dbname":"defaultdb","port":25060,"username":"doadmin","password":"paakjnfe10rsrsmf"},"disable_ssl":false,"ignore_dbs":"['db0','db1']"}' \
+  -d '{"source":{"host":"source-do-user-6607903-0.b.db.ondigitalocean.com","dbname":"defaultdb","port":25060,"username":"doadmin","password":"paakjnfe10rsrsmf"},"disable_ssl":false,"ignore_dbs":["db0","db1"]}' \
   "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/online-migration"

--- a/specification/resources/databases/examples/curl/databases_update_onlineMigration.yml
+++ b/specification/resources/databases/examples/curl/databases_update_onlineMigration.yml
@@ -3,5 +3,5 @@ source: |-
   curl -X PUT \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-  -d '{"source":{"host":"source-do-user-6607903-0.b.db.ondigitalocean.com","dbname":"defaultdb","port":25060,"username":"doadmin","password":"paakjnfe10rsrsmf"},"disable_ssl":false}' \
-  "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/online-migration" 
+  -d '{"source":{"host":"source-do-user-6607903-0.b.db.ondigitalocean.com","dbname":"defaultdb","port":25060,"username":"doadmin","password":"paakjnfe10rsrsmf"},"disable_ssl":false,"ignore_dbs":"['db0','db1']"}' \
+  "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/online-migration"

--- a/specification/resources/databases/examples/python/databases_update_onlineMigration.yml
+++ b/specification/resources/databases/examples/python/databases_update_onlineMigration.yml
@@ -14,6 +14,7 @@ source: |-
       "password": "paakjnfe10rsrsmf"
     },
     "disable_ssl": False
+    "ignore_dbs": "['db0','db1']"
   }
 
   update_resp = client.databases.update_online_migration(database_cluster_uuid="a7a8bas", body=req)

--- a/specification/resources/databases/examples/python/databases_update_onlineMigration.yml
+++ b/specification/resources/databases/examples/python/databases_update_onlineMigration.yml
@@ -14,7 +14,7 @@ source: |-
       "password": "paakjnfe10rsrsmf"
     },
     "disable_ssl": False
-    "ignore_dbs": "['db0','db1']"
+    "ignore_dbs": ["db0","db1"]
   }
 
   update_resp = client.databases.update_online_migration(database_cluster_uuid="a7a8bas", body=req)

--- a/specification/resources/databases/models/source_database.yml
+++ b/specification/resources/databases/models/source_database.yml
@@ -29,6 +29,11 @@ properties:
     description: Enables SSL encryption when connecting to the source database.
     example: false
   ignore_dbs:
-    type: string
+    type: array
+    items:
+      type: string
+    example:
+    - db0
+    - db1
+    default: []
     description: List of databases that should be ignored during migration.
-    example: "['db0','db1']"

--- a/specification/resources/databases/models/source_database.yml
+++ b/specification/resources/databases/models/source_database.yml
@@ -28,3 +28,7 @@ properties:
     type: boolean
     description: Enables SSL encryption when connecting to the source database.
     example: false
+  ignore_dbs:
+    type: string
+    description: List of databases that should be ignored during migration.
+    example: "['db0','db1']"


### PR DESCRIPTION
This PR aims at adding `ignore_dbs` to online migration docs to DigitalOcean's OpenAPI.

![image](https://github.com/digitalocean/openapi/assets/7105473/5e242254-b718-45a1-8ad9-04a1730c1da5)


Sample Request: 

```
curl -X PUT \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-d '{"source":{"host":"source-do-user-6607903-0.b.db.ondigitalocean.com","dbname":"defaultdb","port":25060,"username":"doadmin","password":"******"},"disable_ssl":false,"ignore_dbs":["db0","db1"]}' \
"https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/online-migration"
```


