### PR TITLE
BILL-9714: Update docs for added invoice_id field

### DIFF
--- a/specification/resources/billing/models/invoice_preview.yml
+++ b/specification/resources/billing/models/invoice_preview.yml
@@ -8,6 +8,11 @@ properties:
     description: >- 
       The UUID of the invoice. The canonical reference for the invoice.
     example: fdabb512-6faf-443c-ba2e-665452332a9e
+  invoice_id:
+    type: string
+    description: >-
+      ID of the invoice. Listed on the face of the invoice PDF as the "Invoice number".
+    example: "123456789"
   amount:
     type: string
     description: >- 

--- a/specification/resources/billing/models/invoice_summary.yml
+++ b/specification/resources/billing/models/invoice_summary.yml
@@ -6,6 +6,11 @@ properties:
     description: UUID of the invoice
     example: 22737513-0ea7-4206-8ceb-98a575af7681
 
+  invoice_id:
+    type: string
+    description: ID of the invoice
+    example: '123456789'
+
   billing_period:
     type: string
     description: >- 

--- a/specification/resources/billing/responses/invoice_summary.yml
+++ b/specification/resources/billing/responses/invoice_summary.yml
@@ -16,6 +16,7 @@ content:
       $ref: '../models/invoice_summary.yml'
     example:
       invoice_uuid: 22737513-0ea7-4206-8ceb-98a575af7681
+      invoice_id: '123456789'
       billing_period: 2020-01
       amount: '27.13'
       user_name: Sammy Shark

--- a/specification/resources/billing/responses/invoices.yml
+++ b/specification/resources/billing/responses/invoices.yml
@@ -34,13 +34,16 @@ content:
       example:
         invoices:
           - invoice_uuid: 22737513-0ea7-4206-8ceb-98a575af7681
+            invoice_id: '12345678'
             amount: '12.34'
             invoice_period: 2019-12
           - invoice_uuid: fdabb512-6faf-443c-ba2e-665452332a9e
+            invoice_id: '23456789'
             amount: '23.45'
             invoice_period: 2019-11
         invoice_preview:
           invoice_uuid: 1afe95e6-0958-4eb0-8d9a-9c5060d3ef03
+          invoice_id: '34567890'
           amount: '34.56'
           invoice_period: 2020-02
           updated_at: '2020-02-23T06:31:50Z'


### PR DESCRIPTION
Since we already expose the invoice_id as part of the BillingHistory endpoint as well as on the face of the invoice PDF, we should also include it here for consistency. 

See https://do-internal.atlassian.net/browse/BILL-9714
