### PR TITLE
apps: mark prefix matching for CORS allowed origins as deprecated

### DIFF
--- a/specification/resources/apps/models/apps_string_match.yml
+++ b/specification/resources/apps/models/apps_string_match.yml
@@ -15,6 +15,7 @@ properties:
     maxLength: 256
     minLength: 1
     example: https://www.example.com
+    deprecated: true
 
   regex:
     type: string


### PR DESCRIPTION
App Platform has deprecated support for prefix matching for CORS allowed origins.

CC: @ElanHasson 