### PR TITLE
Add field to customize the offline page during app maintenance

### DIFF
--- a/specification/resources/apps/models/app_maintenance_spec.yml
+++ b/specification/resources/apps/models/app_maintenance_spec.yml
@@ -9,3 +9,7 @@ properties:
     type: boolean
     description: Indicates whether the app should be archived. Setting this to true implies that enabled is set to true. Note that this feature is currently in closed beta.
     example: true
+  offline_page_url:
+    type: string
+    description: A custom offline page to display when maintenance mode is enabled or the app is archived.
+    example: https://example.com/offline.html


### PR DESCRIPTION
The `offline_page_url` allows users to customize the offline page when an app is in maintenance mode or when an app is archived.