### PR TITLE
APPS-8872: Change permission requirement to app:read for propose app api

### DIFF
--- a/specification/resources/apps/apps_validate_appSpec.yml
+++ b/specification/resources/apps/apps_validate_appSpec.yml
@@ -53,5 +53,5 @@ responses:
 
 security:
   - bearer_auth:
-    - 'app:create'
+    - 'app:read'
 


### PR DESCRIPTION
The `v2/apps/propose` API doesn't modify any resource even though the method is post and hence `app:read` should suffice. This also makes it consistent with the [graphql operation](https://github.internal.digitalocean.com/IAM/policies/blob/main/policies/v2/graphql_mapping/data.json#L1450-L1455) which is used in the UI. The permission is already modified in the edge config, and we haven't seen [any rejections](https://logs.internal.digitalocean.com/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-2w,to:now))&_a=(columns:!(msg,request_path,response_status,request_user_agent,user_id,X-Org-Id,permissions,request_method),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:edge,key:msg,negate:!f,params:(query:'outgoing%20response'),type:phrase),query:(match_phrase:(msg:'outgoing%20response'))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:edge,key:response_status,negate:!f,params:(query:403),type:phrase),query:(match_phrase:(response_status:403))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:edge,key:user_id,negate:!t,params:(query:'14558595'),type:phrase),query:(match_phrase:(user_id:'14558595')))),index:edge,interval:auto,query:(language:kuery,query:'request_path:%22%2Fv2%2Fapps%2Fpropose%22'),sort:!(!('@timestamp',desc)))) for existing customers.