### PR TITLE
APPS-8398: Mark ListTiers and GetTier as deprecated

### DIFF
--- a/specification/resources/apps/apps_get_tier.yml
+++ b/specification/resources/apps/apps_get_tier.yml
@@ -1,8 +1,13 @@
 operationId: apps_get_tier
 
+deprecated: true
+
 summary: Retrieve an App Tier
 
-description: Retrieve information about a specific app tier.
+description: |
+  Retrieve information about a specific app tier. 
+  This endpoint has been deprecated because app tiers are not tied to instance sizes anymore. 
+  The concept of tiers will be retired in the future.
 
 tags:
 - Apps

--- a/specification/resources/apps/apps_list_tiers.yml
+++ b/specification/resources/apps/apps_list_tiers.yml
@@ -1,8 +1,13 @@
 operationId: apps_list_tiers
 
+deprecated: true
+
 summary: List App Tiers
 
-description: List all app tiers.
+description: | 
+  List all app tiers. 
+  This endpoint has been deprecated because app tiers are not tied to instance sizes anymore. 
+  The concept of tiers will be retired in the future.
 
 tags:
 - Apps


### PR DESCRIPTION
After the Apps Relaunch in May, the new pricing structure is not tied to app tiers anymore. Hence, going forward, we would want to retire the use of tiers. 
(Note: The APIs will continue to work for a while until customer comms is done. We are just marking them as deprecated to discourage their usage.)