### PR TITLE
OpenSearch: disable refresh interval param

### DIFF
--- a/specification/resources/databases/models/advanced_config/opensearch_advanced_config.yml
+++ b/specification/resources/databases/models/advanced_config/opensearch_advanced_config.yml
@@ -302,3 +302,11 @@ properties:
     minimum: 3
     maximum: 100
     default: 50
+  keep_index_refresh_interval:
+    description: >-
+      DigitalOcean automatically resets the `index.refresh_interval` to the default value (once per second) to 
+      ensure that new documents are quickly available for search queries. If you are setting your own refresh intervals, 
+      you can disable this by setting this field to true.
+    example: true
+    type: boolean
+    default: false


### PR DESCRIPTION
Resolves [PDOCS-3255](https://do-internal.atlassian.net/browse/PDOCS-3255). Adds an advanced OpenSearch parameter that allows users to disable automation that automatically sets the index refresh value to its default in the database.

[PDOCS-3255]: https://do-internal.atlassian.net/browse/PDOCS-3255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