### PR TITLE
New Spectral Function Added: Ensuring Schema property has type defined

### DIFF
--- a/specification/resources/apps/models/app_log_destination_open_search_spec_basic_auth.yml
+++ b/specification/resources/apps/models/app_log_destination_open_search_spec_basic_auth.yml
@@ -7,6 +7,7 @@ properties:
       Defaults to `doadmin` when `cluster_name` is set.
     example: apps_user
   password:
+    type: string
     description: |-
       Password for user defined in User. Is required when `endpoint` is set.
       Cannot be set if using a DigitalOcean DBaaS OpenSearch cluster.

--- a/specification/resources/droplets/responses/all_droplet_backup_policies.yml
+++ b/specification/resources/droplets/responses/all_droplet_backup_policies.yml
@@ -17,6 +17,7 @@ content:
         - type: object
           properties:
             policies:
+              type: object
               description: |
                 A map where the keys are the Droplet IDs and the values are
                 objects containing the backup policy information for each Droplet.

--- a/specification/resources/kubernetes/models/options.yml
+++ b/specification/resources/kubernetes/models/options.yml
@@ -3,6 +3,7 @@ kubernetes_options:
   type: object
   properties:
     options:
+      type: object
       properties:
         regions:
           type: array

--- a/specification/resources/monitoring/models/destination.yml
+++ b/specification/resources/monitoring/models/destination.yml
@@ -11,6 +11,7 @@ properties:
     description: "destination name"
     example: "managed_opensearch_cluster"    
   type:
+    type: string
     enum:
       - opensearch_dbaas
       - opensearch_ext

--- a/specification/resources/monitoring/models/destination_omit_credentials.yml
+++ b/specification/resources/monitoring/models/destination_omit_credentials.yml
@@ -9,6 +9,7 @@ properties:
     description: "destination name"
     example: "managed_opensearch_cluster"    
   type:
+    type: string
     enum:
       - opensearch_dbaas
       - opensearch_ext

--- a/specification/resources/monitoring/models/destination_request.yml
+++ b/specification/resources/monitoring/models/destination_request.yml
@@ -8,6 +8,7 @@ properties:
     description: "destination name"
     example: "managed_opensearch_cluster"
   type:
+    type: string
     enum:
       - opensearch_dbaas
       - opensearch_ext

--- a/specification/resources/regions/models/region.yml
+++ b/specification/resources/regions/models/region.yml
@@ -14,6 +14,7 @@ properties:
     example: nyc3
 
   features:
+    type: array
     items:
       type: string
     description: This attribute is set to an array which contains features available
@@ -34,6 +35,7 @@ properties:
     example: true
 
   sizes:
+    type: array
     items:
       type: string
     description: This attribute is set to an array which contains the identifying

--- a/spectral/functions/ensureSchemaHasType.js
+++ b/spectral/functions/ensureSchemaHasType.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2020 Box, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Ensures that every schema property has a type defined
+ *
+ * This function validates that all schema properties include a 'type' field,
+ * unless they have other valid schema indicators like $ref, allOf, anyOf, oneOf
+ */
+export default (input, _, context) => {
+	if (!input || typeof input !== "object") {
+		return;
+	}
+
+	if (input["$ref"]) {
+		return;
+	}
+
+	if (input["allOf"] || input["anyOf"] || input["oneOf"]) {
+		return;
+	}
+
+	if (context.path.join(".").endsWith(".properties")) {
+		return;
+	}
+
+	const pathString = context.path.join(".");
+	if (pathString.includes(".items.") && !pathString.endsWith(".items")) {
+		return;
+	}
+
+	const hasSchemaLikeProperties =
+		input.description ||
+		input.example ||
+		input.items ||
+		input.properties ||
+		input.enum ||
+		input.format ||
+		input.minimum ||
+		input.maximum ||
+		input.minLength ||
+		input.maxLength;
+
+	if (hasSchemaLikeProperties && !input.type) {
+		return [ {message: `Schema property is missing 'type' field. Path: ${context.path.join(".")}`,},];
+	}
+};

--- a/spectral/ruleset.yml
+++ b/spectral/ruleset.yml
@@ -3,6 +3,7 @@ functions:
   - ensureAllArraysHaveItemTypes
   - ensureSnakeCaseWithDigits
   - validateOpIDNaming
+  - ensureSchemaHasType
 
 rules:
   ratelimit-headers:
@@ -175,6 +176,14 @@ rules:
     then:
       function: ensureSnakeCaseWithDigits
   
+  schema-properties-must-have-type:
+    description: Schema properties must have a type defined
+    given: '$..properties.*'
+    severity: error
+    message: '{{error}}'
+    then:
+      function: ensureSchemaHasType
+      
   oas3-operation-security-defined:
     description: Check operation security is defined
     severity: "error"


### PR DESCRIPTION
[APCLI-3150](https://do-internal.atlassian.net/browse/APICLI-3150)

- some schema defined in openApi spec missing **type** fields which causing **Kiota**(typescript sdk generator) to send out nested value fields response.
- to resolve this issue implemented **ensureSchemaHasType.js** acts as a linter and logs the fields if they do not have a  **type** field.


Example:

```
openapi/specification/resources/monitoring/monitoring_update_destination.yml
 36:14  error  schema-properties-must-have-type  Schema property is missing 'type' field. Path: paths./v2/monitoring/sinks/destinations/{destination_uuid}.post.requestBody.content.application/json.schema.properties.type  requestBody.content.application/json.schema

```
