### PR TITLE
Use latest version of Redoc for previews.

### DIFF
--- a/docs-preview/redoc-index.html
+++ b/docs-preview/redoc-index.html
@@ -103,7 +103,7 @@
         document.querySelector('redoc').setAttribute('spec-url', specUrl);
     </script>
 
-    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.50/bundles/redoc.standalone.js"> </script>
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>
 </body>
 
 </html>


### PR DESCRIPTION
Recently the product docs site began using the latest version of Redoc directly from the redoc.ly CDN. Previously we had pinned the version we use for PR previews to use the older version that the product docs site had used. Now that they use latest, we should do the same here.