### PR TITLE
APPS-10258: Update auth token scope for get exec API

### DIFF
--- a/specification/resources/apps/apps_get_exec_active_deployment.yml
+++ b/specification/resources/apps/apps_get_exec_active_deployment.yml
@@ -38,4 +38,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-      - "app:update"
+      - "app:access_console"


### PR DESCRIPTION
Missed to update scope for app exec per deployment API in https://github.com/digitalocean/openapi/pull/989
