### PR TITLE
Specify fine grained permissions for 'Validate Client Generation' workflow.

### DIFF
--- a/.github/workflows/validate-client-generation.yml
+++ b/.github/workflows/validate-client-generation.yml
@@ -7,6 +7,11 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+  statuses: write
+  actions: read
+
 jobs:
   validate-client-gen:
     name: Validate Client Generation
@@ -31,6 +36,7 @@ jobs:
             -f target_url='${{ env.target_url }}' \
             -f description='Starting pydo validation' \
             -f context='${{ github.workflow }}'
+
       - name: Check out pydo repo
         uses: actions/checkout@v2.5.0
         with:


### PR DESCRIPTION
This restricts the token used with the 'Validate Client Generation' workflow to a more limited set of permissions.

- `contents: read` - Allows access to the contents of the repository.
- `statuses: write` - As we update the status on the PR
- `actions: read` - Is required to download artifacts https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#get-an-artifact
