### PR TITLE
Update operation IDs for partner attachment endpoints

### DIFF
--- a/specification/resources/partner_network_connect/partner_attachment_bgp_auth_key_get.yml
+++ b/specification/resources/partner_network_connect/partner_attachment_bgp_auth_key_get.yml
@@ -1,9 +1,9 @@
-operationId: attachments_get_bgp_auth_key
+operationId: partnerAttachments_get_bgp_auth_key
 
 summary: Get current BGP auth key for the partner attachment
 
 description: |
-  To get the current BGP auth key for a partner attachment, send a `GET` request to 
+  To get the current BGP auth key for a partner attachment, send a `GET` request to
   `/v2/partner_network_connect/attachments/{pa_id}/bgp_auth_key`.
 
 tags:

--- a/specification/resources/partner_network_connect/partner_attachment_create.yml
+++ b/specification/resources/partner_network_connect/partner_attachment_create.yml
@@ -1,9 +1,9 @@
-operationId: attachments_create
+operationId: partnerAttachments_create
 
 summary: Create a new partner attachment
 
 description: |
-  To create a new partner attachment, send a `POST` request to 
+  To create a new partner attachment, send a `POST` request to
   `/v2/partner_network_connect/attachments` with a JSON object containing the
   required configuration details.
 
@@ -25,7 +25,7 @@ responses:
 
   '404':
     $ref: '../../shared/responses/not_found.yml'
-  
+
   '422':
     $ref: '../../shared/responses/unprocessable_entity.yml'
 

--- a/specification/resources/partner_network_connect/partner_attachment_delete.yml
+++ b/specification/resources/partner_network_connect/partner_attachment_delete.yml
@@ -1,9 +1,9 @@
-operationId: attachments_delete
+operationId: partnerAttachments_delete
 
 summary: Delete an existing partner attachment
 
 description: |
-  To delete an existing partner attachment, send a `DELETE` request to 
+  To delete an existing partner attachment, send a `DELETE` request to
   `/v2/partner_network_connect/attachments/{pa_id}`.
 
 tags:

--- a/specification/resources/partner_network_connect/partner_attachment_get.yml
+++ b/specification/resources/partner_network_connect/partner_attachment_get.yml
@@ -1,9 +1,9 @@
-operationId: attachments_get
+operationId: partnerAttachments_get
 
 summary: Retrieve an existing partner attachment
 
 description: |
-  To get the details of a partner attachment, send a `GET` request to 
+  To get the details of a partner attachment, send a `GET` request to
   `/v2/partner_network_connect/attachments/{pa_id}`.
 
 tags:

--- a/specification/resources/partner_network_connect/partner_attachment_list.yml
+++ b/specification/resources/partner_network_connect/partner_attachment_list.yml
@@ -1,4 +1,4 @@
-operationId: attachments_list
+operationId: partnerAttachments_list
 
 summary: List all partner attachments
 

--- a/specification/resources/partner_network_connect/partner_attachment_remote_routes_list.yml
+++ b/specification/resources/partner_network_connect/partner_attachment_remote_routes_list.yml
@@ -1,9 +1,9 @@
-operationId: attachments_list_remote_routes
+operationId: partnerAttachments_list_remote_routes
 
 summary: List remote routes for a partner attachment
 
 description: |
-  To list all remote routes associated with a partner attachment, send a `GET` request to 
+  To list all remote routes associated with a partner attachment, send a `GET` request to
   `/v2/partner_network_connect/attachments/{pa_id}/remote_routes`.
 
 tags:

--- a/specification/resources/partner_network_connect/partner_attachment_remote_routes_update.yml
+++ b/specification/resources/partner_network_connect/partner_attachment_remote_routes_update.yml
@@ -1,9 +1,9 @@
-operationId: attachments_update_remote_routes
+operationId: partnerAttachments_update_remote_routes
 
 summary: Set remote routes for a partner attachment
 
 description: |
-  To set remote routes for a partner attachment, send a `PUT` request to 
+  To set remote routes for a partner attachment, send a `PUT` request to
   `/v2/partner_network_connect/attachments/{pa_id}/remote_routes` with a JSON object
   containing the remote routes to be set.
 

--- a/specification/resources/partner_network_connect/partner_attachment_service_key_create.yml
+++ b/specification/resources/partner_network_connect/partner_attachment_service_key_create.yml
@@ -1,4 +1,4 @@
-operationId: attachments_create_service_key
+operationId: partnerAttachments_create_service_key
 
 summary: Regenerate the service key for the partner attachment
 

--- a/specification/resources/partner_network_connect/partner_attachment_service_key_get.yml
+++ b/specification/resources/partner_network_connect/partner_attachment_service_key_get.yml
@@ -1,9 +1,9 @@
-operationId: attachments_get_service_key
+operationId: partnerAttachments_get_service_key
 
 summary: Get the current service key for the partner attachment
 
 description: |
-  To get the current service key for a partner attachment, send a `GET` request to 
+  To get the current service key for a partner attachment, send a `GET` request to
   `/v2/partner_network_connect/attachments/{pa_id}/service_key`.
 
 tags:

--- a/specification/resources/partner_network_connect/partner_attachment_update.yml
+++ b/specification/resources/partner_network_connect/partner_attachment_update.yml
@@ -1,9 +1,9 @@
-operationId: attachments_patch
+operationId: partnerAttachments_patch
 
 summary: Update an existing partner attachment
 
 description: |
-  To update an existing partner attachment, send a `PATCH` request to 
+  To update an existing partner attachment, send a `PATCH` request to
   `/v2/partner_network_connect/attachments/{pa_id}` with a JSON object containing the
   fields to be updated.
 


### PR DESCRIPTION
This updates the operation IDs for the partner attachment endpoints so that the generated pydo client follows the same naming scheme as we used in godo. 