### PR TITLE
APPS-8385 Add new instance size fields and new pricing slugs

### DIFF
--- a/specification/resources/apps/apps_create.yml
+++ b/specification/resources/apps/apps_create.yml
@@ -31,7 +31,7 @@ requestBody:
               run_command: bin/api
               environment_slug: node-js
               instance_count: 2
-              instance_size_slug: basic-xxs
+              instance_size_slug: apps-s-1vcpu-0.5gb
               routes:
                 - path: /api
   required: true

--- a/specification/resources/apps/apps_validate_appSpec.yml
+++ b/specification/resources/apps/apps_validate_appSpec.yml
@@ -29,7 +29,7 @@ requestBody:
               run_command: bin/api
               environment_slug: node-js
               instance_count: 2
-              instance_size_slug: basic-xxs
+              instance_size_slug: apps-s-1vcpu-0.5gb
               routes:
                 - path: /api
         app_id: b6bdf840-2854-4f87-a36c-5f231c617c84

--- a/specification/resources/apps/examples/curl/apps_create.yml
+++ b/specification/resources/apps/examples/curl/apps_create.yml
@@ -8,5 +8,5 @@ source: |-
     "services":[{"name":"api","github":{"branch":"main",\
     "deploy_on_push":true,"repo":"digitalocean/sample-golang"}, \
     "run_command":"bin/api","environment_slug":"node-js", \
-    "instance_count":2,"instance_size_slug":"basic-xxs", \
+    "instance_count":2,"instance_size_slug":"apps-s-1vcpu-0.5gb", \
     "routes":[{"path":"/api"}]}]}}'

--- a/specification/resources/apps/examples/python/apps_create.yml
+++ b/specification/resources/apps/examples/python/apps_create.yml
@@ -17,7 +17,7 @@ source: |-
                       "run_command": "bin/api",
                       "environment_slug": "node-js",
                       "instance_count": 2,
-                      "instance_size_slug": "basic-xxs",
+                      "instance_size_slug": "apps-s-1vcpu-0.5gb",
                       "routes": [],
                   }
               ],

--- a/specification/resources/apps/examples/python/apps_get_instanceSize.yml
+++ b/specification/resources/apps/examples/python/apps_get_instanceSize.yml
@@ -5,4 +5,4 @@ source: |-
 
   client = Client(token=os.environ.get("DIGITALOCEAN_TOKEN"))
 
-  get_resp = client.apps.get_instance_size(slug="basic-xxs")
+  get_resp = client.apps.get_instance_size(slug="apps-s-1vcpu-0.5gb")

--- a/specification/resources/apps/examples/python/apps_update.yml
+++ b/specification/resources/apps/examples/python/apps_update.yml
@@ -82,7 +82,7 @@ source: |-
                   },
               },
               "instance_count": 2,
-              "instance_size_slug": "basic-xxs",
+              "instance_size_slug": "apps-s-1vcpu-0.5gb",
               "kind": "PRE_DEPLOY",
           }
       ],
@@ -127,7 +127,7 @@ source: |-
                   },
               },
               "instance_count": 2,
