### PR TITLE
Fix eviction policy enum values to use hyphens instead of underscores

### DIFF
--- a/specification/resources/databases/models/advanced_config/redis_advanced_config.yml
+++ b/specification/resources/databases/models/advanced_config/redis_advanced_config.yml
@@ -2,7 +2,24 @@ type: object
 
 properties:
   redis_maxmemory_policy:
-    $ref: "../eviction_policy_model.yml"
+    type: string
+    enum:
+      - noeviction
+      - allkeys-lru
+      - allkeys-random
+      - volatile-lru
+      - volatile-random
+      - volatile-ttl
+    description: |2-
+      A string specifying the desired eviction policy for the Redis cluster.
+
+      - `noeviction`: Don't evict any data, returns error when memory limit is reached.
+      - `allkeys-lru:` Evict any key, least recently used (LRU) first.
+      - `allkeys-random`: Evict keys in a random order.
+      - `volatile-lru`: Evict keys with expiration only, least recently used (LRU) first.
+      - `volatile-random`: Evict keys with expiration only in a random order.
+      - `volatile-ttl`: Evict keys with expiration only, shortest time-to-live (TTL) first.
+    example: allkeys-lru
   redis_pubsub_client_output_buffer_limit:
     description: >-
       Set output buffer limit for pub / sub clients in MB. The value is the hard

--- a/specification/resources/databases/models/eviction_policy_model.yml
+++ b/specification/resources/databases/models/eviction_policy_model.yml
@@ -1,18 +1,18 @@
 type: string
 enum:
   - noeviction
-  - allkeys_lru
-  - allkeys_random
-  - volatile_lru
-  - volatile_random
-  - volatile_ttl
+  - allkeys-lru
+  - allkeys-random
+  - volatile-lru
+  - volatile-random
+  - volatile-ttl
 description: |2-
   A string specifying the desired eviction policy for the Redis cluster.
 
   - `noeviction`: Don't evict any data, returns error when memory limit is reached.
-  - `allkeys_lru:` Evict any key, least recently used (LRU) first.
-  - `allkeys_random`: Evict keys in a random order.
-  - `volatile_lru`: Evict keys with expiration only, least recently used (LRU) first.
-  - `volatile_random`: Evict keys with expiration only in a random order.
-  - `volatile_ttl`: Evict keys with expiration only, shortest time-to-live (TTL) first.
-example: allkeys_lru
+  - `allkeys-lru:` Evict any key, least recently used (LRU) first.
+  - `allkeys-random`: Evict keys in a random order.
+  - `volatile-lru`: Evict keys with expiration only, least recently used (LRU) first.
+  - `volatile-random`: Evict keys with expiration only in a random order.
+  - `volatile-ttl`: Evict keys with expiration only, shortest time-to-live (TTL) first.
+example: allkeys-lru

--- a/specification/resources/databases/models/eviction_policy_model.yml
+++ b/specification/resources/databases/models/eviction_policy_model.yml
@@ -1,18 +1,18 @@
 type: string
 enum:
   - noeviction
-  - allkeys-lru
-  - allkeys-random
-  - volatile-lru
-  - volatile-random
-  - volatile-ttl
+  - allkeys_lru
+  - allkeys_random
+  - volatile_lru
+  - volatile_random
+  - volatile_ttl
 description: |2-
   A string specifying the desired eviction policy for the Redis cluster.
 
   - `noeviction`: Don't evict any data, returns error when memory limit is reached.
-  - `allkeys-lru:` Evict any key, least recently used (LRU) first.
-  - `allkeys-random`: Evict keys in a random order.
-  - `volatile-lru`: Evict keys with expiration only, least recently used (LRU) first.
-  - `volatile-random`: Evict keys with expiration only in a random order.
-  - `volatile-ttl`: Evict keys with expiration only, shortest time-to-live (TTL) first.
-example: allkeys-lru
+  - `allkeys_lru:` Evict any key, least recently used (LRU) first.
+  - `allkeys_random`: Evict keys in a random order.
+  - `volatile_lru`: Evict keys with expiration only, least recently used (LRU) first.
+  - `volatile_random`: Evict keys with expiration only in a random order.
+  - `volatile_ttl`: Evict keys with expiration only, shortest time-to-live (TTL) first.
+example: allkeys_lru


### PR DESCRIPTION
Fixes the `eviction_policy_model` in the API spec.

Example of it failing with the current values:

```
curl -X PATCH \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer dop_x" \
  -d '{
  "config": {
    "redis_maxmemory_policy": "volatile_lru"
  }
}' \
  "https://api.digitalocean.com/v2/databases/f1900b2d-688b-4898-9eef-83c48df855b2/config"
{"message":"invalid eviction policy - volatile_lru","id":"bad_request","request_id":"d7c7156a-e850-49ac-abed-fb41d8bf0367"}
```