### PR TITLE
DBAAS: Update spec with rbac changes for mongo

### DIFF
--- a/specification/resources/databases/databases_add_user.yml
+++ b/specification/resources/databases/databases_add_user.yml
@@ -60,6 +60,16 @@ requestBody:
           value:
             name: my-readonly
             readonly: true
+
+        Add New User that is restricted to a database (MongoDB Only):
+          value:
+            name: my-readWrite
+            settings:
+              mongo_user_settings:
+                databases:
+                  - my-db
+                  - my-db-2
+                role: readWrite
         
         Add New User for Postgres with replication rights:
           value:

--- a/specification/resources/databases/databases_add_user.yml
+++ b/specification/resources/databases/databases_add_user.yml
@@ -14,6 +14,9 @@ description: |
   When adding a user to a Kafka cluster, additional options can be configured in
   the `settings` object.
 
+   When adding a user to a MongoDB cluster, additional options can be configured in
+  the `settings.mongo_user_settings` object.
+
   The response will be a JSON object with a key called `user`. The value of this will be an
   object that contains the standard attributes associated with a database user including
   its randomly generated password.
@@ -37,8 +40,10 @@ requestBody:
               type: boolean
               example: true
               description: |
+                (To be deprecated: use settings.mongo_user_settings.role instead for access controls to MongoDB databases). 
                 For MongoDB clusters, set to `true` to create a read-only user.
-                This option is not currently supported for other database engines.             
+                This option is not currently supported for other database engines.
+                           
 
       examples:
         Add New User:

--- a/specification/resources/databases/databases_get_user.yml
+++ b/specification/resources/databases/databases_get_user.yml
@@ -16,6 +16,8 @@ description: |
 
   For Kafka clusters, additional options will be contained in the `settings` object.
 
+  For MongoDB clusters, additional information will be contained in the mongo_user_settings object
+
 tags:
   - Databases
 

--- a/specification/resources/databases/databases_list_users.yml
+++ b/specification/resources/databases/databases_list_users.yml
@@ -13,6 +13,8 @@ description: |
 
   For MySQL clusters, additional options will be contained in the mysql_settings object.
 
+  For MongoDB clusters, additional information will be contained in the mongo_user_settings object
+
 tags:
   - Databases
 

--- a/specification/resources/databases/models/user_settings.yml
+++ b/specification/resources/databases/models/user_settings.yml
@@ -68,3 +68,30 @@ properties:
     description: >-
       ACLs (Access Control Lists) specifying permissions on topics within a
       Kafka cluster.
+  mongo_user_settings:
+    type: object
+    properties:
+      databases:
+        type: array
+        items:
+          type: string
+          example: my-db
+        description: >-
+          A list of databases to which the user should have access. When the database is set to `admin`,
+          the user will have access to all databases based on the user's role i.e. a user with the role `readOnly`
+          assigned to the `admin` database will have read access to all databases.
+      role:
+        type: string
+        enum:
+          - readOnly
+          - readWrite
+          - dbAdmin
+        example: readOnly
+        description: >-
+          The role to assign to the user with each role mapping to a MongoDB built-in role. 
+          `readOnly` maps to a [read](https://www.mongodb.com/docs/manual/reference/built-in-roles/#mongodb-authrole-read) role.
+          `readWrite` maps to a [readWrite](https://www.mongodb.com/docs/manual/reference/built-in-roles/#mongodb-authrole-readWrite) role.
+          `dbAdmin` maps to a [dbAdmin](https://www.mongodb.com/docs/manual/reference/built-in-roles/#mongodb-authrole-dbAdmin) role.
+    description: >-
+      MongoDB-specific settings for the user. This option is not currently
+      supported for other database engines.

--- a/specification/resources/databases/models/user_settings.yml
+++ b/specification/resources/databases/models/user_settings.yml
@@ -76,6 +76,7 @@ properties:
         items:
           type: string
           example: my-db
+        example: [my-db, my-db-2]
         description: >-
           A list of databases to which the user should have access. When the database is set to `admin`,
           the user will have access to all databases based on the user's role i.e. a user with the role `readOnly`


### PR DESCRIPTION
Response schema for `GET /users/$username` (similar output for `GET /users/` to list all users)
<img width="1305" alt="image" src="https://github.com/user-attachments/assets/ea92b395-f854-447b-bac0-0ab5aa5aa3b6" />

Request schema for `POST /users`
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/b065d804-6064-4171-8ced-bd1047556422" />

With new example for `POST /users`
<img width="901" alt="image" src="https://github.com/user-attachments/assets/56e90344-0887-49e2-bf39-374a868c2409" />
