### PR TITLE
Add optional instance_name query param for Get Exec URL

### DIFF
--- a/specification/resources/apps/apps_get_exec_active_deployment.yml
+++ b/specification/resources/apps/apps_get_exec_active_deployment.yml
@@ -12,6 +12,7 @@ tags:
 parameters:
   - $ref: parameters.yml#/app_id
   - $ref: parameters.yml#/component
+  - $ref: parameters.yml#/instance_name
 
 responses:
   "200":


### PR DESCRIPTION
We support this parameter both in Get Exec URL and Get Exec URL for Deployment. This PR adds the query parameter option for Get Exec URL. 

Change preview: 
<img width="1644" alt="image" src="https://github.com/user-attachments/assets/0061c8bd-6047-491d-8360-f3e55e7a9a66" />
