### PR TITLE
LBAAS: remove TLS cipher policy option weak as it is unused

### DIFF
--- a/specification/resources/load_balancers/models/load_balancer_base.yml
+++ b/specification/resources/load_balancers/models/load_balancer_base.yml
@@ -224,11 +224,10 @@ properties:
     example: STRONG
     enum:
       - DEFAULT
-      - WEAK
       - STRONG
     default: DEFAULT
     description: A string indicating the policy for the TLS cipher suites used by the load balancer.
-      The possible values are `DEFAULT`, `WEAK`, or `STRONG`. The default value is `DEFAULT`.
+      The possible values are `DEFAULT` or `STRONG`. The default value is `DEFAULT`.
 
 required:
   - forwarding_rules


### PR DESCRIPTION
remove TLS cipher policy option weak as it is unused