### PR TITLE
vpcs: update operationId for vpcs_update_peerings

### DIFF
--- a/specification/resources/vpcs/vpcs_update_peerings.yml
+++ b/specification/resources/vpcs/vpcs_update_peerings.yml
@@ -1,4 +1,4 @@
-operationId: vpcsPeerings_patch
+operationId: vpcs_patch_peerings
 
 summary: Update a VPC Peering
 


### PR DESCRIPTION
This is a follow on to https://github.com/digitalocean/openapi/pull/924. Reviewing https://github.com/digitalocean/pydo/pull/361, I noticed that it creates both  `VpcPeeringsOperations` and `VpcsPeeringsOperations`. This endpoint is under `/v2/vpcs` rather than `/v2/vpcs_peerings`.