### PR TITLE
APPS-11227: Add support for VALKEY in apps database spec

### DIFF
--- a/specification/resources/apps/models/app_database_spec.yml
+++ b/specification/resources/apps/models/app_database_spec.yml
@@ -29,6 +29,7 @@ properties:
       - MONGODB
       - KAFKA
       - OPENSEARCH
+      - VALKEY
     description: |-
       - MYSQL: MySQL
       - PG: PostgreSQL
@@ -36,6 +37,7 @@ properties:
       - MONGODB: MongoDB
       - KAFKA: Kafka
       - OPENSEARCH: OpenSearch
+      - VALKEY: ValKey
     example: PG
 
   name:


### PR DESCRIPTION
Add support in App Platform for VALKEY as a new database option.
GA on 04/30.