### PR TITLE
database: size is part of the database replica response schema

### DIFF
--- a/specification/resources/databases/models/database_replica.yml
+++ b/specification/resources/databases/models/database_replica.yml
@@ -20,7 +20,6 @@ properties:
       the cluster.
   size:
     type: string
-    writeOnly: true
     example: db-s-2vcpu-4gb
     description: >-
       A slug identifier representing the size of the node for the read-only


### PR DESCRIPTION
`size` is now included in the API response to `GET /v2/databases/{uuid}/replicas/{name}` and `GET /v2/databases/{uuid}/replicas`.

