### PR TITLE
Add OpenAPI spec for dedicated egress IPs

### DIFF
--- a/specification/resources/apps/apps_create.yml
+++ b/specification/resources/apps/apps_create.yml
@@ -34,6 +34,8 @@ requestBody:
               instance_size_slug: apps-s-1vcpu-0.5gb
               routes:
                 - path: /api
+          egress:
+            type: DEDICATED_IP
   required: true
 
 responses:

--- a/specification/resources/apps/models/app.yml
+++ b/specification/resources/apps/models/app.yml
@@ -80,6 +80,12 @@ properties:
     allOf:
       - description: The deployment that the app is pinned to.
       - $ref: apps_deployment.yml
+  dedicated_ips:
+    readOnly: true
+    title: The dedicated egress IP addresses associated with the app.
+    type: array
+    items:
+      $ref: apps_dedicated_egress_ip.yml
 required:
 - spec
 type: object

--- a/specification/resources/apps/models/app_egress_spec.yml
+++ b/specification/resources/apps/models/app_egress_spec.yml
@@ -1,0 +1,5 @@
+type: object
+description: Specification for app egress configurations.
+properties:
+  type:
+    $ref: app_egress_type_spec.yml

--- a/specification/resources/apps/models/app_egress_type_spec.yml
+++ b/specification/resources/apps/models/app_egress_type_spec.yml
@@ -1,0 +1,7 @@
+title: The app egress type.
+type: string
+default: AUTOASSIGN
+example: AUTOASSIGN
+enum:
+  - AUTOASSIGN
+  - DEDICATED_IP

--- a/specification/resources/apps/models/app_spec.yml
+++ b/specification/resources/apps/models/app_spec.yml
@@ -74,5 +74,8 @@ properties:
   ingress:
     $ref: app_ingress_spec.yml
 
+  egress:
+    $ref: app_egress_spec.yml
+
 required:
 - name

--- a/specification/resources/apps/models/apps_dedicated_egress_ip.yml
+++ b/specification/resources/apps/models/apps_dedicated_egress_ip.yml
@@ -1,0 +1,13 @@
+type: object
+readOnly: true
+properties:
+  ip:
+    title: The IP address of the dedicated egress IP.
+    type: string
+    example: 192.168.1.1
+  id:
+    title: The ID of the dedicated egress IP. 
+    type: string
+    example: 9e7bc2ac-205a-45d6-919c-e1ac5e73f962
+  status:
+    $ref: apps_dedicated_egress_ip_status.yml

--- a/specification/resources/apps/models/apps_dedicated_egress_ip_status.yml
+++ b/specification/resources/apps/models/apps_dedicated_egress_ip_status.yml
@@ -1,0 +1,10 @@
+title: The status of the dedicated egress IP.
+type: string
+readOnly: true
+default: UNKNOWN
+enum:
+- UNKNOWN
+- ASSIGNING
+- ASSIGNED
+- REMOVED
+example: ASSIGNED

--- a/specification/resources/apps/responses/examples.yml
+++ b/specification/resources/apps/responses/examples.yml
@@ -192,6 +192,13 @@ apps:
               name: configuration-alert
               started_at: '2023-01-30T22:15:46.278987808Z'
               status: SUCCESS
+        dedicated_ips:
+          - ip: 192.168.1.1
+            id: c24d8f48-3bc4-49f5-8ca0-58e8164427ac
+            status: ASSIGNED
+          - ip: 192.168.1.2
+            id: 4768fb15-2837-4dda-9be5-3951df4bc3d0
+            status: ASSIGNED
     links:
       pages: {}
     meta:
@@ -414,6 +421,13 @@ app:
             name: configuration-alert
             started_at: '0001-01-01T00:00:00'
             status: PENDING
+      dedicated_ips:
+        - ip: 192.168.1.1
+          id: c24d8f48-3bc4-49f5-8ca0-58e8164427ac
+          status: ASSIGNED
+        - ip: 192.168.1.2
+          id: 4768fb15-2837-4dda-9be5-3951df4bc3d0
+          status: ASSIGNED
 
 
 deployments:


### PR DESCRIPTION
This updates the OpenAPI spec for App Platform to include dedicated egress IPs.

![Screenshot 2024-05-13 at 10 04 42 AM](https://github.com/digitalocean/openapi/assets/6701014/ecbb3a3d-94b9-41fc-a704-486dfdc2f303)
![Screenshot 2024-05-13 at 10 08 35 AM](https://github.com/digitalocean/openapi/assets/6701014/75add0e3-5a13-45f7-b203-d1dbeccc10fb)
