### PR TITLE
Clarifies that OpenSearch is in Closed Beta

### DIFF
--- a/specification/resources/databases/databases_create_cluster.yml
+++ b/specification/resources/databases/databases_create_cluster.yml
@@ -27,6 +27,8 @@ description: >-
 
   Note: Backups are not supported for Redis clusters.
 
+  OpenSearch is in closed beta. To request access, [contact support](https://cloudsupport.digitalocean.com).
+
 tags:
   - Databases
 

--- a/specification/resources/databases/databases_list_options.yml
+++ b/specification/resources/databases/databases_list_options.yml
@@ -8,6 +8,8 @@ description: >-
 
   The result will be a JSON object with an `options` key.
 
+  OpenSearch is in closed beta. To request access, [contact support](https://cloudsupport.digitalocean.com).
+
 tags:
   - Databases
 

--- a/specification/resources/databases/models/database_cluster.yml
+++ b/specification/resources/databases/models/database_cluster.yml
@@ -24,7 +24,7 @@ properties:
     description: >-
       A slug representing the database engine used for the cluster. The possible values
       are: "pg" for PostgreSQL, "mysql" for MySQL, "redis" for Redis, "mongodb" for MongoDB,
-      "kafka" for Kafka and "opensearch" for Opensearch.
+      "kafka" for Kafka and "opensearch" for OpenSearch. OpenSearch is in closed beta. To request access, [contact support](https://cloudsupport.digitalocean.com).
   version:
     type: string
     example: '8'


### PR DESCRIPTION
No associated JIRA ticket, but see this [Slack thread](https://digitalocean.enterprise.slack.com/archives/C06B5BUV5J9/p1717088106018769) for context.

This PR clarifies that OpenSearch is available in closed beta, and users can contact support for access. Dev requested this since finding users for the closed beta has been difficult, but he doesn't want to surface the rest of our secret closed beta docs in order to manage a potential user influx.