### PR TITLE
Remove auth 1click list from docs

### DIFF
--- a/specification/resources/1-clicks/examples/curl/oneClicks.yml
+++ b/specification/resources/1-clicks/examples/curl/oneClicks.yml
@@ -2,5 +2,4 @@ lang: cURL
 source: |-
   curl -X GET \
     -H "Content-Type: application/json"  \
-    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
     "https://api.digitalocean.com/v2/1-clicks"

--- a/specification/resources/1-clicks/examples/python/oneClicks.yml
+++ b/specification/resources/1-clicks/examples/python/oneClicks.yml
@@ -3,6 +3,6 @@ source: |-
   import os
   from pydo import Client
 
-  client = Client(token=os.getenv("$DIGITALOCEAN_TOKEN"))
+  client = Client(token="")
 
   one_click_apps = client.one_clicks.list()

--- a/specification/resources/1-clicks/oneClicks_list.yml
+++ b/specification/resources/1-clicks/oneClicks_list.yml
@@ -35,8 +35,3 @@ responses:
 x-codeSamples:
   - $ref: 'examples/curl/oneClicks.yml'
   - $ref: 'examples/python/oneClicks.yml'
-
-security:
-  - bearer_auth:
-    - 'addon:read'
-

--- a/specification/resources/1-clicks/oneClicks_list.yml
+++ b/specification/resources/1-clicks/oneClicks_list.yml
@@ -35,3 +35,6 @@ responses:
 x-codeSamples:
   - $ref: 'examples/curl/oneClicks.yml'
   - $ref: 'examples/python/oneClicks.yml'
+
+security:
+  - bearer_auth: []


### PR DESCRIPTION
1-clicks list is a fully public endpoint and token isn't needed. This PR fixes documentation: token info is removed from list 1clicks information