### PR TITLE
actions: in-line region_slug property.

### DIFF
--- a/specification/resources/actions/models/action.yml
+++ b/specification/resources/actions/models/action.yml
@@ -49,7 +49,8 @@ properties:
       $ref: '../../regions/models/region.yml'
 
   region_slug:
-    allOf:
-      - $ref: '../../regions/models/region.yml#/properties/slug'
-      - type: string
-        nullable: true
+    type: string
+    nullable: true
+    description: A human-readable string that is used as a unique identifier
+      for each region.
+    example: nyc3


### PR DESCRIPTION
This in-lines the `region_slug` property in the actions response model. We had been overriding the `nullable` attribute using `allOf`. Some tools are not treating this as expected, inlcuding Redocly not displaying the example correctly: 

![image](https://github.com/user-attachments/assets/cf6b1fe6-7d65-4173-bba5-a593553e6a75)

While the duplication isn't ideal, this is the simplest solution to unblock the pdocs team's work on pydo documentation.

CC: @hazel-nut 