### PR TITLE
Add documentation for instance_name for GetExec()

### DIFF
--- a/specification/resources/apps/apps_get_exec.yml
+++ b/specification/resources/apps/apps_get_exec.yml
@@ -4,7 +4,7 @@ summary: Retrieve Exec URL for Deployment
 
 description:
   Returns a websocket URL that allows sending/receiving console input and output
-  to a component of the specified deployment if one exists.
+  to a component of the specified deployment if one exists. Optionally, the instance_name parameter can be provided to retrieve the exec URL for a specific instance. Note that instances are ephemeral; therefore, avoid making persistent changes or scripting around them.
 
 tags:
   - Apps
@@ -13,6 +13,7 @@ parameters:
   - $ref: parameters.yml#/app_id
   - $ref: parameters.yml#/deployment_id
   - $ref: parameters.yml#/component
+  - $ref: parameters.yml#/instance_name
 
 responses:
   "200":

--- a/specification/resources/apps/apps_get_exec.yml
+++ b/specification/resources/apps/apps_get_exec.yml
@@ -4,7 +4,7 @@ summary: Retrieve Exec URL for Deployment
 
 description:
   Returns a websocket URL that allows sending/receiving console input and output
-  to a component of the specified deployment if one exists. Optionally, the instance_name parameter can be provided to retrieve the exec URL for a specific instance. Note that instances are ephemeral; therefore, avoid making persistent changes or scripting around them.
+  to a component of the specified deployment if one exists. Optionally, the instance_name parameter can be provided to retrieve the exec URL for a specific instance. Note that instances are ephemeral; therefore, we recommended to avoid making persistent changes or such scripting around them.
 
 tags:
   - Apps

--- a/specification/resources/apps/parameters.yml
+++ b/specification/resources/apps/parameters.yml
@@ -6,8 +6,8 @@ accept:
   schema:
     type: string
     enum:
-    - application/json
-    - application/yaml
+      - application/json
+      - application/yaml
   example: application/json
 
 content-type:
@@ -18,8 +18,8 @@ content-type:
   schema:
     type: string
     enum:
-    - application/json
-    - application/yaml
+      - application/json
+      - application/yaml
   example: application/json
 
 app_id:
@@ -67,7 +67,8 @@ slug_size:
   example: apps-s-1vcpu-0.5gb
 
 component:
-  description: An optional component name. If set, logs will be limited to this component
+  description:
+    An optional component name. If set, logs will be limited to this component
     only.
   in: path
   name: component_name
@@ -105,17 +106,18 @@ log_type:
   schema:
     default: UNSPECIFIED
     enum:
-    - UNSPECIFIED
-    - BUILD
-    - DEPLOY
-    - RUN
-    - RUN_RESTARTED
+      - UNSPECIFIED
+      - BUILD
+      - DEPLOY
+      - RUN
+      - RUN_RESTARTED
     type: string
   example: BUILD
 
 time_wait:
-  description: 'An optional time duration to wait if the underlying component instance
-    is not immediately available. Default: `3m`.'
+  description:
+    "An optional time duration to wait if the underlying component instance
+    is not immediately available. Default: `3m`."
   in: query
   name: pod_connection_timeout
   schema:
@@ -139,3 +141,12 @@ alert_id:
   schema:
     type: string
   example: 5a624ab5-dd58-4b39-b7dd-8b7c36e8a91d
+
+instance_name:
+  description: The name of the actively running ephemeral compute instance
+  in: path
+  name: instance_name
+  required: false
+  schema:
+    type: string
+  example: go-app-d768568df-zz77d

--- a/specification/resources/apps/parameters.yml
+++ b/specification/resources/apps/parameters.yml
@@ -144,7 +144,7 @@ alert_id:
 
 instance_name:
   description: The name of the actively running ephemeral compute instance
-  in: path
+  in: query
   name: instance_name
   required: false
   schema:


### PR DESCRIPTION
We introduced a new request field `instance_name`, this is optional. This field allows us to get an exec url to a specific instance, beneficial for apps with multiple instances.

This PR adds documentations for that. 
