### PR TITLE
reservedIPv6: fix tagging and remove 'Public Preview.'

### DIFF
--- a/specification/resources/reserved_ipv6/reservedIPv6Actions_post.yml
+++ b/specification/resources/reserved_ipv6/reservedIPv6Actions_post.yml
@@ -1,6 +1,6 @@
 operationId: reservedIPv6Actions_post
 
-summary: "[Public Preview] Initiate a Reserved IPv6 Action"
+summary: "Initiate a Reserved IPv6 Action"
 
 description: |
     To initiate an action on a reserved IPv6 send a POST request to
@@ -13,7 +13,7 @@ description: |
     | `unassign` | Unassign a reserved IPv6 from a Droplet
 
 tags:
-  -  "[Public Preview] Reserved IPv6 Actions"
+  -  "Reserved IPv6 Actions"
 
 parameters:
   - $ref: 'parameters.yml#/reserved_ipv6'

--- a/specification/resources/reserved_ipv6/reservedIPv6_create.yml
+++ b/specification/resources/reserved_ipv6/reservedIPv6_create.yml
@@ -1,6 +1,6 @@
 operationId: reservedIPv6_create
 
-summary: "[Public Preview] Create a New Reserved IPv6"
+summary: "Create a New Reserved IPv6"
 
 description: >-
   On creation, a reserved IPv6 must be reserved to a region.
@@ -10,7 +10,7 @@ description: >-
 
 
 tags:
-  - "[Public Preview] Reserved IPv6"
+  - "Reserved IPv6"
 
 requestBody:
   required: true

--- a/specification/resources/reserved_ipv6/reservedIPv6_delete.yml
+++ b/specification/resources/reserved_ipv6/reservedIPv6_delete.yml
@@ -1,6 +1,6 @@
 operationId: reservedIPv6_delete
 
-summary: "[Public Preview] Delete a Reserved IPv6"
+summary: "Delete a Reserved IPv6"
 
 description: |
   To delete a reserved IP and remove it from your account, send a DELETE request
@@ -10,7 +10,7 @@ description: |
   This indicates that the request was processed successfully.
 
 tags:
-  - "[Public Preview] Reserved IPv6"
+  - "Reserved IPv6"
 
 parameters:
   - $ref: 'parameters.yml#/reserved_ipv6'

--- a/specification/resources/reserved_ipv6/reservedIPv6_get.yml
+++ b/specification/resources/reserved_ipv6/reservedIPv6_get.yml
@@ -1,12 +1,12 @@
 operationId: reservedIPv6_get
 
-summary: "[Public Preview] Retrieve an Existing Reserved IPv6"
+summary: "Retrieve an Existing Reserved IPv6"
 
 description: To show information about a reserved IPv6, send a GET request to
   `/v2/reserved_ipv6/$RESERVED_IPV6`.
 
 tags:
-  - "[Public Preview] Reserved IPv6"
+  - "Reserved IPv6"
 
 parameters:
   - $ref: 'parameters.yml#/reserved_ipv6'

--- a/specification/resources/reserved_ipv6/reservedIPv6_list.yml
+++ b/specification/resources/reserved_ipv6/reservedIPv6_list.yml
@@ -1,12 +1,12 @@
 operationId: reservedIPv6_list
 
-summary: "[Public Preview] List All Reserved IPv6s"
+summary: "List All Reserved IPv6s"
 
 description: To list all of the reserved IPv6s available on your account, send a
   GET request to `/v2/reserved_ipv6`.
 
 tags:
-  - "[Public Preview] Reserved IPv6"
+  - "Reserved IPv6"
 
 parameters:
   - $ref: '../../shared/parameters.yml#/per_page'


### PR DESCRIPTION
This is a follow up to https://github.com/digitalocean/openapi/pull/1081 That PR renamed the tag, but did not update its usage.