### PR TITLE
Update API definitions and responses to reflect cluster_autoscaler_configuration support

### DIFF
--- a/specification/resources/kubernetes/models/cluster.yml
+++ b/specification/resources/kubernetes/models/cluster.yml
@@ -67,10 +67,10 @@ properties:
     items:
       type: string
     example:
-    - k8s
-    - k8s:bd5f5959-5e1e-4205-a714-a914373942af
-    - production
-    - web-team
+      - k8s
+      - k8s:bd5f5959-5e1e-4205-a714-a914373942af
+      - production
+      - web-team
     description: An array of tags applied to the Kubernetes cluster. All
       clusters are automatically tagged `k8s` and `k8s:$K8S_CLUSTER_ID`.
 
@@ -79,10 +79,10 @@ properties:
     description: An object specifying the details of the worker nodes available
       to the Kubernetes cluster.
     items:
-      $ref: 'node_pool.yml#/kubernetes_node_pool'
+      $ref: "node_pool.yml#/kubernetes_node_pool"
 
   maintenance_policy:
-    $ref: 'maintenance_policy.yml'
+    $ref: "maintenance_policy.yml"
 
   auto_upgrade:
     type: boolean
@@ -100,13 +100,13 @@ properties:
       state:
         type: string
         enum:
-        - running
-        - provisioning
-        - degraded
-        - error
-        - deleted
-        - upgrading
-        - deleting
+          - running
+          - provisioning
+          - degraded
+          - error
+          - deleted
+          - upgrading
+          - deleting
         example: provisioning
         description: A string indicating the current status of the cluster.
       message:
@@ -156,7 +156,10 @@ properties:
       integrated with the cluster.
 
   control_plane_firewall:
-    $ref: 'control_plane_firewall.yml'
+    $ref: "control_plane_firewall.yml"
+
+  cluster_autoscaler_configuration:
+    $ref: "cluster_autoscaler_configuration.yml"
 
 required:
   - name

--- a/specification/resources/kubernetes/models/cluster_autoscaler_configuration.yml
+++ b/specification/resources/kubernetes/models/cluster_autoscaler_configuration.yml
@@ -1,0 +1,13 @@
+type: object
+nullable: true
+description: An object specifying custom cluster autoscaler configuration.
+properties:
+  scaleDownUtilizationThreshold:
+    type: float
+    description: Used to customize when cluster autoscaler scales down non-empty nodes by setting the node utilization threshold.
+    example: 0.65
+
+  scaleDownUnneededTime:
+    type: string
+    description: Used to customize how long a node is unneeded before being scaled down.
+    example: "1m0s"

--- a/specification/resources/kubernetes/models/cluster_autoscaler_configuration.yml
+++ b/specification/resources/kubernetes/models/cluster_autoscaler_configuration.yml
@@ -3,7 +3,7 @@ nullable: true
 description: An object specifying custom cluster autoscaler configuration.
 properties:
   scaleDownUtilizationThreshold:
-    type: float
+    type: number
     description: Used to customize when cluster autoscaler scales down non-empty nodes by setting the node utilization threshold.
     example: 0.65
 

--- a/specification/resources/kubernetes/models/cluster_autoscaler_configuration.yml
+++ b/specification/resources/kubernetes/models/cluster_autoscaler_configuration.yml
@@ -2,12 +2,12 @@ type: object
 nullable: true
 description: An object specifying custom cluster autoscaler configuration.
 properties:
-  scaleDownUtilizationThreshold:
+  scale_down_utilization_threshold:
     type: number
     description: Used to customize when cluster autoscaler scales down non-empty nodes by setting the node utilization threshold.
     example: 0.65
 
-  scaleDownUnneededTime:
+  scale_down_unneeded_time:
     type: string
     description: Used to customize how long a node is unneeded before being scaled down.
     example: "1m0s"

--- a/specification/resources/kubernetes/models/cluster_update.yml
+++ b/specification/resources/kubernetes/models/cluster_update.yml
@@ -11,15 +11,15 @@ properties:
     items:
       type: string
     example:
-      - k8s
-      - k8s:bd5f5959-5e1e-4205-a714-a914373942af
-      - production
-      - web-team
+    - k8s
+    - k8s:bd5f5959-5e1e-4205-a714-a914373942af
+    - production
+    - web-team
     description: An array of tags applied to the Kubernetes cluster. All
       clusters are automatically tagged `k8s` and `k8s:$K8S_CLUSTER_ID`.
 
   maintenance_policy:
-    $ref: "maintenance_policy.yml"
+    $ref: 'maintenance_policy.yml'
 
   auto_upgrade:
     type: boolean
@@ -46,10 +46,10 @@ properties:
       control planes incur less downtime. The property cannot be disabled.
 
   control_plane_firewall:
-    $ref: "control_plane_firewall.yml"
+    $ref: 'control_plane_firewall.yml'
 
   cluster_autoscaler_configuration:
-    $ref: "cluster_autoscaler_configuration.yml"
+    $ref: 'cluster_autoscaler_configuration.yml'
 
 required:
   - name

--- a/specification/resources/kubernetes/models/cluster_update.yml
+++ b/specification/resources/kubernetes/models/cluster_update.yml
@@ -11,15 +11,15 @@ properties:
     items:
       type: string
     example:
