### PR TITLE
Add get app instances endpoint specs

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -147,7 +147,7 @@ tags:
       offers support for [PostgreSQL](http://docs.digitalocean.com/products/databases/postgresql/),
       [Redis](https://docs.digitalocean.com/products/databases/redis/),
       [Valkey](https://docs.digitalocean.com/products/databases/valkey/),
-      [MySQL](https://docs.digitalocean.com/products/databases/mysql/), 
+      [MySQL](https://docs.digitalocean.com/products/databases/mysql/),
       [MongoDB](https://docs.digitalocean.com/products/databases/mongodb/), and
       [OpenSearch](https://docs.digitalocean.com/products/databases/opensearch/).
 
@@ -398,8 +398,8 @@ tags:
 
   - name: Partner Network Connect
     description: |-
-      Partner Network Connect lets you establish high-bandwidth, low-latency 
-      network connections directly between DigitalOcean VPC networks and other 
+      Partner Network Connect lets you establish high-bandwidth, low-latency
+      network connections directly between DigitalOcean VPC networks and other
       public cloud providers or on-premises datacenters.
 
   - name: Projects
@@ -597,6 +597,10 @@ paths:
   /v2/apps/{app_id}/components/{component_name}/exec:
     get:
       $ref: "resources/apps/apps_get_exec_active_deployment.yml"
+
+  /v2/apps/{app_id}/instances:
+    get:
+      $ref: "resources/apps/apps_get_instances.yml"
 
   /v2/apps/{app_id}/deployments:
     get:
@@ -1916,210 +1920,182 @@ paths:
 
   /v2/gen-ai/agents:
     get:
-      $ref: 'resources/gen-ai/genai_list_agents.yml'
+      $ref: "resources/gen-ai/genai_list_agents.yml"
 
     post:
-      $ref: 'resources/gen-ai/genai_create_agent.yml'
-
+      $ref: "resources/gen-ai/genai_create_agent.yml"
 
   /v2/gen-ai/agents/{agent_uuid}/api_keys:
     get:
-      $ref: 'resources/gen-ai/genai_list_agent_api_keys.yml'
+      $ref: "resources/gen-ai/genai_list_agent_api_keys.yml"
 
     post:
-      $ref: 'resources/gen-ai/genai_create_agent_api_key.yml'
-
+      $ref: "resources/gen-ai/genai_create_agent_api_key.yml"
 
   /v2/gen-ai/agents/{agent_uuid}/api_keys/{api_key_uuid}:
     put:
-      $ref: 'resources/gen-ai/genai_update_agent_api_key.yml'
+      $ref: "resources/gen-ai/genai_update_agent_api_key.yml"
 
     delete:
-      $ref: 'resources/gen-ai/genai_delete_agent_api_key.yml'
-
+      $ref: "resources/gen-ai/genai_delete_agent_api_key.yml"
 
   /v2/gen-ai/agents/{agent_uuid}/api_keys/{api_key_uuid}/regenerate:
     put:
-      $ref: 'resources/gen-ai/genai_regenerate_agent_api_key.yml'
-
+      $ref: "resources/gen-ai/genai_regenerate_agent_api_key.yml"
 
   /v2/gen-ai/agents/{agent_uuid}/functions:
     post:
-      $ref: 'resources/gen-ai/genai_attach_agent_function.yml'
-
+      $ref: "resources/gen-ai/genai_attach_agent_function.yml"
 
   /v2/gen-ai/agents/{agent_uuid}/functions/{function_uuid}:
     put:
-      $ref: 'resources/gen-ai/genai_update_agent_function.yml'
+      $ref: "resources/gen-ai/genai_update_agent_function.yml"
 
     delete:
-      $ref: 'resources/gen-ai/genai_detach_agent_function.yml'
-
+      $ref: "resources/gen-ai/genai_detach_agent_function.yml"
 
   /v2/gen-ai/agents/{agent_uuid}/knowledge_bases:
     post:
-      $ref: 'resources/gen-ai/genai_attach_knowledge_bases.yml'
-
+      $ref: "resources/gen-ai/genai_attach_knowledge_bases.yml"
 
   /v2/gen-ai/agents/{agent_uuid}/knowledge_bases/{knowledge_base_uuid}:
     post:
-      $ref: 'resources/gen-ai/genai_attach_knowledge_base.yml'
+      $ref: "resources/gen-ai/genai_attach_knowledge_base.yml"
 
     delete:
-      $ref: 'resources/gen-ai/genai_detach_knowledge_base.yml'
-
+      $ref: "resources/gen-ai/genai_detach_knowledge_base.yml"
 
   /v2/gen-ai/agents/{parent_agent_uuid}/child_agents/{child_agent_uuid}:
     post:
-      $ref: 'resources/gen-ai/genai_attach_agent.yml'
+      $ref: "resources/gen-ai/genai_attach_agent.yml"
 
     put:
-      $ref: 'resources/gen-ai/genai_update_attached_agent.yml'
+      $ref: "resources/gen-ai/genai_update_attached_agent.yml"
 
     delete:
-      $ref: 'resources/gen-ai/genai_detach_agent.yml'
-
+      $ref: "resources/gen-ai/genai_detach_agent.yml"
 
   /v2/gen-ai/agents/{uuid}:
     get:
-      $ref: 'resources/gen-ai/genai_get_agent.yml'
+      $ref: "resources/gen-ai/genai_get_agent.yml"
 
     put:
-      $ref: 'resources/gen-ai/genai_update_agent.yml'
+      $ref: "resources/gen-ai/genai_update_agent.yml"
 
     delete:
-      $ref: 'resources/gen-ai/genai_delete_agent.yml'
-
+      $ref: "resources/gen-ai/genai_delete_agent.yml"
 
   /v2/gen-ai/agents/{uuid}/child_agents:
     get:
-      $ref: 'resources/gen-ai/genai_get_agent_children.yml'
-
+      $ref: "resources/gen-ai/genai_get_agent_children.yml"
 
   /v2/gen-ai/agents/{uuid}/deployment_visibility:
     put:
-      $ref: 'resources/gen-ai/genai_update_agent_deployment_visibility.yml'
-
+      $ref: "resources/gen-ai/genai_update_agent_deployment_visibility.yml"
 
   /v2/gen-ai/agents/{uuid}/versions:
     get:
-      $ref: 'resources/gen-ai/genai_list_agent_versions.yml'
+      $ref: "resources/gen-ai/genai_list_agent_versions.yml"
 
     put:
-      $ref: 'resources/gen-ai/genai_rollback_to_agent_version.yml'
-
+      $ref: "resources/gen-ai/genai_rollback_to_agent_version.yml"
 
   /v2/gen-ai/anthropic/keys:
     get:
-      $ref: 'resources/gen-ai/genai_list_anthropic_api_keys.yml'
+      $ref: "resources/gen-ai/genai_list_anthropic_api_keys.yml"
 
     post:
-      $ref: 'resources/gen-ai/genai_create_anthropic_api_key.yml'
-
+      $ref: "resources/gen-ai/genai_create_anthropic_api_key.yml"
 
   /v2/gen-ai/anthropic/keys/{api_key_uuid}:
     get:
-      $ref: 'resources/gen-ai/genai_get_anthropic_api_key.yml'
+      $ref: "resources/gen-ai/genai_get_anthropic_api_key.yml"
 
     put:
-      $ref: 'resources/gen-ai/genai_update_anthropic_api_key.yml'
+      $ref: "resources/gen-ai/genai_update_anthropic_api_key.yml"
 
     delete:
-      $ref: 'resources/gen-ai/genai_delete_anthropic_api_key.yml'
-
+      $ref: "resources/gen-ai/genai_delete_anthropic_api_key.yml"
 
   /v2/gen-ai/anthropic/keys/{uuid}/agents:
     get:
-      $ref: 'resources/gen-ai/genai_list_agents_by_anthropic_key.yml'
-
+      $ref: "resources/gen-ai/genai_list_agents_by_anthropic_key.yml"
 
   /v2/gen-ai/indexing_jobs:
     get:
-      $ref: 'resources/gen-ai/genai_list_indexing_jobs.yml'
+      $ref: "resources/gen-ai/genai_list_indexing_jobs.yml"
 
     post:
-      $ref: 'resources/gen-ai/genai_create_indexing_job.yml'
-
+      $ref: "resources/gen-ai/genai_create_indexing_job.yml"
 
   /v2/gen-ai/indexing_jobs/{indexing_job_uuid}/data_sources:
     get:
-      $ref: 'resources/gen-ai/genai_list_indexing_job_data_sources.yml'
-
+      $ref: "resources/gen-ai/genai_list_indexing_job_data_sources.yml"
 
   /v2/gen-ai/indexing_jobs/{uuid}:
     get:
-      $ref: 'resources/gen-ai/genai_get_indexing_job.yml'
-
+      $ref: "resources/gen-ai/genai_get_indexing_job.yml"
 
   /v2/gen-ai/indexing_jobs/{uuid}/cancel:
     put:
-      $ref: 'resources/gen-ai/genai_cancel_indexing_job.yml'
-
+      $ref: "resources/gen-ai/genai_cancel_indexing_job.yml"
 
   /v2/gen-ai/knowledge_bases:
     get:
-      $ref: 'resources/gen-ai/genai_list_knowledge_bases.yml'
+      $ref: "resources/gen-ai/genai_list_knowledge_bases.yml"
 
     post:
-      $ref: 'resources/gen-ai/genai_create_knowledge_base.yml'
-
+      $ref: "resources/gen-ai/genai_create_knowledge_base.yml"
 
   /v2/gen-ai/knowledge_bases/{knowledge_base_uuid}/data_sources:
     get:
-      $ref: 'resources/gen-ai/genai_list_knowledge_base_data_sources.yml'
+      $ref: "resources/gen-ai/genai_list_knowledge_base_data_sources.yml"
 
     post:
-      $ref: 'resources/gen-ai/genai_create_knowledge_base_data_source.yml'
-
+      $ref: "resources/gen-ai/genai_create_knowledge_base_data_source.yml"
 
   /v2/gen-ai/knowledge_bases/{knowledge_base_uuid}/data_sources/{data_source_uuid}:
     delete:
-      $ref: 'resources/gen-ai/genai_delete_knowledge_base_data_source.yml'
-
+      $ref: "resources/gen-ai/genai_delete_knowledge_base_data_source.yml"
 
   /v2/gen-ai/knowledge_bases/{uuid}:
     get:
-      $ref: 'resources/gen-ai/genai_get_knowledge_base.yml'
+      $ref: "resources/gen-ai/genai_get_knowledge_base.yml"
 
     put:
-      $ref: 'resources/gen-ai/genai_update_knowledge_base.yml'
+      $ref: "resources/gen-ai/genai_update_knowledge_base.yml"
 
     delete:
-      $ref: 'resources/gen-ai/genai_delete_knowledge_base.yml'
-
+      $ref: "resources/gen-ai/genai_delete_knowledge_base.yml"
 
   /v2/gen-ai/models:
     get:
-      $ref: 'resources/gen-ai/genai_list_models.yml'
-
+      $ref: "resources/gen-ai/genai_list_models.yml"
 
   /v2/gen-ai/openai/keys:
     get:
-      $ref: 'resources/gen-ai/genai_list_openai_api_keys.yml'
+      $ref: "resources/gen-ai/genai_list_openai_api_keys.yml"
 
     post:
-      $ref: 'resources/gen-ai/genai_create_openai_api_key.yml'
-
+      $ref: "resources/gen-ai/genai_create_openai_api_key.yml"
 
   /v2/gen-ai/openai/keys/{api_key_uuid}:
     get:
-      $ref: 'resources/gen-ai/genai_get_openai_api_key.yml'
+      $ref: "resources/gen-ai/genai_get_openai_api_key.yml"
 
     put:
-      $ref: 'resources/gen-ai/genai_update_openai_api_key.yml'
+      $ref: "resources/gen-ai/genai_update_openai_api_key.yml"
 
     delete:
-      $ref: 'resources/gen-ai/genai_delete_openai_api_key.yml'
-
+      $ref: "resources/gen-ai/genai_delete_openai_api_key.yml"
 
   /v2/gen-ai/openai/keys/{uuid}/agents:
     get:
-      $ref: 'resources/gen-ai/genai_list_agents_by_openai_key.yml'
-
+      $ref: "resources/gen-ai/genai_list_agents_by_openai_key.yml"
 
   /v2/gen-ai/regions:
     get:
-      $ref: 'resources/gen-ai/genai_list_datacenter_regions.yml'
+      $ref: "resources/gen-ai/genai_list_datacenter_regions.yml"
 
 components:
   securitySchemes:

--- a/specification/resources/apps/apps_get_instances.yml
+++ b/specification/resources/apps/apps_get_instances.yml
@@ -1,0 +1,39 @@
+operationId: apps_get_instances
+
+summary: Retrieve App Instances
+
+description:
+  Retrieve the list of running instances for a given app, including instance names and component types.
+  Note that these instances are emphemeral and may change over time. It is
+
+parameters:
+  - $ref: parameters.yml#/app_id
+
+tags:
+  - Apps
+
+responses:
+  "200":
+    $ref: responses/apps_instances.yml
+
+  "401":
+    $ref: ../../shared/responses/unauthorized.yml
+
+  "404":
+    $ref: "../../shared/responses/not_found.yml"
+
+  "429":
+    $ref: "../../shared/responses/too_many_requests.yml"
+
+  "500":
+    $ref: ../../shared/responses/server_error.yml
+
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+
+x-codeSamples:
+  - $ref: "examples/curl/get_app_instances.yml"
+
+security:
+  - bearer_auth:
+      - "app:read"

--- a/specification/resources/apps/apps_get_instances.yml
+++ b/specification/resources/apps/apps_get_instances.yml
@@ -2,9 +2,7 @@ operationId: apps_get_instances
 
 summary: Retrieve App Instances
 
-description:
-  Retrieve the list of running instances for a given app, including instance names and component types.
-  Note that these instances are emphemeral and may change over time. It is
+description: Retrieve the list of running instances for a given application, including instance names and component types. Please note that these instances are ephemeral and may change over time. It is recommended not to make persistent changes or develop scripts that rely on their persistence.
 
 parameters:
   - $ref: parameters.yml#/app_id

--- a/specification/resources/apps/examples/curl/get_app_instances.yml
+++ b/specification/resources/apps/examples/curl/get_app_instances.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/apps/{id}/instances"

--- a/specification/resources/apps/models/app_component_health copy.yml
+++ b/specification/resources/apps/models/app_component_health copy.yml
@@ -1,0 +1,29 @@
+type: object
+properties:
+  name:
+    type: string
+    example: sample_app
+  cpu_usage_percent:
+    type: number
+    format: double
+    example: 30
+  memory_usage_percent:
+    type: number
+    format: double
+    example: 25
+  replicas_desired:
+    type: integer
+    format: int64
+    example: 1
+  replicas_ready:
+    type: integer
+    format: int64
+    example: 1
+  state:
+    type: string
+    enum:
+      - UNKNOWN
+      - HEALTHY
+      - UNHEALTHY
+    default: UNKNOWN
+    example: HEALTHY

--- a/specification/resources/apps/models/app_instance.yml
+++ b/specification/resources/apps/models/app_instance.yml
@@ -1,0 +1,18 @@
+type: object
+properties:
+  component_name:
+    type: string
+    example: sample-golang
+    description: Name of the component, from the app spec.
+  component_type:
+    type: string
+    description: Supported compute component by DigitalOcean App Platform.
+    enum:
+      - SERVICE
+      - WORKER
+      - JOB
+    example: SERVICE
+  instance_name:
+    type: string
+    description: Name of the instance, which is a unique identifier for the instance.
+    example: sample-golang-76b84c7fb8-6p8kq

--- a/specification/resources/apps/models/app_instances.yml
+++ b/specification/resources/apps/models/app_instances.yml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  instances:
+    type: array
+    items:
+      "$ref": app_instance.yml

--- a/specification/resources/apps/models/app_instances_response.yml
+++ b/specification/resources/apps/models/app_instances_response.yml
@@ -1,0 +1,4 @@
+properties:
+  instances:
+    "$ref": app_instances.yml
+type: object

--- a/specification/resources/apps/responses/apps_instances.yml
+++ b/specification/resources/apps/responses/apps_instances.yml
@@ -1,0 +1,17 @@
+description: A JSON with key `instances`
+
+content:
+  application/json:
+    schema:
+      $ref: ../models/app_instances.yml
+    examples:
+      app_instances:
+        $ref: examples.yml#/app_instances
+
+headers:
+  ratelimit-limit:
+    $ref: ../../../shared/headers.yml#/ratelimit-limit
+  ratelimit-remaining:
+    $ref: ../../../shared/headers.yml#/ratelimit-remaining
+  ratelimit-reset:
+    $ref: ../../../shared/headers.yml#/ratelimit-reset

--- a/specification/resources/apps/responses/examples.yml
+++ b/specification/resources/apps/responses/examples.yml
@@ -922,3 +922,18 @@ app_health:
         replicas_desired: 1
         replicas_ready: 2
         state: HEALTHY
+app_instances:
+  value:
+    instances:
+      - component_name: sample-golang
+        instance_name: sample-golang-76b84c7fb8-6p8kq
+        component_type: SERVICE
+      - component_name: sample-golang
+        instance_name: sample-golang-76b84c7fb8-ngvpc
+        component_type: SERVICE
+      - component_name: sample-php
+        instance_name: sample-php-767c6b49c4-dkgpt
+        component_type: SERVICE
+      - component_name: sample-php
+        instance_name: sample-php-767c6b49c4-z8dll
+        component_type: SERVICE


### PR DESCRIPTION
This PR adds specs for `/v2/apps/{app_id}/instances` endpoint. A sample request can be made by running
```curl
curl -X GET \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
    "https://api.digitalocean.com/v2/apps/{$app_id}/instances" | jq
```