### PR TITLE
apps: update db engine enum with MongoDB and Kafka

### DIFF
--- a/specification/resources/apps/models/app_database_spec.yml
+++ b/specification/resources/apps/models/app_database_spec.yml
@@ -25,10 +25,14 @@ properties:
     - MYSQL
     - PG
     - REDIS
+    - MONGODB
+    - KAFKA
     description: |-
       - MYSQL: MySQL
       - PG: PostgreSQL
       - REDIS: Redis
+      - MONGODB: MongoDB
+      - KAFKA: Kafka
     example: PG
 
   name:


### PR DESCRIPTION
We're missing App Platform support for MongoDB and Kafka. These values are in the app spec refereance:

https://docs.digitalocean.com/products/app-platform/reference/app-spec/

and godo: https://github.com/digitalocean/godo/blob/2abf3ae0efbbbe5a2c427d2abe25cd756c3f31b6/apps.gen.go#L223-L224


Originally flagged at https://github.com/andrewsomething/app-platform-json-schema/pull/1