-    - k8s
-    - k8s:bd5f5959-5e1e-4205-a714-a914373942af
-    - production
-    - web-team
+      - k8s
+      - k8s:bd5f5959-5e1e-4205-a714-a914373942af
+      - production
+      - web-team
     description: An array of tags applied to the Kubernetes cluster. All
       clusters are automatically tagged `k8s` and `k8s:$K8S_CLUSTER_ID`.
 
   maintenance_policy:
-    $ref: 'maintenance_policy.yml'
+    $ref: "maintenance_policy.yml"
 
   auto_upgrade:
     type: boolean
@@ -46,7 +46,10 @@ properties:
       control planes incur less downtime. The property cannot be disabled.
 
   control_plane_firewall:
-    $ref: 'control_plane_firewall.yml'
+    $ref: "control_plane_firewall.yml"
+
+  cluster_autoscaler_configuration:
+    $ref: "cluster_autoscaler_configuration.yml"
 
 required:
   - name

--- a/specification/resources/kubernetes/responses/examples.yml
+++ b/specification/resources/kubernetes/responses/examples.yml
@@ -104,8 +104,8 @@ kubernetes_clusters_all:
           - "1.2.3.4/32"
           - "1.1.0.0/16"
       cluster_autoscaler_configuration:
-        scaleDownUtilizationThreshold: 0.65
-        scaleDownUnneededTime: "1m"
+        scale_down_utilization_threshold: 0.65
+        scale_down_unneeded_time: "1m"
     meta:
       total: 1
 
@@ -214,8 +214,8 @@ kubernetes_single:
           - "1.2.3.4/32"
           - "1.1.0.0/16"
       cluster_autoscaler_configuration:
-        scaleDownUtilizationThreshold: 0.65
-        scaleDownUnneededTime: "1m"
+        scale_down_utilization_threshold: 0.65
+        scale_down_unneeded_time: "1m"
 
 kubernetes_updated:
   value:
@@ -322,8 +322,8 @@ kubernetes_updated:
           - "1.2.3.4/32"
           - "1.1.0.0/16"
       cluster_autoscaler_configuration:
-        scaleDownUtilizationThreshold: 0.65
-        scaleDownUnneededTime: "1m"
+        scale_down_utilization_threshold: 0.65
+        scale_down_unneeded_time: "1m"
 
 kubernetes_clusters_create_basic_response:
   value:
@@ -395,8 +395,8 @@ kubernetes_clusters_create_basic_response:
           - "1.2.3.4/32"
           - "1.1.0.0/16"
       cluster_autoscaler_configuration:
-        scaleDownUtilizationThreshold: 0.65
-        scaleDownUnneededTime: "1m"
+        scale_down_utilization_threshold: 0.65
+        scale_down_unneeded_time: "1m"
 
 kubernetes_clusters_multi_pool_response:
   value:
@@ -505,8 +505,8 @@ kubernetes_clusters_multi_pool_response:
           - "1.2.3.4/32"
           - "1.1.0.0/16"
       cluster_autoscaler_configuration:
-        scaleDownUtilizationThreshold: 0.65
-        scaleDownUnneededTime: "1m"
+        scale_down_utilization_threshold: 0.65
+        scale_down_unneeded_time: "1m"
 
 kubernetes_options:
   value:

--- a/specification/resources/kubernetes/responses/examples.yml
+++ b/specification/resources/kubernetes/responses/examples.yml
@@ -103,6 +103,9 @@ kubernetes_clusters_all:
         allowed_addresses:
           - "1.2.3.4/32"
           - "1.1.0.0/16"
+      cluster_autoscaler_configuration:
+        scaleDownUtilizationThreshold: 0.65
+        scaleDownUnneededTime: "1m"
     meta:
       total: 1
 
@@ -210,6 +213,9 @@ kubernetes_single:
         allowed_addresses:
           - "1.2.3.4/32"
           - "1.1.0.0/16"
+      cluster_autoscaler_configuration:
+        scaleDownUtilizationThreshold: 0.65
+        scaleDownUnneededTime: "1m"
 
 kubernetes_updated:
   value:
@@ -315,6 +321,9 @@ kubernetes_updated:
         allowed_addresses:
           - "1.2.3.4/32"
           - "1.1.0.0/16"
+      cluster_autoscaler_configuration:
+        scaleDownUtilizationThreshold: 0.65
+        scaleDownUnneededTime: "1m"
 
 kubernetes_clusters_create_basic_response:
   value:
@@ -385,6 +394,9 @@ kubernetes_clusters_create_basic_response:
         allowed_addresses:
           - "1.2.3.4/32"
           - "1.1.0.0/16"
+      cluster_autoscaler_configuration:
+        scaleDownUtilizationThreshold: 0.65
+        scaleDownUnneededTime: "1m"
 
 kubernetes_clusters_multi_pool_response:
   value:
@@ -492,6 +504,9 @@ kubernetes_clusters_multi_pool_response:
         allowed_addresses:
           - "1.2.3.4/32"
           - "1.1.0.0/16"
+      cluster_autoscaler_configuration:
+        scaleDownUtilizationThreshold: 0.65
+        scaleDownUnneededTime: "1m"
 
 kubernetes_options:
   value:


### PR DESCRIPTION
Add cluster_autoscaler_configuration to the API.

Impacts the response of the List All Kubernetes Clusters, Create a New Kubernetes Cluster, Update a Kubernetes Cluster & Retrieve an Existing Kubernetes Cluster.

Impacts the payload of Create a New Kubernetes Cluster & Update a Kubernetes Cluster with the new optional/nullable control_plane_firewall property. Both property are also optional/nullable.