### PR TITLE
Adding examples for regenerate service key for partner attachment

### DIFF
--- a/specification/resources/partner_network_connect/examples/curl/partner_attachment_service_key_create.yml
+++ b/specification/resources/partner_network_connect/examples/curl/partner_attachment_service_key_create.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/partner_network_connect/attachments/1cf0aad8-292b-40f8-9d32-1fbde6e04991/service_key"

--- a/specification/resources/partner_network_connect/examples/go/partner_attachment_service_key_create.yml
+++ b/specification/resources/partner_network_connect/examples/go/partner_attachment_service_key_create.yml
@@ -1,0 +1,15 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "os"
+      
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      token := os.Getenv("DIGITALOCEAN_TOKEN")
+      client := godo.NewFromToken(token)
+      ctx := context.TODO()
+      response, _, err := client.PartnerAttachment.RegenerateServiceKey(ctx, "5a4981aa-9653-4bd1-bef5-d6bff52042e4")
+  }

--- a/specification/resources/partner_network_connect/examples/python/partner_attachment_service_key_create.yml
+++ b/specification/resources/partner_network_connect/examples/python/partner_attachment_service_key_create.yml
@@ -1,0 +1,6 @@
+lang: Python
+source: |-
+  import os
+  from pydo import Client
+  client = Client(token=os.getenv("$DIGITALOCEAN_TOKEN"))
+  response = client.partner_attachments.create_service_key("5a4981aa-9653-4bd1-bef5-d6bff52042e4")

--- a/specification/resources/partner_network_connect/partner_attachment_service_key_create.yml
+++ b/specification/resources/partner_network_connect/partner_attachment_service_key_create.yml
@@ -31,12 +31,9 @@ responses:
     $ref: '../../shared/responses/unexpected_error.yml'
 
 x-codeSamples:
-  - lang: cURL
-    source: |-
-      curl -X POST \
-        -H "Content-Type: application/json" \
-        -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-        "https://api.digitalocean.com/v2/partner_network_connect/attachments/1cf0aad8-292b-40f8-9d32-1fbde6e04991/service_key"
+  -  $ref: 'examples/curl/partner_attachment_service_key_create.yml'
+  -  $ref: 'examples/go/partner_attachment_service_key_create.yml'
+  -  $ref: 'examples/python/partner_attachment_service_key_create.yml'
 
 security:
   - bearer_auth:


### PR DESCRIPTION
This PR updates the examples for regenerate service key for partner attachments.

https://github.com/user-attachments/assets/d48f9e62-803c-4c60-af77-f8f76f90211c

