### PR TITLE
dbaas: metrics_endpoints is readOnly

### DIFF
--- a/specification/resources/databases/models/database_cluster.yml
+++ b/specification/resources/databases/models/database_cluster.yml
@@ -161,7 +161,7 @@ properties:
     description: >-
       Public hostname and port of the cluster's metrics endpoint(s). Includes one record for the cluster's primary node and
       a second entry for the cluster's standby node(s).
-
+    readOnly: true
 
 
 


### PR DESCRIPTION
Reviewing https://github.com/digitalocean/openapi/pull/868, I noticed that `metrics_endpoints` shows up as a create time option when it is not actually user configurable. It should be marked `readOnly`.