### PR TITLE
apps: log_destinations is an array

### DIFF
--- a/specification/resources/apps/models/app_component_base.yml
+++ b/specification/resources/apps/models/app_component_base.yml
@@ -59,4 +59,7 @@ properties:
     example: node-js
 
   log_destinations:
-    $ref: app_log_destination_definition.yml
+    type: array
+    items:
+      $ref: app_log_destination_definition.yml
+    description: A list of configured log forwarding destinations.

--- a/specification/resources/apps/models/app_functions_spec.yml
+++ b/specification/resources/apps/models/app_functions_spec.yml
@@ -50,7 +50,10 @@ properties:
     $ref: apps_gitlab_source_spec.yml
 
   log_destinations:
-    $ref: app_log_destination_definition.yml
+    type: array
+    items:
+      $ref: app_log_destination_definition.yml
+    description: A list of configured log forwarding destinations.
 
 required:
 - name


### PR DESCRIPTION
`log_destinations` is an array. This is a "bug" with the spec, not a change to the API. For example, see godo:

https://github.com/digitalocean/godo/blob/9eb6e771f72ccc97ecfa8df04c433358d486588b/apps.gen.go#L508