### PR TITLE
Make sure to display old deprecated instance sizes

### DIFF
--- a/specification/resources/apps/models/app_component_instance_base.yml
+++ b/specification/resources/apps/models/app_component_instance_base.yml
@@ -12,8 +12,8 @@ properties:
   instance_size_slug:
     description: "The instance size to use for this component. Default: `apps-s-1vcpu-0.5gb`"
     oneOf:
-      - $ref: "#/properties/old_instance_size_slug"
-      - type: string
+      - title: "Size slug"
+        type: string
         enum:
           - apps-s-1vcpu-0.5gb
           - apps-s-1vcpu-1gb-fixed
@@ -31,25 +31,25 @@ properties:
           - apps-d-8vcpu-32gb
         default: apps-s-1vcpu-0.5gb
         example: apps-s-1vcpu-0.5gb
+      - title: "Deprecated"
+        description: | 
+          Deprecated size slugs for legacy plans. We strongly encourage customers
+          to use the new plans when creating or upgrading apps.
+        type: string
+        enum:
+          - basic-xxs
+          - basic-xs
+          - basic-s
+          - basic-m
+          - professional-xs
+          - professional-s
+          - professional-m
+          - professional-1l
+          - professional-l
+          - professional-xl
+        example: basic-xxs
+        deprecated: true
     example: apps-s-1vcpu-0.5gb
-
-  old_instance_size_slug:
-    description: "Deprecated in favor of more detailed instance size slugs. Default: `basic-xxs`"
-    type: string
-    enum:
-      - basic-xxs
-      - basic-xs
-      - basic-s
-      - basic-m
-      - professional-xs
-      - professional-s
-      - professional-m
-      - professional-1l
-      - professional-l
-      - professional-xl
-    default: basic-xxs
-    example: basic-xxs
-    deprecated: true
 
   autoscaling:
     description: Configuration for automatically scaling this component based on metrics.

--- a/specification/resources/apps/models/app_component_instance_base.yml
+++ b/specification/resources/apps/models/app_component_instance_base.yml
@@ -5,51 +5,52 @@ properties:
     type: integer
     format: int64
     minimum: 1
-    description: 'The amount of instances that this component should be scaled to. Default: 1. Must not be set if autoscaling is used.'
+    description: "The amount of instances that this component should be scaled to. Default: 1. Must not be set if autoscaling is used."
     default: 1
     example: 2
 
   instance_size_slug:
-    description: 'The instance size to use for this component. Default: `apps-s-1vcpu-0.5gb`'
+    description: "The instance size to use for this component. Default: `apps-s-1vcpu-0.5gb`"
     oneOf:
-      - $ref: '#/properties/old_instance_size_slug'
+      - $ref: "#/properties/old_instance_size_slug"
       - type: string
         enum:
-        - apps-s-1vcpu-0.5gb
-        - apps-s-1vcpu-1gb-fixed
-        - apps-s-1vcpu-1gb
-        - apps-s-1vcpu-2gb
-        - apps-s-2vcpu-4gb
-        - apps-d-1vcpu-0.5gb
-        - apps-d-1vcpu-1gb
-        - apps-d-1vcpu-2gb
-        - apps-d-1vcpu-4gb
-        - apps-d-2vcpu-4gb
-        - apps-d-2vcpu-8gb
-        - apps-d-4vcpu-8gb
-        - apps-d-4vcpu-16gb
-        - apps-d-8vcpu-32gb
+          - apps-s-1vcpu-0.5gb
+          - apps-s-1vcpu-1gb-fixed
+          - apps-s-1vcpu-1gb
+          - apps-s-1vcpu-2gb
+          - apps-s-2vcpu-4gb
+          - apps-d-1vcpu-0.5gb
+          - apps-d-1vcpu-1gb
+          - apps-d-1vcpu-2gb
+          - apps-d-1vcpu-4gb
+          - apps-d-2vcpu-4gb
+          - apps-d-2vcpu-8gb
+          - apps-d-4vcpu-8gb
+          - apps-d-4vcpu-16gb
+          - apps-d-8vcpu-32gb
         default: apps-s-1vcpu-0.5gb
         example: apps-s-1vcpu-0.5gb
