### PR TITLE
note on k8s RBAC for custom DO roles

### DIFF
--- a/specification/resources/kubernetes/kubernetes_get_kubeconfig.yml
+++ b/specification/resources/kubernetes/kubernetes_get_kubeconfig.yml
@@ -21,6 +21,12 @@ description: |
   If not set or 0, then the token will have a 7 day expiry. The query parameter
   has no impact in certificate-based authentication.
 
+  Kubernetes Roles granted to a user with a token-based kubeconfig are derived from that user's
+  DigitalOcean role. Predefined roles (Owner, Member, Modifier etc.) have an automatic mapping
+  to Kubernetes roles. Custom roles are not automatically mapped to any Kubernetes roles,
+  and require [additional configuration](https://docs.digitalocean.com/products/kubernetes/how-to/set-up-custom-rolebindings/)
+  by a cluster administrator.
+
 tags:
   - Kubernetes
 


### PR DESCRIPTION
There are some gotchas on how Custom Roles work inside k8s clusters.