### PR TITLE
PDOCS-3334: Fix RBAC permissions for domain records create and delete

### DIFF
--- a/specification/resources/domains/domains_create_record.yml
+++ b/specification/resources/domains/domains_create_record.yml
@@ -84,4 +84,5 @@ x-codeSamples:
 security:
   - bearer_auth:
     - 'domain:create'
+  - bearer_auth:
     - 'domain:update'

--- a/specification/resources/domains/domains_delete_record.yml
+++ b/specification/resources/domains/domains_delete_record.yml
@@ -44,3 +44,5 @@ x-codeSamples:
 security:
   - bearer_auth:
     - 'domain:delete'
+  - bearer_auth:
+    - 'domain:update'


### PR DESCRIPTION
Adds `domain:update` as a possible permission for domain record `create` and `delete`, and updates `create` to show that either permission is sufficient, you don't need both.