### PR TITLE
Include DBAAS standby Nodes

### DIFF
--- a/specification/resources/databases/databases_create_cluster.yml
+++ b/specification/resources/databases/databases_create_cluster.yml
@@ -11,8 +11,12 @@ description: >-
   `creating`. When the cluster is ready to receive traffic, this will transition to
   `online`.
 
+
   The embedded `connection` and `private_connection` objects will contain the
-  information needed to access the database cluster.
+  information needed to access the database cluster. For multi-node clusters, the
+  `standby_connection` and `standby_private_connection` objects will contain the information
+  needed to connect to the cluster's standby node(s).
+
 
   DigitalOcean managed PostgreSQL and MySQL database clusters take automated daily backups.
   To create a new database cluster based on a backup of an existing cluster, send a POST

--- a/specification/resources/databases/databases_get_cluster.yml
+++ b/specification/resources/databases/databases_get_cluster.yml
@@ -6,11 +6,16 @@ description: >-
   To show information about an existing database cluster, send a GET request to
   `/v2/databases/$DATABASE_ID`.
 
+
   The response will be a JSON object with a database key. This will be set to an object
   containing the standard database cluster attributes.
 
-  The embedded connection and private_connection objects will contain the information
-  needed to access the database cluster.
+
+  The embedded `connection` and `private_connection` objects will contain the
+  information needed to access the database cluster. For multi-node clusters, the
+  `standby_connection` and `standby_private_connection` objects contain the information
+  needed to connect to the cluster's standby node(s).
+
 
   The embedded maintenance_window object will contain information about any scheduled
   maintenance for the database cluster.

--- a/specification/resources/databases/databases_list_clusters.yml
+++ b/specification/resources/databases/databases_list_clusters.yml
@@ -7,11 +7,15 @@ description: >-
   `/v2/databases`. To limit the results to database clusters with a specific tag, include
   the `tag_name` query parameter set to the name of the tag. For example, `/v2/databases?tag_name=$TAG_NAME`.
 
+
   The result will be a JSON object with a `databases` key. This will be set to an array of database objects,
   each of which will contain the standard database attributes.
 
+
   The embedded `connection` and `private_connection` objects will contain the information needed to access the
-  database cluster:
+  database cluster. For multi-node clusters, the `standby_connection` and `standby_private_connection` objects
+  will contain the information needed to connect to the cluster's standby node(s).
+
 
   The embedded `maintenance_window` object will contain information about any scheduled maintenance for the
   database cluster.

--- a/specification/resources/databases/models/connection_pool.yml
+++ b/specification/resources/databases/models/connection_pool.yml
@@ -42,6 +42,14 @@ properties:
     allOf:
     - $ref: './database_connection.yml'
     - readOnly: true
+  standby_connection:
+    allOf:
+    - $ref: './database_connection.yml'
+    - readOnly: true
+  standby_private_connection:
+    allOf:
+    - $ref: './database_connection.yml'
+    - readOnly: true
 required:
   - name
   - mode

--- a/specification/resources/databases/models/database_cluster.yml
+++ b/specification/resources/databases/models/database_cluster.yml
@@ -100,6 +100,14 @@ properties:
     allOf:
     - $ref: './database_connection.yml'
     - readOnly: true
+  standby_connection:
+    allOf:
+    - $ref: './database_connection.yml'
+    - readOnly: true
+  standby_private_connection:
+    allOf:
+    - $ref: './database_connection.yml'
+    - readOnly: true
   users:
     type: array
     nullable: true

--- a/specification/resources/databases/responses/database_cluster.yml
+++ b/specification/resources/databases/responses/database_cluster.yml
@@ -40,6 +40,22 @@ content:
           user: doadmin
           password: wv78n3zpz42xezdk
           ssl: true
+        standby_connection:
+          uri: postgres://doadmin:wv78n3zpz42xezdk@replica-backend-do-user-19081923-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require
+          database: ''
+          host: replica-backend-do-user-19081923-0.db.ondigitalocean.com
+          port: 25060
+          user: doadmin
+          password: wv78n3zpz42xezdk
+          ssl: true
+        standby_private_connection:
+          uri: postgres://doadmin:wv78n3zpz42xezdk@private-replica-backend-do-user-19081923-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require
+          database: ''
+          host: private-replica-backend-do-user-19081923-0.db.ondigitalocean.com
+          port: 25060
+          user: doadmin
+          password: wv78n3zpz42xezdk
+          ssl: true
         users:
         - name: doadmin
           role: primary


### PR DESCRIPTION
The DO public API now includes standby node hostnames (standby_connection and standby_private_connection) in responses for clusters and pools. . This PR adds these fields to the OpenAPI spec.

Follows https://github.com/digitalocean/godo/pull/663