### PR TITLE
Include PG Replication User Option

### DIFF
--- a/specification/resources/databases/databases_add_user.yml
+++ b/specification/resources/databases/databases_add_user.yml
@@ -59,7 +59,7 @@ requestBody:
         Add New User for Postgres with replication rights:
           value:
             name: app-02
-            access_control:
+            settings:
               pg_allow_replication: true
 
         Add New User with Kafka ACLs:

--- a/specification/resources/databases/databases_add_user.yml
+++ b/specification/resources/databases/databases_add_user.yml
@@ -39,6 +39,13 @@ requestBody:
               description: |
                 For MongoDB clusters, set to `true` to create a read-only user.
                 This option is not currently supported for other database engines.
+            pg_allow_replication:
+              type: boolean
+              example: true
+              description: |
+                For Postgres clusters, set to `true` to create a user with replication rights.
+                This option is not currently supported for other database engines.
+
       examples:
         Add New User:
           value:
@@ -54,6 +61,11 @@ requestBody:
           value:
             name: my-readonly
             readonly: true
+        
+        Add New User for Postgres with replication rights:
+          value:
+            name: pg_allow_replication
+            pg_allow_replication: true
 
         Add New User with Kafka ACLs:
           value:

--- a/specification/resources/databases/databases_add_user.yml
+++ b/specification/resources/databases/databases_add_user.yml
@@ -38,13 +38,7 @@ requestBody:
               example: true
               description: |
                 For MongoDB clusters, set to `true` to create a read-only user.
-                This option is not currently supported for other database engines.
-            pg_allow_replication:
-              type: boolean
-              example: true
-              description: |
-                For Postgres clusters, set to `true` to create a user with replication rights.
-                This option is not currently supported for other database engines.
+                This option is not currently supported for other database engines.             
 
       examples:
         Add New User:
@@ -64,8 +58,9 @@ requestBody:
         
         Add New User for Postgres with replication rights:
           value:
-            name: pg_allow_replication
-            pg_allow_replication: true
+            name: app-02
+            access_control:
+              pg_allow_replication: true
 
         Add New User with Kafka ACLs:
           value:

--- a/specification/resources/databases/models/database_user.yml
+++ b/specification/resources/databases/models/database_user.yml
@@ -34,17 +34,6 @@ properties:
     example: "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDBIZMz8pnK6V52\nSVf+CYssOfCQHAx5f0Ou5rYbq3xNh8VHAIYJCQ1QxQIxKSP6+uODSYrb2KWyurP1\nDwGb8OYm0J3syEDtCUQik1cpCzpeNlAZ2f8FzXyYQAqPopxdRpsFz8DtZnVvu86X\nwrE4oFPl9MReICmZfBNWylpV5qgFPoXyJ70ZAsTm3cEe3n+LBXEnY4YrVDRWxA3w\nZ2mzZ03HZ1hHrxK9CMnS829U+8sK+UneZpCO7yLRPuxwhmps0wpK/YuZZfRAKF1F\nZRnak/SIQ28rnWufmdg16YqqHgl5JOgnb3aslKRvL4dI2Gwnkd2IHtpZnTR0gxFX\nfqqbQwuRAgMBAAECggEBAILLmkW0JzOkmLTDNzR0giyRkLoIROqDpfLtjKdwm95l\n9NUBJcU4vCvXQITKt/NhtnNTexcowg8pInb0ksJpg3UGE+4oMNBXVi2UW5MQZ5cm\ncVkQqgXkBF2YAY8FMaB6EML+0En2+dGR/3gIAr221xsFiXe1kHbB8Nb2c/d5HpFt\neRpLVJnK+TxSr78PcZA8DDGlSgwvgimdAaFUNO2OqB9/0E9UPyKk2ycdff/Z6ldF\n0hkCLtdYTTl8Kf/OwjcuTgmA2O3Y8/CoQX/L+oP9Rvt9pWCEfuebiOmHJVPO6Y6x\ngtQVEXwmF1pDHH4Qtz/e6UZTdYeMl9G4aNO2CawwcaYECgYEA57imgSOG4XsJLRh\nGGncV9R/xhy4AbDWLtAMzQRX4ktvKCaHWyQV2XK2we/cu29NLv2Y89WmerTNPOU+\nP8+pB31uty2ELySVn15QhKpQClVEAlxCnnNjXYrii5LOM80+lVmxvQwxVd8Yz8nj\nIntyioXNBEnYS7V2RxxFGgFun1cCgYEA1V3W+Uyamhq8JS5EY0FhyGcXdHd70K49\nW1ou7McIpncf9tM9acLS1hkI98rd2T69Zo8mKoV1V2hjFaKUYfNys6tTkYWeZCcJ\n3rW44j9DTD+FmmjcX6b8DzfybGLehfNbCw6n67/r45DXIV/fk6XZfkx6IEGO4ODt\nNfnvx4TuI1cCgYBACDiKqwSUvmkUuweOo4IuCxyb5Ee8v98P5JIE/VRDxlCbKbpx\npxEam6aBBQVcDi+n8o0H3WjjlKc6UqbW/01YMoMrvzotxNBLz8Y0QtQHZvR6KoCG\nRKCKstxTcWflzKuknbqN4RapAhNbKBDJ8PMSWfyDWNyaXzSmBdvaidbF1QKBgDI0\no4oD0Xkjg1QIYAUu9FBQmb9JAjRnW36saNBEQS/SZg4RRKknM683MtoDvVIKJk0E\nsAlfX+4SXQZRPDMUMtA+Jyrd0xhj6zmhbwClvDMr20crF3fWdgcqtft1BEFmsuyW\nJUMe5OWmRkjPI2+9ncDPRAllA7a8lnSV/Crph5N/AoGBAIK249temKrGe9pmsmAo\nQbNuYSmwpnMoAqdHTrl70HEmK7ob6SIVmsR8QFAkH7xkYZc4Bxbx4h1bdpozGB+/\nAangbiaYJcAOD1QyfiFbflvI1RFeHgrk7VIafeSeQv6qu0LLMi2zUbpgVzxt78Wg\neTuK2xNR0PIM8OI7pRpgyj1I\n-----END PRIVATE KEY-----"
     description: Access key for TLS client authentication. (Kafka only)
     readOnly: true
