### PR TITLE
Update Opensearch example protocol to https

### DIFF
--- a/specification/resources/databases/models/opensearch_connection.yml
+++ b/specification/resources/databases/models/opensearch_connection.yml
@@ -5,7 +5,7 @@ properties:
     type: string
     description: >-
      This is provided as a convenience and should be able to be constructed by the other attributes.
-    example: opensearch://doadmin:wv78n3zpz42xezdk@backend-do-user-19081923-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require
+    example: https://doadmin:wv78n3zpz42xezdk@backend-do-user-19081923-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require
     readOnly: true
   host:
     type: string

--- a/specification/resources/databases/models/opensearch_connection.yml
+++ b/specification/resources/databases/models/opensearch_connection.yml
@@ -5,7 +5,7 @@ properties:
     type: string
     description: >-
      This is provided as a convenience and should be able to be constructed by the other attributes.
-    example: https://doadmin:wv78n3zpz42xezdk@backend-do-user-19081923-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require
+    example: https://doadmin:wv78n3zpz42xezdk@backend-do-user-19081923-0.db.ondigitalocean.com:25060
     readOnly: true
   host:
     type: string


### PR DESCRIPTION
This PR updates the `uri` in an Opensearch connection. 

- The correct protocol for connecting to an Opensearch cluster is `https://`, changes from `opensearch://` 
- Truncates unessecary parameters from the `uri`, query parameters (e.g. `defaultdb`) aren't recognized for OS clusters