### PR TITLE
DB: Logsink response missing root

### DIFF
--- a/specification/resources/databases/responses/logsink.yml
+++ b/specification/resources/databases/responses/logsink.yml
@@ -21,29 +21,32 @@ content:
     examples:
       Create an opensearch logsink:
         value:
-          sink_id: "dfcc9f57d86bf58e321c2c6c31c7a971be244ac7"
-          sink_name: "logs-sink"
-          sink_type: "opensearch"
-          config:
-            url: https://user:passwd@192.168.0.1:25060
-            index_prefix: "opensearch-logs"
-            index_days_max: 5
+          sink:
+            sink_id: "dfcc9f57d86bf58e321c2c6c31c7a971be244ac7"
+            sink_name: "logs-sink"
+            sink_type: "opensearch"
+            config:
+              url: https://user:passwd@192.168.0.1:25060
+              index_prefix: "opensearch-logs"
+              index_days_max: 5
       Create an elasticsearch logsink:
         value:
-          sink_id: "dfcc9f57d86bf58e321c2c6c31c7a971be244ac7"
-          sink_name: "logs-sink"
-          sink_type: "elasticsearch"
-          config:
-            url: https://user:passwd@192.168.0.1:25060
-            index_prefix: "elasticsearch-logs"
-            index_days_max: 5
+          sink:
+            sink_id: "dfcc9f57d86bf58e321c2c6c31c7a971be244ac7"
+            sink_name: "logs-sink"
+            sink_type: "elasticsearch"
+            config:
+              url: https://user:passwd@192.168.0.1:25060
+              index_prefix: "elasticsearch-logs"
+              index_days_max: 5
       Create a rsyslog logsink:
         value:
-          sink_id: "dfcc9f57d86bf58e321c2c6c31c7a971be244ac7"
-          sink_name: logs-sink
-          sink_type: rsyslog
-          config:
-            server: 192.168.0.1
-            port: 514
-            tls: false
-            format: rfc5424
+          sink:
+            sink_id: "dfcc9f57d86bf58e321c2c6c31c7a971be244ac7"
+            sink_name: logs-sink
+            sink_type: rsyslog
+            config:
+              server: 192.168.0.1
+              port: 514
+              tls: false
+              format: rfc5424

--- a/specification/resources/databases/responses/logsink.yml
+++ b/specification/resources/databases/responses/logsink.yml
@@ -11,13 +11,15 @@ headers:
 content:
   application/json:
     schema:
-      allOf:
-        - $ref: "../models/logsink_verbose.yml"
-      required:
-        - sink_id
-        - sink_name
-        - sink_type
-        - config
+      properties:
+        sink:
+          allOf:
+            - $ref: "../models/logsink_verbose.yml"
+          required:
+            - sink_id
+            - sink_name
+            - sink_type
+            - config
     examples:
       Create an opensearch logsink:
         value:


### PR DESCRIPTION
[Documentation](https://docs.digitalocean.com/reference/api/api-reference/#operation/databases_get_logsink) is missing `sink` root:

```
---[ REQUEST ]---------------------------------------
POST /v2/databases/ddddd-0fdd-486b-ab1f-40bc2d87392e/logsink HTTP/1.1
Host: api.digitalocean.com
User-Agent: Terraform/1.5.7 godo/1.122.0
Content-Length: 164
Accept: application/json
Content-Type: application/json
Accept-Encoding: gzip

{
 "sink_name": "sinkexample11",
 "sink_type": "opensearch",
 "config": {
  "url": "https://user:passwd@192.168.0.1:25060",
  "index_prefix": "opensearch-logs",
  "index_days_max": 5
 }
}

```


```
---[ RESPONSE ]--------------------------------------
HTTP/2.0 201 Created
Gateway: Edge-Gateway
X-Request-Id:-83ee-4104-b746-X-Response-From: service

{
 "sink": {
  "sink_id": "ddddd-30aa-4efe-984a-ddddd",
  "sink_name": "sinkexample11",
  "sink_type": "opensearch",
  "config": {
   "url": "https://user:passwd@192.168.0.1:25060",
   "index_prefix": "opensearch-logs",
   "index_days_max": 5
  }
 }
}
```

