### PR TITLE
Add 'type' field to load balancers

### DIFF
--- a/specification/resources/load_balancers/models/load_balancer_base.yml
+++ b/specification/resources/load_balancers/models/load_balancer_base.yml
@@ -169,5 +169,16 @@ properties:
       to resources on the same VPC network. This property cannot be updated after
       creating the load balancer.
 
+  type:
+    type: string
+    example: REGIONAL
+    enum:
+      - REGIONAL
+      - REGIONAL_NETWORK
+    default: REGIONAL
+    description: A string indicating whether the load balancer should be a standard
+      regional load balancer or a regional network load balancer that routes traffic
+      at the TCP/UDP transport layer.
+
 required:
   - forwarding_rules

--- a/specification/resources/load_balancers/models/load_balancer_base.yml
+++ b/specification/resources/load_balancers/models/load_balancer_base.yml
@@ -175,10 +175,11 @@ properties:
     enum:
       - REGIONAL
       - REGIONAL_NETWORK
+      - GLOBAL
     default: REGIONAL
     description: A string indicating whether the load balancer should be a standard
-      regional load balancer or a regional network load balancer that routes traffic
-      at the TCP/UDP transport layer.
+      regional HTTP load balancer, a regional network load balancer that routes traffic
+      at the TCP/UDP transport layer, or a global load balancer.
 
 required:
   - forwarding_rules


### PR DESCRIPTION
Adds a single `type` field to load balancers.

This is for an EA release on 12/12. 