### PR TITLE
API changes for GPU Droplets

### DIFF
--- a/specification/resources/droplets/droplets_list.yml
+++ b/specification/resources/droplets/droplets_list.yml
@@ -16,6 +16,11 @@ description: |
   parameter set to the name of the tag in your GET request. For example,
   `/v2/droplets?tag_name=$TAG_NAME`.
 
+  ### GPU Droplets
+
+  By default, only non-GPU Droplets are returned. To list only GPU Droplets, set
+  the `type` query parameter to `gpus`. For example, `/v2/droplets?type=gpus`.
+
 tags:
   - Droplets
 
@@ -24,6 +29,7 @@ parameters:
   - $ref: '../../shared/parameters.yml#/page'
   - $ref: 'parameters.yml#/droplet_tag_name'
   - $ref: 'parameters.yml#/droplet_name'
+  - $ref: 'parameters.yml#/droplet_type'
 
 responses:
   '200':

--- a/specification/resources/droplets/models/droplet.yml
+++ b/specification/resources/droplets/models/droplet.yml
@@ -28,6 +28,13 @@ properties:
     example: 25
     description: The size of the Droplet's disk in gigabytes.
 
+  disk_info:
+    type: array
+    description: An array of objects containing information about the disks
+      available to the Droplet.
+    items:
+      $ref: '../../sizes/models/disk_info.yml'
+
   locked:
     type: boolean
     example: false
@@ -146,6 +153,9 @@ properties:
     example: '760e09ef-dc84-11e8-981e-3cfdfeaae000'
     description: A string specifying the UUID of the VPC to which the Droplet
       is assigned.
+
+  gpu_info:
+    $ref: '../../sizes/models/gpu_info.yml'
 
 required:
   - id

--- a/specification/resources/droplets/parameters.yml
+++ b/specification/resources/droplets/parameters.yml
@@ -12,11 +12,25 @@ droplet_tag_name:
   in: query
   name: tag_name
   description: Used to filter Droplets by a specific tag. Can not be combined
-    with `name`.
+    with `name` or `type`.
   required: false
   schema:
     type: string
   example: env:prod
+
+droplet_type:
+  in: query
+  name: type
+  description: When `type` is set to `gpus`, only GPU Droplets will be returned.
+    By default, only non-GPU Droplets are returned. Can not be combined with
+    `tag_name`.
+  required: false
+  schema:
+    type: string
+    enum:
+    - droplets
+    - gpus
+  example: droplets
 
 droplet_delete_tag_name:
   in: query

--- a/specification/resources/droplets/responses/all_droplets.yml
+++ b/specification/resources/droplets/responses/all_droplets.yml
@@ -25,3 +25,5 @@ content:
         $ref: 'examples.yml#/droplets_all'
       Droplets Filtered By Tag:
         $ref: 'examples.yml#/droplets_tagged'
+      GPU Droplets:
+        $ref: 'examples.yml#/gpu_droplets'

--- a/specification/resources/droplets/responses/examples.yml
+++ b/specification/resources/droplets/responses/examples.yml
@@ -6,6 +6,11 @@ droplets_all:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: active
       kernel: null
@@ -126,6 +131,11 @@ droplets_all:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: active
       kernel: null
@@ -239,6 +249,11 @@ droplets_all:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: active
       kernel: null
@@ -360,6 +375,11 @@ droplets_tagged:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: active
       kernel: null
@@ -480,6 +500,11 @@ droplets_tagged:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: active
       kernel: null
@@ -594,6 +619,143 @@ droplets_tagged:
       total:
         2
 
+gpu_droplets:
+  value:
+    droplets:
+    - id: 448543583
+      name: ml-ai-ubuntu-gpu-h100x1-80gb-tor1
+      memory: 245760
+      vcpus: 20
+      disk: 720
+      disk_info:
+      - type: local
+        size:
+          amount: 720
+          unit: gib
+      - type: scratch
+        size:
+          amount: 5120
+          unit: gib
+      locked: false
+      status: active
+      kernel: null
+      created_at: 2024-09-30T15:23:36Z
+      features:
+        - droplet_agent
+        - private_networking
+      backup_ids: []
+      next_backup_window: null
+      snapshot_ids: []
+      image:
+        id: 166407044
+        name: AI/ML Ready H100x1
+        distribution: Ubuntu
+        slug: gpu-h100x1-base
+        public: true
+        regions:
+          - nyc3
+          - nyc1
+          - sfo1
+          - nyc2
+          - ams2
+          - sgp1
+          - lon1
+          - ams3
+          - fra1
+          - tor1
+          - sfo2
+          - blr1
+          - sfo3
+          - syd1
+        created_at: 2024-09-27T15:35:19Z
+        min_disk_size: 25
+        type: base
+        size_gigabytes: 18.47
+        description: GPU H100 1x Base Image
+        tags: []
+        status: available
+      volume_ids: []
+      size:
+        slug: gpu-h100x1-80gb
+        memory: 245760
+        vcpus: 20
+        disk: 720
+        transfer: 15
+        price_monthly: 4529.3
+        price_hourly: 6.74
+        regions:
+          - tor1
+        available: true
+        description: H100 GPU - 1X
+        gpu_info:
+          count: 1
+          vram:
+            amount: 80
+            unit: gib
+          model: nvidia_h100
+        disk_info:
+          - type: local
+            size:
+              amount: 720
+              unit: gib
+          - type: scratch
+            size:
+              amount: 5120
+              unit: gib
+      size_slug: gpu-h100x1-80gb
+      networks:
+        v4:
+        - ip_address: '10.128.192.124'
+          netmask: '255.255.0.0'
+          gateway: nil
+          type: private
+        - ip_address: '192.241.165.154'
+          netmask: '255.255.255.0'
+          gateway: '192.241.165.1'
+          type: public
+        v6: []
+      region:
+        name: Toronto 1
+        slug: tor1
+        features:
+          - backups
+          - ipv6
+          - metadata
+          - install_agent
+          - storage
+          - image_transfer
+          - server_id
+          - management_networking
+        available: true
+        sizes:
+        - s-1vcpu-1gb
+        - s-1vcpu-2gb
+        - s-1vcpu-3gb
+        - s-2vcpu-2gb
+        - s-3vcpu-1gb
+        - s-2vcpu-4gb
+        - s-4vcpu-8gb
+        - s-6vcpu-16gb
+        - s-8vcpu-32gb
+        - s-12vcpu-48gb
+        - s-16vcpu-64gb
+        - s-20vcpu-96gb
+        - s-24vcpu-128gb
+        - s-32vcpu-192g
+        - gpu-h100x1-80gb
+        - gpu-h100x8-640gb
+      tags: []
+      vpc_uuid: e2fdd15c-6ae6-4c11-8c5d-72dae2ba1ad1
+      gpu_info:
+        count: 1
+        vram:
+          amount: 80
+          unit: gib
+        model: nvidia_h100
+    links: {}
+    meta:
+      total: 1
+
 droplet_single:
   value:
     droplet:
