### PR TITLE
Certificate token scope

### DIFF
--- a/specification/resources/certificates/certificates_get.yml
+++ b/specification/resources/certificates/certificates_get.yml
@@ -39,5 +39,5 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'cdn:read'
+    - 'certificate:read'
 

--- a/specification/resources/certificates/certificates_list.yml
+++ b/specification/resources/certificates/certificates_list.yml
@@ -38,4 +38,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'cdn:read'
+    - 'certificate:read'


### PR DESCRIPTION
Resolves PDOCS-2782. Corrects the token scopes for certificate GET and certificate LIST endpoints.