### PR TITLE
workflows: use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/spec.main.yml
+++ b/.github/workflows/spec.main.yml
@@ -33,15 +33,18 @@ jobs:
       - name: Bundle
         run: make bundle
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: openapi-bundled
           path: tests/openapi-bundled.yaml
+
       - name: Set outputs
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
       - name: Check outputs
         run: echo ${{ steps.vars.outputs.sha_short }}
+
       - name: Upload Main spec
         run: >-
           aws s3 cp tests/openapi-bundled.yaml
@@ -55,6 +58,7 @@ jobs:
           SPACES_PATH: ${{ secrets.SPACES_PATH }}
           SPACES_ENDPOINT: ${{ secrets.SPACES_ENDPOINT }}
           AWS_EC2_METADATA_DISABLED: true
+
       - name: Upload revision spec
         # this uploads a duplicate of the bundled spec with the short sha
         # appended to the file name for reference during client generation.

--- a/.github/workflows/spec.pr.yml
+++ b/.github/workflows/spec.pr.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Bundle
         run: make bundle
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: openapi-bundled
           path: tests/openapi-bundled.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Bundle
         run: make bundle
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: openapi-bundled
           path: tests/openapi-bundled.yaml

--- a/.github/workflows/spec.pr.yml
+++ b/.github/workflows/spec.pr.yml
@@ -55,11 +55,6 @@ jobs:
       - name: Bundle
         run: make bundle
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: openapi-bundled
-          path: tests/openapi-bundled.yaml
-
       - name: Upload PR spec
         run: >-
           aws s3 cp tests/openapi-bundled.yaml


### PR DESCRIPTION
Our PR workflow has begun failing due to the deprecation of `actions/upload-artifact@v2`

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

https://github.com/digitalocean/openapi/actions/runs/10855754222/job/30129028044?pr=911

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

This also removes a duplicate upload in same workflow due to a breaking change in v4. It was a duplicate and safe to remove.

> Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.

https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes