### PR TITLE
APPS-8033 Add the RUN_RESTARTED log type

### DIFF
--- a/specification/resources/apps/parameters.yml
+++ b/specification/resources/apps/parameters.yml
@@ -98,6 +98,7 @@ log_type:
     - BUILD: Build-time logs
     - DEPLOY: Deploy-time logs
     - RUN: Live run-time logs
+    - RUN_RESTARTED: Logs of crashed/restarted instances during runtime
   in: query
   name: type
   required: true
@@ -108,6 +109,7 @@ log_type:
     - BUILD
     - DEPLOY
     - RUN
+    - RUN_RESTARTED
     type: string
   example: BUILD
 


### PR DESCRIPTION
This new log type captures "previous" logs so that users that see that their app has seen restarts can fetch those old logs and debug them themselves.