### PR TITLE
Added examples to get current BGP auth key for partner attachment

### DIFF
--- a/specification/resources/partner_network_connect/examples/curl/partner_attachment_bgp_auth_key_get.yml
+++ b/specification/resources/partner_network_connect/examples/curl/partner_attachment_bgp_auth_key_get.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/partner_network_connect/attachments/1cf0aad8-292b-40f8-9d32-1fbde6e04991/bgp_auth_key"

--- a/specification/resources/partner_network_connect/examples/curl/partner_attachment_bgp_auth_key_get.yml
+++ b/specification/resources/partner_network_connect/examples/curl/partner_attachment_bgp_auth_key_get.yml
@@ -3,4 +3,4 @@ source: |-
   curl -X GET \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-    "https://api.digitalocean.com/v2/partner_network_connect/attachments/1cf0aad8-292b-40f8-9d32-1fbde6e04991/bgp_auth_key"
+    "https://api.digitalocean.com/v2/partner_network_connect/attachments/5a4981aa-9653-4bd1-bef5-d6bff52042e4/bgp_auth_key"

--- a/specification/resources/partner_network_connect/examples/go/partner_attachment_bgp_auth_key_get.yml
+++ b/specification/resources/partner_network_connect/examples/go/partner_attachment_bgp_auth_key_get.yml
@@ -13,5 +13,5 @@ source: |-
       client := godo.NewFromToken(token)
       ctx := context.TODO()
 
-      response, _, err := client.PartnerAttachment.GetBGPAuthKey(ctx,"1cf0aad8-292b-40f8-9d32-1fbde6e04991")
+      response, _, err := client.PartnerAttachment.GetBGPAuthKey(ctx,"5a4981aa-9653-4bd1-bef5-d6bff52042e4")
   }

--- a/specification/resources/partner_network_connect/examples/go/partner_attachment_bgp_auth_key_get.yml
+++ b/specification/resources/partner_network_connect/examples/go/partner_attachment_bgp_auth_key_get.yml
@@ -1,0 +1,17 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "os"
+
+      "github.com/digitalocean/godo"
+  )
+  
+  func main() {
+      token := os.Getenv("DIGITALOCEAN_TOKEN")
+
+      client := godo.NewFromToken(token)
+      ctx := context.TODO()
+
+      response, _, err := client.PartnerAttachment.GetBGPAuthKey(ctx,"1cf0aad8-292b-40f8-9d32-1fbde6e04991")
+  }

--- a/specification/resources/partner_network_connect/examples/python/partner_attachment_bgp_auth_key_get.yml
+++ b/specification/resources/partner_network_connect/examples/python/partner_attachment_bgp_auth_key_get.yml
@@ -1,0 +1,8 @@
+lang: Python
+source: |-
+  import os
+  from pydo import Client
+
+  client = Client(token=os.getenv("$DIGITALOCEAN_TOKEN"))
+
+  response = client.partner_attachments.get_bgp_auth_key("1cf0aad8-292b-40f8-9d32-1fbde6e04991")

--- a/specification/resources/partner_network_connect/examples/python/partner_attachment_bgp_auth_key_get.yml
+++ b/specification/resources/partner_network_connect/examples/python/partner_attachment_bgp_auth_key_get.yml
@@ -5,4 +5,4 @@ source: |-
 
   client = Client(token=os.getenv("$DIGITALOCEAN_TOKEN"))
 
-  response = client.partner_attachments.get_bgp_auth_key("1cf0aad8-292b-40f8-9d32-1fbde6e04991")
+  response = client.partner_attachments.get_bgp_auth_key("5a4981aa-9653-4bd1-bef5-d6bff52042e4")

--- a/specification/resources/partner_network_connect/partner_attachment_bgp_auth_key_get.yml
+++ b/specification/resources/partner_network_connect/partner_attachment_bgp_auth_key_get.yml
@@ -32,13 +32,10 @@ responses:
     $ref: '../../shared/responses/unexpected_error.yml'
 
 x-codeSamples:
-  - lang: cURL
-    source: |-
-      curl -X GET \
-        -H "Content-Type: application/json" \
-        -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-        "https://api.digitalocean.com/v2/partner_network_connect/attachments/1cf0aad8-292b-40f8-9d32-1fbde6e04991/bgp_auth_key"
-
+  - $ref: 'examples/curl/partner_attachment_bgp_auth_key_get.yml'
+  - $ref: 'examples/go/partner_attachment_bgp_auth_key_get.yml'
+  - $ref: 'examples/python/partner_attachment_bgp_auth_key_get.yml'
+ 
 security:
   - bearer_auth:
       - partner_network_connect:read


### PR DESCRIPTION
Added example for cURL, go and python.