@@ -602,6 +764,11 @@ droplet_single:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: active
       kernel: null
@@ -726,6 +893,11 @@ droplet_create_response:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: new
       kernel: null
@@ -839,6 +1011,11 @@ droplet_multi_create_response:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: new
       kernel: null
@@ -943,6 +1120,11 @@ droplet_multi_create_response:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: new
       kernel: null

--- a/specification/resources/sizes/models/disk_info.yml
+++ b/specification/resources/sizes/models/disk_info.yml
@@ -1,0 +1,22 @@
+type: object
+
+properties:
+  type:
+    type: string
+    enum:
+      - local
+      - scratch
+    description: The type of disk. All Droplets contain a `local` disk. Additionally,
+      GPU Droplets can also have a `scratch` disk for non-persistent data.
+    example: local
+  size:
+    type: object
+    properties:
+      amount:
+        type: integer
+        description: The amount of space allocated to the disk.
+        example: 25
+      unit:
+        type: string
+        description: The unit of measure for the disk size.
+        example: gib

--- a/specification/resources/sizes/models/gpu_info.yml
+++ b/specification/resources/sizes/models/gpu_info.yml
@@ -1,0 +1,25 @@
+type: object
+description: >-
+  An object containing information about the GPU capabilities of Droplets
+  created with this size.
+
+properties:
+  count:
+    type: integer
+    description: The number of GPUs allocated to the Droplet.
+    example: 1
+  model:
+    type: string
+    description: The model of the GPU.
+    example: nvidia_h100
+  vram:
+    type: object
+    properties:
+      amount:
+        type: integer
+        description: The amount of VRAM allocated to the GPU.
+        example: 25
+      unit:
+        type: string
+        description: The unit of measure for the VRAM.
+        example: gib

--- a/specification/resources/sizes/models/size.yml
+++ b/specification/resources/sizes/models/size.yml
@@ -18,7 +18,7 @@ properties:
   vcpus:
     type: integer
     example: 1
-    description: The integer of number CPUs allocated to Droplets of this size.
+    description: The number of CPUs allocated to Droplets of this size.
 
   disk:
     type: integer
@@ -87,8 +87,13 @@ properties:
 
   disk_info:
     type: array
+    description: An array of objects containing information about the disks
+      available to Droplets created with this size.
     items:
       $ref: './disk_info.yml'
+
+  gpu_info:
+    $ref: './gpu_info.yml'
 
 required:
   - available

--- a/specification/resources/sizes/models/size.yml
+++ b/specification/resources/sizes/models/size.yml
@@ -85,6 +85,11 @@ properties:
       example: Basic, General Purpose, CPU-Optimized, Memory-Optimized, or
       Storage-Optimized.
 
+  disk_info:
+    type: array
+    items:
+      $ref: './disk_info.yml'
+
 required:
   - available
   - disk

--- a/specification/resources/sizes/responses/all_sizes.yml
+++ b/specification/resources/sizes/responses/all_sizes.yml
@@ -54,7 +54,7 @@ content:
           disk_info:
             - type: "local"
               size:
-                amount: 25,
+                amount: 25
                 unit: "gib"
         links:
           pages:

--- a/specification/resources/sizes/responses/all_sizes.yml
+++ b/specification/resources/sizes/responses/all_sizes.yml
@@ -51,6 +51,11 @@ content:
           - tor1
           available: true
           description: Basic
+          disk_info:
+            - type: "local"
+              size:
+                amount: 25,
+                unit: "gib"
         links:
           pages:
             last: "https://api.digitalocean.com/v2/sizes?page=64&per_page=1"

--- a/specification/shared/attributes/region_slug.yml
+++ b/specification/shared/attributes/region_slug.yml
@@ -17,4 +17,5 @@ enum:
   - sfo3
   - sgp1
   - tor1
+  - syd1
 example: nyc3


### PR DESCRIPTION
This documents the changes to the API that support GPU Droplets:

- New `type` query parameter for `/v2/droplets`
- `disk_info` and `gpu_info` added to the sizes response
- `disk_info` and `gpu_info` added to Droplets responses