### PR TITLE
Updates Droplet name field with character limits

### DIFF
--- a/specification/resources/droplets/models/droplet_multi_create.yml
+++ b/specification/resources/droplets/models/droplet_multi_create.yml
@@ -7,6 +7,8 @@ allOf:
         type: array
         items:
           type: string
+          maxLength: 255
+          pattern: ^[a-z][a-z0-9-]{0,30}[a-z0-9]$
         example:
         - sub-01.example.com
         - sub-02.example.com

--- a/specification/resources/droplets/models/droplet_multi_create.yml
+++ b/specification/resources/droplets/models/droplet_multi_create.yml
@@ -8,7 +8,7 @@ allOf:
         items:
           type: string
           maxLength: 255
-          pattern: ^[a-z][a-z0-9-]{0,30}[a-z0-9]$
+          pattern: ^[a-zA-Z0-9]?[a-z0-9A-Z.\-]*[a-z0-9A-Z]$
         example:
         - sub-01.example.com
         - sub-02.example.com

--- a/specification/resources/droplets/models/droplet_single_create.yml
+++ b/specification/resources/droplets/models/droplet_single_create.yml
@@ -5,6 +5,8 @@ allOf:
     properties:
       name:
         type: string
+        maxLength: 255
+        pattern: ^[a-z][a-z0-9-]{0,30}[a-z0-9]$
         example: example.com
         description: The human-readable string you wish to use when displaying
           the Droplet name. The name, if set to a domain name managed in the

--- a/specification/resources/droplets/models/droplet_single_create.yml
+++ b/specification/resources/droplets/models/droplet_single_create.yml
@@ -6,7 +6,7 @@ allOf:
       name:
         type: string
         maxLength: 255
-        pattern: ^[a-z][a-z0-9-]{0,30}[a-z0-9]$
+        pattern: ^[a-zA-Z0-9]?[a-z0-9A-Z.\-]*[a-z0-9A-Z]$
         example: example.com
         description: The human-readable string you wish to use when displaying
           the Droplet name. The name, if set to a domain name managed in the


### PR DESCRIPTION
Resolves some customer feedback we received about how the Droplet name field doesn't specify any limits. This PR updates the Droplet name field with the allowed number of characters and alpha-numeric pattern.