### PR TITLE
Fix code examples for image actions

### DIFF
--- a/specification/resources/images/examples/python/imageActions_get.yml
+++ b/specification/resources/images/examples/python/imageActions_get.yml
@@ -5,4 +5,4 @@ source: |-
 
   client = Client(token=os.environ.get("DIGITALOCEAN_TOKEN"))
 
-  resp = client.image_actions.get(image_id="fd9391a")
+  resp = client.image_actions.get(action_id=36805527, image_id=7938269)

--- a/specification/resources/images/examples/python/imageActions_list.yml
+++ b/specification/resources/images/examples/python/imageActions_list.yml
@@ -5,4 +5,4 @@ source: |-
 
   client = Client(token=os.environ.get("DIGITALOCEAN_TOKEN"))
 
-  resp = client.image_actions.list()
+  resp = client.image_actions.list(image_id=7938269)


### PR DESCRIPTION
This change fixes code samples in Python for Image Actions:
[List All Actions for an Image
](https://docs.digitalocean.com/reference/api/api-reference/#operation/imageActions_list)[Retrieve an Existing Action
](http://127.0.0.1:8080/#tag/Image-Actions/operation/imageActions_get)

Related to: https://github.com/digitalocean/pydo/pull/331/files#r1752158258

### Notes
I didn't find an implementation for listing image actions in godo.

Go code example doesn't have an actual call to [List All Actions for an Image](https://docs.digitalocean.com/reference/api/api-reference/#operation/imageActions_list) (please, see the screenshot) and may be confusing.

Should Go code example section be removed?
![Screenshot from 2024-09-10 14-58-58](https://github.com/user-attachments/assets/ee70185d-b188-4402-8155-d43bb702b122)
