### PR TITLE
APPS-10258: Update auth token scopes for apps APIs

### DIFF
--- a/specification/resources/apps/apps_create_deployment.yml
+++ b/specification/resources/apps/apps_create_deployment.yml
@@ -43,4 +43,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'app:create'
+    - 'app:update'

--- a/specification/resources/apps/apps_get_exec.yml
+++ b/specification/resources/apps/apps_get_exec.yml
@@ -39,4 +39,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-      - "app:update"
+      - "app:access_console"


### PR DESCRIPTION
Update token permissions on create app deployment and app exec endpoints to improve access control.

Note that, both the previous and the new permission for these endpoints are currently allowed. We choose to just go with the new permissions in the doc to make sure users creating a new token use the ones that will work in the future.
The old permissions will be retired after customer comms and on completion of notice period following that.