+    example: apps-s-1vcpu-0.5gb
 
   old_instance_size_slug:
-    description: 'Deprecated in favor of more detailed instance size slugs. Default: `basic-xxs`'
+    description: "Deprecated in favor of more detailed instance size slugs. Default: `basic-xxs`"
     type: string
     enum:
-    - basic-xxs
-    - basic-xs
-    - basic-s
-    - basic-m
-    - professional-xs
-    - professional-s
-    - professional-m
-    - professional-1l
-    - professional-l
-    - professional-xl
+      - basic-xxs
+      - basic-xs
+      - basic-s
+      - basic-m
+      - professional-xs
+      - professional-s
+      - professional-m
+      - professional-1l
+      - professional-l
+      - professional-xl
     default: basic-xxs
     example: basic-xxs
     deprecated: true
-  
+
   autoscaling:
     description: Configuration for automatically scaling this component based on metrics.
     type: object

--- a/specification/resources/apps/models/app_component_instance_base.yml
+++ b/specification/resources/apps/models/app_component_instance_base.yml
@@ -11,24 +11,44 @@ properties:
 
   instance_size_slug:
     description: 'The instance size to use for this component. Default: `apps-s-1vcpu-0.5gb`'
+    oneOf:
+      - $ref: 'old_instance_size_slug'
+      - type: string
+        enum:
+        - apps-s-1vcpu-0.5gb
+        - apps-s-1vcpu-1gb-fixed
+        - apps-s-1vcpu-1gb
+        - apps-s-1vcpu-2gb
+        - apps-s-2vcpu-4gb
+        - apps-d-1vcpu-0.5gb
+        - apps-d-1vcpu-1gb
+        - apps-d-1vcpu-2gb
+        - apps-d-1vcpu-4gb
+        - apps-d-2vcpu-4gb
+        - apps-d-2vcpu-8gb
+        - apps-d-4vcpu-8gb
+        - apps-d-4vcpu-16gb
+        - apps-d-8vcpu-32gb
+        default: apps-s-1vcpu-0.5gb
+        example: apps-s-1vcpu-0.5gb
+
+  old_instance_size_slug:
+    description: 'Deprecated in favor of more detailed instance size slugs. Default: `basic-xxs`'
     type: string
     enum:
-    - apps-s-1vcpu-0.5gb
-    - apps-s-1vcpu-1gb-fixed
-    - apps-s-1vcpu-1gb
-    - apps-s-1vcpu-2gb
-    - apps-s-2vcpu-4gb
-    - apps-d-1vcpu-0.5gb
-    - apps-d-1vcpu-1gb
-    - apps-d-1vcpu-2gb
-    - apps-d-1vcpu-4gb
-    - apps-d-2vcpu-4gb
-    - apps-d-2vcpu-8gb
-    - apps-d-4vcpu-8gb
-    - apps-d-4vcpu-16gb
-    - apps-d-8vcpu-32gb
-    default: apps-s-1vcpu-0.5gb
-    example: apps-s-1vcpu-0.5gb
+    - basic-xxs
+    - basic-xs
+    - basic-s
+    - basic-m
+    - professional-xs
+    - professional-s
+    - professional-m
+    - professional-1l
+    - professional-l
+    - professional-xl
+    default: basic-xxs
+    example: basic-xxs
+    deprecated: true
   
   autoscaling:
     description: Configuration for automatically scaling this component based on metrics.

--- a/specification/resources/apps/models/app_component_instance_base.yml
+++ b/specification/resources/apps/models/app_component_instance_base.yml
@@ -12,7 +12,7 @@ properties:
   instance_size_slug:
     description: 'The instance size to use for this component. Default: `apps-s-1vcpu-0.5gb`'
     oneOf:
-      - $ref: 'old_instance_size_slug'
+      - $ref: '#/properties/old_instance_size_slug'
       - type: string
         enum:
         - apps-s-1vcpu-0.5gb


### PR DESCRIPTION
Hi,

I'm not entirely sure if this is valid. But I noticed that the old instance slugs still work, but are not part of the schema.

My idea is to display them, but as deprecated. This would be great for the project Im working on, because we still use those old slugs and would benefit from them being present in the API spec.