### PR TITLE
update error response for non-snapshots

### DIFF
--- a/specification/resources/snapshots/responses/not_a_snapshot.yml
+++ b/specification/resources/snapshots/responses/not_a_snapshot.yml
@@ -1,0 +1,18 @@
+description: Bad Request
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../../../shared/models/error.yml'
+    example:
+      id: bad_request
+      message: the resource is not a snapshot
+      request_id: bbd8d7d4-2beb-4be1-a374-338e6165e32d

--- a/specification/resources/snapshots/snapshots_delete.yml
+++ b/specification/resources/snapshots/snapshots_delete.yml
@@ -20,6 +20,9 @@ responses:
   '204':
     $ref: '../../shared/responses/no_content.yml'
 
+  '400':
+    $ref: 'responses/not_a_snapshot.yml'
+
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 

--- a/specification/resources/snapshots/snapshots_get.yml
+++ b/specification/resources/snapshots/snapshots_get.yml
@@ -19,6 +19,9 @@ responses:
   '200':
     $ref: 'responses/snapshots_existing.yml'
 
+  '400':
+    $ref: 'responses/not_a_snapshot.yml'
+
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
 


### PR DESCRIPTION
This doc update relates to a change in behavior in our public API related to a bug fix made back in January - details can be found in https://github.com/digitalocean/product-docs/pull/4150.  While working to migrate this endpoint to a new service, we found that image type unrelated to snapshots (for example backups and custom images) could be interacted with through these endpoints.  All these operations were properly scope to the user's account - the bug sole focused on the image type related to the record.  This was corrected, and we return a 400 in this scenario, with the following response:

```
{"id":"bad_request","message":"the resource is not a snapshot"}
```