### PR TITLE
Update one click api permissions

### DIFF
--- a/specification/resources/1-clicks/oneClicks_install_kubernetes.yml
+++ b/specification/resources/1-clicks/oneClicks_install_kubernetes.yml
@@ -40,4 +40,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - '1click:create'
+    - 'addon:create'

--- a/specification/resources/1-clicks/oneClicks_list.yml
+++ b/specification/resources/1-clicks/oneClicks_list.yml
@@ -38,5 +38,5 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - '1click:read'
+    - 'addon:read'
 


### PR DESCRIPTION
`1click` permissions were deprecated in favor of `addon` permissions on IAM-2228