### PR TITLE
[droplets/backup-policy]: include go and py examples for droplet back…

### DIFF
--- a/specification/resources/droplets/droplets_get_backup_policy.yml
+++ b/specification/resources/droplets/droplets_get_backup_policy.yml
@@ -10,30 +10,32 @@ tags:
   - Droplets
 
 parameters:
-  - $ref: 'parameters.yml#/droplet_id'
+  - $ref: "parameters.yml#/droplet_id"
 
 responses:
-  '200':
-    $ref: 'responses/droplet_backup_policy.yml'
+  "200":
+    $ref: "responses/droplet_backup_policy.yml"
 
-  '401':
-    $ref: '../../shared/responses/unauthorized.yml'
+  "401":
+    $ref: "../../shared/responses/unauthorized.yml"
 
-  '404':
-    $ref: '../../shared/responses/not_found.yml'
+  "404":
+    $ref: "../../shared/responses/not_found.yml"
 
-  '429':
-    $ref: '../../shared/responses/too_many_requests.yml'
+  "429":
+    $ref: "../../shared/responses/too_many_requests.yml"
 
-  '500':
-    $ref: '../../shared/responses/server_error.yml'
+  "500":
+    $ref: "../../shared/responses/server_error.yml"
 
   default:
-    $ref: '../../shared/responses/unexpected_error.yml'
+    $ref: "../../shared/responses/unexpected_error.yml"
 
 x-codeSamples:
-  - $ref: 'examples/curl/droplets_get_backup_policy.yml'
+  - $ref: "examples/curl/droplets_get_backup_policy.yml"
+  - $ref: "examples/go/droplets_get_backup_policy.yml"
+  - $ref: "examples/python/droplets_get_backup_policy.yml"
 
 security:
   - bearer_auth:
-    - 'droplet:read'
+      - "droplet:read"

--- a/specification/resources/droplets/droplets_list_backup_policies.yml
+++ b/specification/resources/droplets/droplets_list_backup_policies.yml
@@ -10,31 +10,33 @@ tags:
   - Droplets
 
 parameters:
-  - $ref: '../../shared/parameters.yml#/per_page'
-  - $ref: '../../shared/parameters.yml#/page'
+  - $ref: "../../shared/parameters.yml#/per_page"
+  - $ref: "../../shared/parameters.yml#/page"
 
 responses:
-  '200':
-    $ref: 'responses/all_droplet_backup_policies.yml'
+  "200":
+    $ref: "responses/all_droplet_backup_policies.yml"
 
-  '401':
-    $ref: '../../shared/responses/unauthorized.yml'
+  "401":
+    $ref: "../../shared/responses/unauthorized.yml"
 
-  '404':
-    $ref: '../../shared/responses/not_found.yml'
+  "404":
+    $ref: "../../shared/responses/not_found.yml"
 
-  '429':
-    $ref: '../../shared/responses/too_many_requests.yml'
+  "429":
+    $ref: "../../shared/responses/too_many_requests.yml"
 
-  '500':
-    $ref: '../../shared/responses/server_error.yml'
+  "500":
+    $ref: "../../shared/responses/server_error.yml"
 
   default:
-    $ref: '../../shared/responses/unexpected_error.yml'
+    $ref: "../../shared/responses/unexpected_error.yml"
 
 x-codeSamples:
-  - $ref: 'examples/curl/droplets_list_backup_policies.yml'
+  - $ref: "examples/curl/droplets_list_backup_policies.yml"
+  - $ref: "examples/go/droplets_list_backup_policies.yml"
+  - $ref: "examples/python/droplets_list_backup_policies.yml"
 
 security:
   - bearer_auth:
-    - 'droplet:read'
+      - "droplet:read"

--- a/specification/resources/droplets/droplets_list_supported_backup_policies.yml
+++ b/specification/resources/droplets/droplets_list_supported_backup_policies.yml
@@ -10,27 +10,29 @@ tags:
   - Droplets
 
 responses:
-  '200':
-    $ref: 'responses/droplets_supported_backup_policies.yml'
+  "200":
+    $ref: "responses/droplets_supported_backup_policies.yml"
 
