### PR TITLE
Update Caching persistence config doc string

### DIFF
--- a/specification/resources/databases/models/advanced_config/redis_advanced_config.yml
+++ b/specification/resources/databases/models/advanced_config/redis_advanced_config.yml
@@ -86,11 +86,12 @@ properties:
       - "off"
       - rdb
     description: >-
-      When persistence is 'rdb', Redis does RDB dumps each 10 minutes if any key
-      is changed. Also RDB dumps are done according to backup schedule for
-      backup purposes. When persistence is 'off', no RDB dumps and backups are
-      done, so data can be lost at any moment if service is restarted for any
-      reason, or if service is powered off. Also service can't be forked.
+      Creates an RDB dump of the database every 10 minutes that can be used 
+      to recover data after a node crash. The database does not create the 
+      dump if no keys have changed since the last dump. When set to `off`, 
+      the database cannot fork services, and data can be lost if a service 
+      is restarted or powered off. DigitalOcean Managed Caching databases 
+      do not support the Append Only File (AOF) persistence method.
     example: rdb
   redis_acl_channels_default:
     type: string


### PR DESCRIPTION
Resolves [PDOCS-2903](https://do-internal.atlassian.net/browse/PDOCS-2903). Updates the doc string for the `redis_persistence` parameter with new information and cleans up the writing to be more clear.

[PDOCS-2903]: https://do-internal.atlassian.net/browse/PDOCS-2903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