### PR TITLE
GenAI cURL example correction

### DIFF
--- a/specification/resources/gen-ai/examples/curl/genai_create_knowledge_base_data_source.yml
+++ b/specification/resources/gen-ai/examples/curl/genai_create_knowledge_base_data_source.yml
@@ -1,6 +1,6 @@
 lang: cURL
 source: |-
-  curl -X DELETE \
+  curl -X POST \
     -H "Content-Type: application/json"  \
     -H "Authorization: Bearer $PREVIEW_API_TOKEN" \
     "https://api.digitalocean.com/v2/gen-ai/knowledge_bases/9a6e3975-b0c6-11ef-bf8f-4e013e2ddde4/data_sources/bd2a2db5-b8b0-11ef-bf8f-4e013e2ddde4"


### PR DESCRIPTION
Resolves [PDOCS-3142](https://do-internal.atlassian.net/browse/PDOCS-3142). Corrects a GenAI cURL example to use `POST` instead of `DELETE`

[PDOCS-3142]: https://do-internal.atlassian.net/browse/PDOCS-3142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