-  '401':
-    $ref: '../../shared/responses/unauthorized.yml'
+  "401":
+    $ref: "../../shared/responses/unauthorized.yml"
 
-  '404':
-    $ref: '../../shared/responses/not_found.yml'
+  "404":
+    $ref: "../../shared/responses/not_found.yml"
 
-  '429':
-    $ref: '../../shared/responses/too_many_requests.yml'
+  "429":
+    $ref: "../../shared/responses/too_many_requests.yml"
 
-  '500':
-    $ref: '../../shared/responses/server_error.yml'
+  "500":
+    $ref: "../../shared/responses/server_error.yml"
 
   default:
-    $ref: '../../shared/responses/unexpected_error.yml'
+    $ref: "../../shared/responses/unexpected_error.yml"
 
 x-codeSamples:
-  - $ref: 'examples/curl/droplets_list_supported_backup_policies.yml'
+  - $ref: "examples/curl/droplets_list_supported_backup_policies.yml"
+  - $ref: "examples/go/droplets_list_supported_backup_policies.yml"
+  - $ref: "examples/python/droplets_list_supported_backup_policies.yml"
 
 security:
   - bearer_auth:
-    - 'droplet:read'
+      - "droplet:read"

--- a/specification/resources/droplets/examples/go/droplets_get_backup_policy.yml
+++ b/specification/resources/droplets/examples/go/droplets_get_backup_policy.yml
@@ -1,0 +1,17 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "os"
+
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      token := os.Getenv("DIGITALOCEAN_TOKEN")
+
+      client := godo.NewFromToken(token)
+      ctx := context.TODO()
+
+      droplet, _, err := client.Droplets.GetBackupPolicy(ctx, 444909706)
+  }

--- a/specification/resources/droplets/examples/go/droplets_list_backup_policies.yml
+++ b/specification/resources/droplets/examples/go/droplets_list_backup_policies.yml
@@ -1,0 +1,17 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "os"
+
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      token := os.Getenv("DIGITALOCEAN_TOKEN")
+
+      client := godo.NewFromToken(token)
+      ctx := context.TODO()
+
+      droplet, _, err := client.Droplets.ListBackupPolicies(ctx)
+  }

--- a/specification/resources/droplets/examples/go/droplets_list_supported_backup_policies.yml
+++ b/specification/resources/droplets/examples/go/droplets_list_supported_backup_policies.yml
@@ -1,0 +1,17 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "os"
+
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      token := os.Getenv("DIGITALOCEAN_TOKEN")
+
+      client := godo.NewFromToken(token)
+      ctx := context.TODO()
+
+      droplet, _, err := client.Droplets.ListSupportedBackupPolicies(ctx)
+  }

--- a/specification/resources/droplets/examples/python/droplets_get_backup_policy.yml
+++ b/specification/resources/droplets/examples/python/droplets_get_backup_policy.yml
@@ -1,0 +1,8 @@
+lang: Python
+source: |-
+  import os
+  from pydo import Client
+
+  client = Client(token=os.environ.get("DIGITALOCEAN_TOKEN"))
+
+  resp = client.droplets.get_backup_policy(droplet_id=444909706)

--- a/specification/resources/droplets/examples/python/droplets_list_backup_policies.yml
+++ b/specification/resources/droplets/examples/python/droplets_list_backup_policies.yml
@@ -1,0 +1,8 @@
+lang: Python
+source: |-
+  import os
+  from pydo import Client
+
+  client = Client(token=os.environ.get("DIGITALOCEAN_TOKEN"))
+
+  resp = client.droplets.list_backup_policies()

--- a/specification/resources/droplets/examples/python/droplets_list_supported_backup_policies.yml
+++ b/specification/resources/droplets/examples/python/droplets_list_supported_backup_policies.yml
@@ -1,0 +1,8 @@
+lang: Python
+source: |-
+  import os
+  from pydo import Client
+
+  client = Client(token=os.environ.get("DIGITALOCEAN_TOKEN"))
+
+  resp = client.droplets.list_supported_backup_policies()


### PR DESCRIPTION
…up policy get, list and list supported

This PR adds Go and Python examples for Droplet Backup Policy:

- Get
- List
- List Supported

Related godo PR: https://github.com/digitalocean/godo/pull/749/files