### PR TITLE
APPS-8386: Deprecate tier upgrade/downgrade fields from instance size

### DIFF
--- a/specification/resources/apps/models/app_propose_response.yml
+++ b/specification/resources/apps/models/app_propose_response.yml
@@ -44,3 +44,4 @@ properties:
       monthly cost of the app if it were to use the Basic tier. If the proposed
       app already uses the lest expensive tier, the field is empty.
     example: 17
+    deprecated: true

--- a/specification/resources/apps/models/apps_instance_size.yml
+++ b/specification/resources/apps/models/apps_instance_size.yml
@@ -23,6 +23,7 @@ properties:
     title: The slug of the corresponding downgradable instance size on the lower tier
     type: string
     example: basic
+    deprecated: true
   tier_slug:
     title: The slug of the tier to which this instance size belongs
     type: string
@@ -31,6 +32,7 @@ properties:
     title: The slug of the corresponding upgradable instance size on the higher tier
     type: string
     example: basic
+    deprecated: true
   usd_per_month:
     title: The cost of this instance size in USD per month
     type: string


### PR DESCRIPTION
- Deprecates tier_downgrade_to and tier_upgrade_to from app instance size spec.
- Deprecates app_tier_downgrade_cost from propose app response.