-  
-  access_control:
-    type: object
-    
-    properties:
-      pg_allow_replication:
-        type: boolean
-        example: true
-        description: |
-          For Postgres clusters, set to `true` for a user with replication rights.
-          This option is not currently supported for other database engines.
 
   mysql_settings:
     $ref: './mysql_settings.yml'

--- a/specification/resources/databases/models/database_user.yml
+++ b/specification/resources/databases/models/database_user.yml
@@ -34,6 +34,16 @@ properties:
     example: "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDBIZMz8pnK6V52\nSVf+CYssOfCQHAx5f0Ou5rYbq3xNh8VHAIYJCQ1QxQIxKSP6+uODSYrb2KWyurP1\nDwGb8OYm0J3syEDtCUQik1cpCzpeNlAZ2f8FzXyYQAqPopxdRpsFz8DtZnVvu86X\nwrE4oFPl9MReICmZfBNWylpV5qgFPoXyJ70ZAsTm3cEe3n+LBXEnY4YrVDRWxA3w\nZ2mzZ03HZ1hHrxK9CMnS829U+8sK+UneZpCO7yLRPuxwhmps0wpK/YuZZfRAKF1F\nZRnak/SIQ28rnWufmdg16YqqHgl5JOgnb3aslKRvL4dI2Gwnkd2IHtpZnTR0gxFX\nfqqbQwuRAgMBAAECggEBAILLmkW0JzOkmLTDNzR0giyRkLoIROqDpfLtjKdwm95l\n9NUBJcU4vCvXQITKt/NhtnNTexcowg8pInb0ksJpg3UGE+4oMNBXVi2UW5MQZ5cm\ncVkQqgXkBF2YAY8FMaB6EML+0En2+dGR/3gIAr221xsFiXe1kHbB8Nb2c/d5HpFt\neRpLVJnK+TxSr78PcZA8DDGlSgwvgimdAaFUNO2OqB9/0E9UPyKk2ycdff/Z6ldF\n0hkCLtdYTTl8Kf/OwjcuTgmA2O3Y8/CoQX/L+oP9Rvt9pWCEfuebiOmHJVPO6Y6x\ngtQVEXwmF1pDHH4Qtz/e6UZTdYeMl9G4aNO2CawwcaYECgYEA57imgSOG4XsJLRh\nGGncV9R/xhy4AbDWLtAMzQRX4ktvKCaHWyQV2XK2we/cu29NLv2Y89WmerTNPOU+\nP8+pB31uty2ELySVn15QhKpQClVEAlxCnnNjXYrii5LOM80+lVmxvQwxVd8Yz8nj\nIntyioXNBEnYS7V2RxxFGgFun1cCgYEA1V3W+Uyamhq8JS5EY0FhyGcXdHd70K49\nW1ou7McIpncf9tM9acLS1hkI98rd2T69Zo8mKoV1V2hjFaKUYfNys6tTkYWeZCcJ\n3rW44j9DTD+FmmjcX6b8DzfybGLehfNbCw6n67/r45DXIV/fk6XZfkx6IEGO4ODt\nNfnvx4TuI1cCgYBACDiKqwSUvmkUuweOo4IuCxyb5Ee8v98P5JIE/VRDxlCbKbpx\npxEam6aBBQVcDi+n8o0H3WjjlKc6UqbW/01YMoMrvzotxNBLz8Y0QtQHZvR6KoCG\nRKCKstxTcWflzKuknbqN4RapAhNbKBDJ8PMSWfyDWNyaXzSmBdvaidbF1QKBgDI0\no4oD0Xkjg1QIYAUu9FBQmb9JAjRnW36saNBEQS/SZg4RRKknM683MtoDvVIKJk0E\nsAlfX+4SXQZRPDMUMtA+Jyrd0xhj6zmhbwClvDMr20crF3fWdgcqtft1BEFmsuyW\nJUMe5OWmRkjPI2+9ncDPRAllA7a8lnSV/Crph5N/AoGBAIK249temKrGe9pmsmAo\nQbNuYSmwpnMoAqdHTrl70HEmK7ob6SIVmsR8QFAkH7xkYZc4Bxbx4h1bdpozGB+/\nAangbiaYJcAOD1QyfiFbflvI1RFeHgrk7VIafeSeQv6qu0LLMi2zUbpgVzxt78Wg\neTuK2xNR0PIM8OI7pRpgyj1I\n-----END PRIVATE KEY-----"
     description: Access key for TLS client authentication. (Kafka only)
     readOnly: true
