### PR TITLE
Add early access control plane firewall new payload and structure definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4744,9 +4744,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
-      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -8578,9 +8578,9 @@
       "dev": true
     },
     "ws": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
-      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "requires": {}
     },

--- a/specification/resources/kubernetes/models/cluster.yml
+++ b/specification/resources/kubernetes/models/cluster.yml
@@ -156,6 +156,8 @@ properties:
     description: A read-only boolean value indicating if a container registry is
       integrated with the cluster.
 
+  control_plane_firewall:
+    $ref: 'control_plane_firewall.yml'
 
 required:
   - name

--- a/specification/resources/kubernetes/models/cluster_update.yml
+++ b/specification/resources/kubernetes/models/cluster_update.yml
@@ -45,5 +45,8 @@ properties:
       is run in a highly available configuration in the cluster. Highly available
       control planes incur less downtime. The property cannot be disabled.
 
+  control_plane_firewall:
+    $ref: 'control_plane_firewall.yml'
+
 required:
   - name

--- a/specification/resources/kubernetes/models/control_plane_firewall.yml
+++ b/specification/resources/kubernetes/models/control_plane_firewall.yml
@@ -6,13 +6,11 @@ properties:
   enable:
     type: boolean
     description: Indicates whether the control plane firewall is enabled.
-    nullable: true
     example: true
 
   allowed_addresses:
     type: array
     description: An array of addresses (IPv4 or CIDR) allowed to access the control plane.
-    nullable: true
     items:
       type: string
     example:

--- a/specification/resources/kubernetes/models/control_plane_firewall.yml
+++ b/specification/resources/kubernetes/models/control_plane_firewall.yml
@@ -1,7 +1,7 @@
 type: object
 nullable: true
 description: An object specifying the control plane firewall for the Kubernetes cluster.
-  Control plane firewall is in early access. To request access, [contact support](https://cloudsupport.digitalocean.com).
+  Control plane firewall is in early availability. To request access, [contact support](https://cloudsupport.digitalocean.com).
 properties:
   enable:
     type: boolean

--- a/specification/resources/kubernetes/models/control_plane_firewall.yml
+++ b/specification/resources/kubernetes/models/control_plane_firewall.yml
@@ -10,9 +10,9 @@ properties:
 
   allowed_addresses:
     type: array
-    description: An array of addresses (IPv4 or CIDR) allowed to access the control plane.
+    description: An array of public addresses (IPv4 or CIDR) allowed to access the control plane.
     items:
       type: string
     example:
-      - 1.2.3.4
-      - 4.3.2.1/32
+      - "1.2.3.4/32"
+      - "1.1.0.0/16"

--- a/specification/resources/kubernetes/models/control_plane_firewall.yml
+++ b/specification/resources/kubernetes/models/control_plane_firewall.yml
@@ -1,0 +1,20 @@
+type: object
+nullable: true
+description: An object specifying the control plane firewall for the Kubernetes cluster.
+  Control plane firewall is in early access. To request access, [contact support](https://cloudsupport.digitalocean.com).
+properties:
+  enable:
+    type: boolean
+    description: Indicates whether the control plane firewall is enabled.
+    nullable: true
+    example: true
+
+  allowed_addresses:
+    type: array
+    description: An array of addresses (IPv4 or CIDR) allowed to access the control plane.
+    nullable: true
+    items:
+      type: string
+    example:
+      - 1.2.3.4
+      - 4.3.2.1/32

--- a/specification/resources/kubernetes/models/control_plane_firewall.yml
+++ b/specification/resources/kubernetes/models/control_plane_firewall.yml
@@ -1,7 +1,7 @@
 type: object
 nullable: true
 description: An object specifying the control plane firewall for the Kubernetes cluster.
-  Control plane firewall is in early availability. To request access, [contact support](https://cloudsupport.digitalocean.com).
+  Control plane firewall is in early availability.
 properties:
   enable:
     type: boolean

--- a/specification/resources/kubernetes/models/control_plane_firewall.yml
+++ b/specification/resources/kubernetes/models/control_plane_firewall.yml
@@ -1,7 +1,7 @@
 type: object
 nullable: true
 description: An object specifying the control plane firewall for the Kubernetes cluster.
-  Control plane firewall is in early availability.
+  Control plane firewall is in early availability (invite only).
 properties:
   enable:
     type: boolean

--- a/specification/resources/kubernetes/responses/examples.yml
+++ b/specification/resources/kubernetes/responses/examples.yml
@@ -98,6 +98,11 @@ kubernetes_clusters_all:
       surge_upgrade: false
       registry_enabled: false
       ha: false
+      control_plane_firewall:
+        enabled: true
+        allowed_addresses:
+          - "1.2.3.4/32"
+          - "1.1.0.0/16"
     meta:
       total: 1
 
@@ -200,6 +205,11 @@ kubernetes_single:
       surge_upgrade: false
       registry_enabled: false
       ha: false
+      control_plane_firewall:
+        enabled: true
+        allowed_addresses:
+          - "1.2.3.4/32"
+          - "1.1.0.0/16"
 
 kubernetes_updated:
   value:
@@ -300,6 +310,11 @@ kubernetes_updated:
       surge_upgrade: true
       registry_enabled: false
       ha: false
+      control_plane_firewall:
+        enabled: true
+        allowed_addresses:
+          - "1.2.3.4/32"
+          - "1.1.0.0/16"
 
 kubernetes_clusters_create_basic_response:
   value:
@@ -365,6 +380,11 @@ kubernetes_clusters_create_basic_response:
       surge_upgrade: false
       registry_enabled: false
       ha: false
+      control_plane_firewall:
+        enabled: true
+        allowed_addresses:
+          - "1.2.3.4/32"
+          - "1.1.0.0/16"
 
 kubernetes_clusters_multi_pool_response:
   value:
@@ -467,6 +487,11 @@ kubernetes_clusters_multi_pool_response:
       surge_upgrade: false
       registry_enabled: false
       ha: false
+      control_plane_firewall:
+        enabled: true
+        allowed_addresses:
+          - "1.2.3.4/32"
+          - "1.1.0.0/16"
 
 kubernetes_options:
   value:


### PR DESCRIPTION
Add early access control plane firewall new payload and structure definition. 

Impacts the response of the `List All Kubernetes Clusters`, `Create a New Kubernetes Cluster`, `Update a Kubernetes Cluster` & `Retrieve an Existing Kubernetes Cluster`.

Impacts the payload of `Create a New Kubernetes Cluster` & `Update a Kubernetes Cluster` with the new optional/nullable `control_plane_firewall` property. Both property are also optional/nullable. 