### PR TITLE
monitoring: Mention units for bandwidth metric.

### DIFF
--- a/specification/resources/monitoring/monitoring_get_dropletBandwidthMetrics.yml
+++ b/specification/resources/monitoring/monitoring_get_dropletBandwidthMetrics.yml
@@ -8,6 +8,8 @@ description: >-
   to specify if the results should be for the `private` or `public` interface.
   Use the `direction` query parameter to specify if the results should be for
   `inbound` or `outbound` traffic.
+
+  The metrics in the response body are in megabits per second (Mbps).
 tags:
   - Monitoring
 

--- a/specification/resources/monitoring/parameters.yml
+++ b/specification/resources/monitoring/parameters.yml
@@ -50,7 +50,7 @@ network_direction:
 metric_timestamp_start:
   in: query
   name: start
-  description: Timestamp to start metric window.
+  description: UNIX timestamp to start metric window.
   example: "1620683817"
   required: true
   schema:
@@ -59,7 +59,7 @@ metric_timestamp_start:
 metric_timestamp_end:
   in: query
   name: end
-  description: Timestamp to end metric window.
+  description: UNIX timestamp to end metric window.
   example: "1620705417"
   required: true
   schema:


### PR DESCRIPTION
We get questions about the unit of measurement used for the Droplet bandwidth metrics. This adds a mention that they are Megabits per second. It also makes it clear that the timestamps used are UNIX timestamps.