-              "instance_size_slug": "basic-xxs",
+              "instance_size_slug": "apps-s-1vcpu-0.5gb",
           }
       ],
       "functions": [

--- a/specification/resources/apps/models/app_component_instance_base.yml
+++ b/specification/resources/apps/models/app_component_instance_base.yml
@@ -10,21 +10,25 @@ properties:
     example: 2
 
   instance_size_slug:
-    description: 'The instance size to use for this component. Default: `basic-xxs`'
+    description: 'The instance size to use for this component. Default: `apps-s-1vcpu-0.5gb`'
     type: string
     enum:
-    - basic-xxs
-    - basic-xs
-    - basic-s
-    - basic-m
-    - professional-xs
-    - professional-s
-    - professional-m
-    - professional-1l
-    - professional-l
-    - professional-xl
-    default: basic-xxs
-    example: basic-xxs
+    - apps-s-1vcpu-0.5gb
+    - apps-s-1vcpu-1gb-fixed
+    - apps-s-1vcpu-1gb
+    - apps-s-1vcpu-2gb
+    - apps-s-2vcpu-4gb
+    - apps-d-1vcpu-0.5gb
+    - apps-d-1vcpu-1gb
+    - apps-d-1vcpu-2gb
+    - apps-d-1vcpu-4gb
+    - apps-d-2vcpu-4gb
+    - apps-d-2vcpu-8gb
+    - apps-d-4vcpu-8gb
+    - apps-d-4vcpu-16gb
+    - apps-d-8vcpu-32gb
+    default: apps-s-1vcpu-0.5gb
+    example: apps-s-1vcpu-0.5gb
   
   autoscaling:
     description: Configuration for automatically scaling this component based on metrics.

--- a/specification/resources/apps/models/app_propose_response.yml
+++ b/specification/resources/apps/models/app_propose_response.yml
@@ -28,11 +28,7 @@ properties:
   app_cost:
     type: integer
     format: int32
-    description: The monthly cost of the proposed app in USD using the next
-      pricing plan tier. For example, if you propose an app that uses the Basic
-      tier, the `app_tier_upgrade_cost` field displays the monthly cost of the
-      app if it were to use the Professional tier. If the proposed app already
-      uses the most expensive tier, the field is empty.
+    description: The monthly cost of the proposed app in USD.
     example: 5
 
   app_tier_downgrade_cost:

--- a/specification/resources/apps/models/apps_instance_size.yml
+++ b/specification/resources/apps/models/apps_instance_size.yml
@@ -1,4 +1,9 @@
 properties:
+  bandwidth_allowance_gib:
+    format: int64
+    title: The bandwidth allowance in GiB for the instance size
+    type: string
+    example: "1" 
   cpu_type:
     $ref: instance_size_cpu_type.yml
   cpus:
@@ -6,6 +11,10 @@ properties:
     title: The number of allotted vCPU cores
     type: string
     example: "3"
+  deprecation_intent:
+    title: Indicates if the instance size is intended for deprecation
+    type: boolean
+    example: true
   memory_bytes:
     format: int64
     title: The allotted memory in bytes
@@ -15,10 +24,18 @@ properties:
     title: A human-readable name of the instance size
     type: string
     example: name
+  scalable:
+    title: Indicates if the instance size can enable autoscaling
+    type: boolean
+    example: false
+  single_instance_only:
+    title: Indicates if the instance size allows more than one instance
+    type: boolean
+    example: true
   slug:
     title: The slug of the instance size
     type: string
-    example: basic
+    example: apps-s-1vcpu-1gb
   tier_downgrade_to:
     title: The slug of the corresponding downgradable instance size on the lower tier
     type: string

--- a/specification/resources/apps/parameters.yml
+++ b/specification/resources/apps/parameters.yml
@@ -64,7 +64,7 @@ slug_size:
   required: true
   schema:
     type: string
-  example: basic-xxs
+  example: apps-s-1vcpu-0.5gb
 
 component:
   description: An optional component name. If set, logs will be limited to this component

--- a/specification/resources/apps/responses/examples.yml
+++ b/specification/resources/apps/responses/examples.yml
@@ -12,7 +12,7 @@ apps:
                 branch: main
               run_command: heroku-php-apache2
               environment_slug: php
-              instance_size_slug: basic-xxs
+              instance_size_slug: apps-s-1vcpu-0.5gb
               instance_count: 1
               http_port: 8080
               routes:
@@ -36,7 +36,7 @@ apps:
                   branch: main
                 run_command: heroku-php-apache2
                 environment_slug: php
-                instance_size_slug: basic-xxs
+                instance_size_slug: apps-s-1vcpu-0.5gb
                 instance_count: 1
                 http_port: 8080
                 routes:
@@ -65,7 +65,7 @@ apps:
                   branch: main
                 run_command: heroku-php-apache2
                 environment_slug: php
-                instance_size_slug: basic-xxs
+                instance_size_slug: apps-s-1vcpu-0.5gb
                 instance_count: 1
                 http_port: 8080
                 routes:
@@ -212,7 +212,7 @@ app:
             branch: main
           run_command: bin/sample-golang
           environment_slug: go
-          instance_size_slug: basic-xxs
+          instance_size_slug: apps-s-1vcpu-0.5gb
           instance_count: 1
           http_port: 8080
           routes:
@@ -236,7 +236,7 @@ app:
               branch: main
             run_command: bin/sample-golang
             environment_slug: go
-            instance_size_slug: basic-xxs
+            instance_size_slug: apps-s-1vcpu-0.5gb
             instance_count: 1
             http_port: 8080
             routes:
@@ -320,7 +320,7 @@ app:
                 branch: main
               run_command: heroku-php-apache2
               environment_slug: php
-              instance_size_slug: basic-xxs
+              instance_size_slug: apps-s-1vcpu-0.5gb
               instance_count: 1
               http_port: 8080
               routes:
@@ -429,7 +429,7 @@ deployments:
                 branch: branch
               run_command: bin/sample-golang
               environment_slug: go
-              instance_size_slug: basic-xxs
+              instance_size_slug: apps-s-1vcpu-0.5gb
               instance_count: 2
               routes:
                 - path: "/"
@@ -500,7 +500,7 @@ deployment:
               branch: branch
             run_command: bin/sample-golang
             environment_slug: go
-            instance_size_slug: basic-xxs
+            instance_size_slug: apps-s-1vcpu-0.5gb
             instance_count: 2
             routes:
               - path: "/"
@@ -642,109 +642,157 @@ regions:
 instance_sizes:
   value:
     instance_sizes:
-    - name: Basic XXS
-      slug: basic-xxs
+    - name: Shared 1VCPU 0.5GB
+      slug: apps-s-1vcpu-0.5gb
       cpu_type: SHARED
       cpus: '1'
       memory_bytes: '536870912'
       usd_per_month: '5.00'
       usd_per_second: '0.000002066799'
       tier_slug: basic
-      tier_upgrade_to: professional-xs
-    - name: Basic XS
-      slug: basic-xs
+      single_instance_only: true
+      bandwidth_allowance_gib: '50'
+    - name: Shared 1VCPU 1GB Fixed
+      slug: apps-s-1vcpu-1gb-fixed
       cpu_type: SHARED
       cpus: '1'
       memory_bytes: '1073741824'
       usd_per_month: '10.00'
       usd_per_second: '0.000004133598'
       tier_slug: basic
-      tier_upgrade_to: professional-xs
-    - name: Basic S
-      slug: basic-s
-      cpu_type: SHARED
-      cpus: '1'
-      memory_bytes: '2147483648'
-      usd_per_month: '20.00'
-      usd_per_second: '0.000008267196'
-      tier_slug: basic
-      tier_upgrade_to: professional-s
-    - name: Basic M
-      slug: basic-m
-      cpu_type: SHARED
-      cpus: '2'
-      memory_bytes: '4294967296'
-      usd_per_month: '40.00'
-      usd_per_second: '0.000016534392'
-      tier_slug: basic
-      tier_upgrade_to: professional-m
-    - name: Professional XS
-      slug: professional-xs
+      single_instance_only: true
+      bandwidth_allowance_gib: '100'
+    - name: Shared 1VCPU 1GB
+      slug: apps-s-1vcpu-1gb
       cpu_type: SHARED
       cpus: '1'
       memory_bytes: '1073741824'
       usd_per_month: '12.00'
       usd_per_second: '0.000004960317'
       tier_slug: professional
-      tier_downgrade_to: basic-xs
-    - name: Professional S
-      slug: professional-s
+      bandwidth_allowance_gib: '150'
+    - name: Shared 1VCPU 2GB
+      slug: apps-s-1vcpu-2gb
       cpu_type: SHARED
       cpus: '1'
       memory_bytes: '2147483648'
       usd_per_month: '25.00'
       usd_per_second: '0.000010333995'
       tier_slug: professional
-      tier_downgrade_to: basic-s
-    - name: Professional M
-      slug: professional-m
+      bandwidth_allowance_gib: '200'
+    - name: Shared 2VCPU 4GB
+      slug: apps-s-2vcpu-4gb
       cpu_type: SHARED
       cpus: '2'
       memory_bytes: '4294967296'
       usd_per_month: '50.00'
       usd_per_second: '0.000020667989'
       tier_slug: professional
-      tier_downgrade_to: basic-s
-    - name: Professional 1L
-      slug: professional-1l
+      bandwidth_allowance_gib: '250'
+    - name: Dedicated 1VCPU 0.5GB
+      slug: apps-d-1vcpu-0.5gb
+      cpu_type: DEDICATED
+      cpus: '1'
+      memory_bytes: '536870912'
+      usd_per_month: '29.00'
+      usd_per_second: '0.000011987434'
+      tier_slug: professional
+      scalable: true
+      bandwidth_allowance_gib: '100'
+    - name: Dedicated 1VCPU 1GB
+      slug: apps-d-1vcpu-1gb
+      cpu_type: DEDICATED
+      cpus: '1'
+      memory_bytes: '1073741824'
+      usd_per_month: '34.00'
+      usd_per_second: '0.000014054233'
+      tier_slug: professional
+      scalable: true
+      bandwidth_allowance_gib: '200'
+    - name: Dedicated 1VCPU 2GB
+      slug: apps-d-1vcpu-2gb
+      cpu_type: DEDICATED
+      cpus: '1'
+      memory_bytes: '2147483648'
+      usd_per_month: '39.00'
+      usd_per_second: '0.000016121032'
+      tier_slug: professional
+      scalable: true
+      bandwidth_allowance_gib: '300'
+    - name: Dedicated 1VCPU 4GB
+      slug: apps-d-1vcpu-4gb
       cpu_type: DEDICATED
       cpus: '1'
       memory_bytes: '4294967296'
-      usd_per_month: '75.00'
-      usd_per_second: '0.000031001984'
+      usd_per_month: '49.00'
+      usd_per_second: '0.000020254630'
       tier_slug: professional
-      tier_downgrade_to: basic-m
-    - name: Professional L
-      slug: professional-l
+      scalable: true
+      bandwidth_allowance_gib: '400'
+    - name: Dedicated 2VCPU 4GB
+      slug: apps-d-2vcpu-4gb
+      cpu_type: DEDICATED
+      cpus: '2'
+      memory_bytes: '4294967296'
+      usd_per_month: '78.00'
+      usd_per_second: '0.000032242063'
+      tier_slug: professional
+      scalable: true
+      bandwidth_allowance_gib: '500'
+    - name: Dedicated 2VCPU 8GB
+      slug: apps-d-2vcpu-8gb
       cpu_type: DEDICATED
       cpus: '2'
       memory_bytes: '8589934592'
-      usd_per_month: '150.00'
-      usd_per_second: '0.000062003968'
+      usd_per_month: '98.00'
+      usd_per_second: '0.000040509259'
       tier_slug: professional
-      tier_downgrade_to: basic-s
-    - name: Professional XL
-      slug: professional-xl
+      scalable: true
+      bandwidth_allowance_gib: '600'
+    - name: Dedicated 4VCPU 8GB
+      slug: apps-d-4vcpu-8gb
+      cpu_type: DEDICATED
+      cpus: '4'
+      memory_bytes: '8589934592'
+      usd_per_month: '156.00'
+      usd_per_second: '0.000064484127'
+      tier_slug: professional
+      scalable: true
+      bandwidth_allowance_gib: '700'
+    - name: Dedicated 4VCPU 16GB
+      slug: apps-d-4vcpu-16gb
       cpu_type: DEDICATED
       cpus: '4'
       memory_bytes: '17179869184'
-      usd_per_month: '300.00'
-      usd_per_second: '0.000124007937'
+      usd_per_month: '196.00'
+      usd_per_second: '0.000081018519'
       tier_slug: professional
-      tier_downgrade_to: basic-s
+      scalable: true
+      bandwidth_allowance_gib: '800'
+    - name: Dedicated 8VCPU 32GB
+      slug: apps-d-8vcpu-32gb
+      cpu_type: DEDICATED
+      cpus: '8'
+      memory_bytes: '34359738368'
+      usd_per_month: '392.00'
+      usd_per_second: '0.000162037037'
+      tier_slug: professional
+      scalable: true
+      bandwidth_allowance_gib: '900'
 
 instance_size:
   value:
     instance_size:
-      name: Basic XXS
-      slug: basic-xxs
+      name: Shared 1VCPU 0.5GB
+      slug: apps-s-1vcpu-0.5gb
       cpu_type: SHARED
       cpus: '1'
       memory_bytes: '536870912'
       usd_per_month: '5.00'
       usd_per_second: '0.000002066799'
       tier_slug: basic
-      tier_upgrade_to: professional-xs
+      single_instance_only: true
+      bandwidth_allowance_gib: '50'
 
 components:
   value:
@@ -776,14 +824,13 @@ propose:
           branch: branch
         run_command: bin/sample-golang
         environment_slug: go
-        instance_size_slug: basic-xxs
+        instance_size_slug: apps-s-1vcpu-0.5gb
         instance_count: 1
         http_port: 8080
         routes:
         - path: "/"
       region: ams
     app_cost: 5
-    app_tier_upgrade_cost: 17
 
 alerts:
   value:


### PR DESCRIPTION
These changes are to go in as part of Apps relaunch and new pricing rollout in **May**. 

- Uses new instance size slugs in examples and for defaults.
- Adds bandwidth_allowance_gib, deprecation_intent, scalable and single_instance_only to app instance size spec.
