### PR TITLE
Update required permission for 1click install

### DIFF
--- a/specification/resources/1-clicks/oneClicks_install_kubernetes.yml
+++ b/specification/resources/1-clicks/oneClicks_install_kubernetes.yml
@@ -40,4 +40,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'addon:create'
+    - 'kubernetes:update'


### PR DESCRIPTION
Kubernetes 1click installations are not resource creation actions, but updates made to existing clusters. As such, the required permissions to make this call are actually `kubernetes:update` rather than `addon:create`.