### PR TITLE
Add Database Event logs details to DO openapi

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -793,6 +793,10 @@ paths:
       $ref: 'resources/databases/databases_list_replicas.yml'
     post:
       $ref: 'resources/databases/databases_create_replica.yml'
+  
+  /v2/databases/{database_cluster_uuid}/events:
+    get:
+      $ref: 'resources/databases/databases_events_logs.yml'
 
   /v2/databases/{database_cluster_uuid}/replicas/{replica_name}:
     get:

--- a/specification/resources/databases/databases_events_logs.yml
+++ b/specification/resources/databases/databases_events_logs.yml
@@ -1,0 +1,42 @@
+operationId: databases_list_events_logs
+
+summary: List all Events Logs
+
+description: |
+  To list all of the cluster events, send a GET request to
+  `/v2/databases/$DATABASE_ID/events`.
+
+  The result will be a JSON object with a `events` key.
+
+tags:
+  - Databases
+
+parameters:
+  - $ref: "parameters.yml#/database_cluster_uuid"
+
+responses:
+  "200":
+    $ref: "responses/events_logs.yml"
+
+  "401":
+    $ref: "../../shared/responses/unauthorized.yml"
+
+  "404":
+    $ref: "../../shared/responses/not_found.yml"
+
+  "429":
+    $ref: "../../shared/responses/too_many_requests.yml"
+
+  "500":
+    $ref: "../../shared/responses/server_error.yml"
+
+  default:
+    $ref: "../../shared/responses/unexpected_error.yml"
+
+x-codeSamples:
+  - $ref: "examples/curl/databases_list_events.yml"
+  - $ref: "examples/go/databases_list_events.yml"
+
+security:
+  - bearer_auth:
+      - "read"

--- a/specification/resources/databases/examples/curl/databases_list_events.yml
+++ b/specification/resources/databases/examples/curl/databases_list_events.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/events"

--- a/specification/resources/databases/examples/go/databases_list_events.yml
+++ b/specification/resources/databases/examples/go/databases_list_events.yml
@@ -1,0 +1,17 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "os"
+
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      token := os.Getenv("DIGITALOCEAN_TOKEN")
+
+      client := godo.NewFromToken(token)
+      ctx := context.TODO()
+
+      replicas, _, err := client.Databases.ListProjectEvents(ctx, "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30", nil)
+  }

--- a/specification/resources/databases/models/events_logs.yml
+++ b/specification/resources/databases/models/events_logs.yml
@@ -1,0 +1,19 @@
+type: object
+
+properties:
+  id:
+    type: string
+    description: ID of the particular event.
+    example: 'pe8u2huh'
+  cluster_name:
+    type: string
+    description: The name of cluster.
+    example: 'sample_cluster'
+  event_type:
+    type: string
+    description: Type of the event.
+    example: 'cluster_create'
+  create_time:
+    type: string
+    description: The time of the generation of a event.
+    example: '2020-10-29T15:57:38Z'

--- a/specification/resources/databases/responses/events_logs.yml
+++ b/specification/resources/databases/responses/events_logs.yml
@@ -1,0 +1,29 @@
+description: A JSON object with a key of `events`.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      properties:
+        events:
+          type: array
+          items:
+            $ref:  '../models/events_logs.yml'
+
+    example:
+      events:
+        - id: 'pe8u2huh'
+          cluster_name: 'customer-events'
+          event_type: 'cluster_create'
+          create_time: '2020-10-29T15:57:38Z'
+        - id: 'pe8ufefuh'
+          cluster_name: 'customer-events'
+          event_type: 'cluster_update'
+          create_time: '2023-10-30T15:57:38Z'


### PR DESCRIPTION
This PR aims at adding the details of the new route that list all of the cluster events. 
  `/v2/databases/$DATABASE_ID/events`.
  
 
![image](https://github.com/digitalocean/openapi/assets/7105473/3bc12d95-521c-46e0-94e0-7e6c83bf4856)
  
  #### Sample Request:
  
  ```
  curl -X GET \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
  "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/events"
  ```
  #### Sample Response
  ```
  {
  "events": [
    {
      "id": "pe8u2huh",
      "cluster_name": "sample-db",
      "event_type": "cluster_create",
      "create_time": "2020-10-29T15:57:38Z"
    },
    {
      "id": "pe8ufefuh",
      "cluster_name": "sample-db",
      "event_type": "cluster_update",
      "create_time": "2023-10-30T15:57:38Z"
    }
  ]
}
  ```
  