### PR TITLE
GET /v2/droplets/<id>/destroy_with_associated_resources{/status} require droplet:delete

### DIFF
--- a/specification/resources/droplets/droplets_get_destroyAssociatedResourcesStatus.yml
+++ b/specification/resources/droplets/droplets_get_destroyAssociatedResourcesStatus.yml
@@ -38,4 +38,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'droplet:read'
+    - 'droplet:delete'

--- a/specification/resources/droplets/droplets_list_associatedResources.yml
+++ b/specification/resources/droplets/droplets_list_associatedResources.yml
@@ -42,4 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'droplet:read'
+    - 'droplet:delete'


### PR DESCRIPTION
This fixes the documentation for both `GET /v2/droplets/<id>/destroy_with_associated_resources` and `GET /v2/droplets/<id>/destroy_with_associated_resources/status`. Despite being GETs, they require the`droplet:delete` scope not `droplet:read`.