### PR TITLE
Pin the Redoc version used in PR previews.

### DIFF
--- a/docs-preview/redoc-index.html
+++ b/docs-preview/redoc-index.html
@@ -103,7 +103,7 @@
         document.querySelector('redoc').setAttribute('spec-url', specUrl);
     </script>
 
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.50/bundles/redoc.standalone.js"> </script>
 </body>
 
 </html>


### PR DESCRIPTION
The live API docs are bundled at version 2.0.0-rc.50:

https://github.com/digitalocean/product-docs/blob/64ac3f9dce1bcc3749d9310c1623bdb5313951ff/assets/js/redoc.js#L4

Let's use the same one for our PR previews.