### PR TITLE
update bearer auth token permissions on some DOKS endpoints

### DIFF
--- a/specification/resources/kubernetes/kubernetes_add_nodePool.yml
+++ b/specification/resources/kubernetes/kubernetes_add_nodePool.yml
@@ -58,4 +58,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'kubernetes:create'
+    - 'kubernetes:update'

--- a/specification/resources/kubernetes/kubernetes_add_registry.yml
+++ b/specification/resources/kubernetes/kubernetes_add_registry.yml
@@ -37,4 +37,5 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'kubernetes:create'
+    - 'kubernetes:update'
+    - 'registry:read'

--- a/specification/resources/kubernetes/kubernetes_delete_node.yml
+++ b/specification/resources/kubernetes/kubernetes_delete_node.yml
@@ -50,4 +50,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'kubernetes:delete'
+    - 'kubernetes:update'

--- a/specification/resources/kubernetes/kubernetes_delete_nodePool.yml
+++ b/specification/resources/kubernetes/kubernetes_delete_nodePool.yml
@@ -43,4 +43,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'kubernetes:delete'
+    - 'kubernetes:update'

--- a/specification/resources/kubernetes/kubernetes_remove_registry.yml
+++ b/specification/resources/kubernetes/kubernetes_remove_registry.yml
@@ -37,4 +37,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'kubernetes:delete'
+    - 'kubernetes:update'

--- a/specification/resources/kubernetes/kubernetes_run_clusterLint.yml
+++ b/specification/resources/kubernetes/kubernetes_run_clusterLint.yml
@@ -52,4 +52,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'kubernetes:create'
+    - 'kubernetes:update'

--- a/specification/resources/kubernetes/kubernetes_upgrade_cluster.yml
+++ b/specification/resources/kubernetes/kubernetes_upgrade_cluster.yml
@@ -55,4 +55,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'kubernetes:create'
+    - 'kubernetes:update'


### PR DESCRIPTION
DOKS is updating required permissions on some endpoints where existing ones seem unintuitive.
Technically, right now both the "old" and the "new" permission for those changing endpoints are accepted, but we'd like the users to go with the new permission, hence omitting the old one from the doc.
The old permissions are to be dropped on ~ Apr 10, after an email to customers goes out plus a month of notice