+  
+  access_control:
+    type: object
+    
+    properties:
+      pg_allow_replication:
+        type: boolean
+        example: true
+        description: |
+          Postgres cluster specific access control rules for user.
 
   mysql_settings:
     $ref: './mysql_settings.yml'

--- a/specification/resources/databases/models/database_user.yml
+++ b/specification/resources/databases/models/database_user.yml
@@ -43,7 +43,8 @@ properties:
         type: boolean
         example: true
         description: |
-          Postgres cluster specific access control rules for user.
+          For Postgres clusters, set to `true` for a user with replication rights.
+          This option is not currently supported for other database engines.
 
   mysql_settings:
     $ref: './mysql_settings.yml'

--- a/specification/resources/databases/models/user_settings.yml
+++ b/specification/resources/databases/models/user_settings.yml
@@ -1,6 +1,12 @@
 type: object
 
 properties:
+  pg_allow_replication:
+        type: boolean
+        example: true
+        description: |
+          For Postgres clusters, set to `true` for a user with replication rights.
+          This option is not currently supported for other database engines.
   acl:
     type: array
     items:

--- a/specification/resources/databases/responses/user.yml
+++ b/specification/resources/databases/responses/user.yml
@@ -40,7 +40,7 @@ content:
             name: app-02
             role: normal
             password: wv78n3zpz42xezdk
-            access_control::
+            settings:
               pg_allow_replication: true 
 
       Kafka User:

--- a/specification/resources/databases/responses/user.yml
+++ b/specification/resources/databases/responses/user.yml
@@ -33,6 +33,15 @@ content:
             password: wv78n3zpz42xezdk
             mysql_settings:
               auth_plugin: mysql_native_password
+      
+      New User for Postgres with replication rights:
+        value:
+          user:
+            name: app-02
+            role: normal
+            password: wv78n3zpz42xezdk
+            access_control::
+              pg_allow_replication: true 
 
       Kafka User:
         value:


### PR DESCRIPTION
This PR aims at updating documentation for [Add a Database User](http://127.0.0.1:8080/#tag/Databases/operation/databases_add_user)
- This API call will create a postgres cluster user with replication rights i.e. `pg_allow_replication`.

![image](https://github.com/digitalocean/openapi/assets/7105473/b0fe2a5c-1ebd-4146-a0f1-248c7616eaa5)

- Sample curl request and response.

#### Request

```
curl -X POST \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
  -d '{"name": "app-01", "settings":{"pg_allow_replication":true}}' \
  "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/users"
  
 ```
#### Response

```
{
  "user": {
    "name": "app-01",
    "role": "normal",
    "password": "jge5lfxtzhx42iff"
    "settings": {
       "pg_allow_replication":true
       }
    }
}

```