### PR TITLE
docr: Fix registry create payload model for multi-registry

### DIFF
--- a/specification/resources/registry/models/multiregistry_create.yml
+++ b/specification/resources/registry/models/multiregistry_create.yml
@@ -10,6 +10,16 @@ properties:
       lowercase and be composed only of numbers, letters and `-`, up to a limit
       of 63 characters.
 
+  subscription_tier_slug:
+    type: string
+    enum:
+    - starter
+    - basic
+    - professional
+    example: basic
+    description: The slug of the subscription tier to sign up for. Valid values
+      can be retrieved using the options endpoint.
+
   region:
     type: string
     enum:


### PR DESCRIPTION
The registry create model for mult-registry was missing `subscsription_tier_slug` - added that. 