### PR TITLE
Add archive field to app maintenance spec

### DIFF
--- a/specification/resources/apps/models/app_maintenance_spec.yml
+++ b/specification/resources/apps/models/app_maintenance_spec.yml
@@ -7,5 +7,5 @@ properties:
     example: true
   archive:
     type: boolean
-    description: Indicates whether the app should be archived. Setting this to true implies that enabled is set to true.
+    description: Indicates whether the app should be archived. Setting this to true implies that enabled is set to true. Note that this feature is currently in closed beta.
     example: true

--- a/specification/resources/apps/models/app_maintenance_spec.yml
+++ b/specification/resources/apps/models/app_maintenance_spec.yml
@@ -1,7 +1,11 @@
 type: object
-description: Specification to configure maintenance settings for the app, such as maintenance mode.
+description: Specification to configure maintenance settings for the app, such as maintenance mode and archiving the app.
 properties:
   enabled:
     type: boolean
     description: Indicates whether maintenance mode should be enabled for the app.
+    example: true
+  archive:
+    type: boolean
+    description: Indicates whether the app should be archived. Setting this to true implies that enabled is set to true.
     example: true


### PR DESCRIPTION
The `archive` field allows users to archive/restore apps.