### PR TITLE
Use actions/upload-artifact@v4 in workflow

### DIFF
--- a/.github/workflows/spec.pr-comment-trigger.yml
+++ b/.github/workflows/spec.pr-comment-trigger.yml
@@ -70,7 +70,7 @@ jobs:
       if: steps.is-digitalocean-member.outputs.result == 'true'
       run: make bundle
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: steps.is-digitalocean-member.outputs.result == 'true'
       with:
         name: openapi-bundled


### PR DESCRIPTION
I somehow missed this one when we updated to `actions/upload-artifact@v4` in https://github.com/digitalocean/openapi/pull/912