### PR TITLE
Extends coredns_autoscaler field in Kubernetes cluster

### DIFF
--- a/specification/resources/kubernetes/models/cluster.yml
+++ b/specification/resources/kubernetes/models/cluster.yml
@@ -177,6 +177,9 @@ properties:
   rdma_shared_dev_plugin:
     $ref: "rdma_shared_dev_plugin.yml"
 
+  coredns_autoscaler:
+    $ref: "coredns_autoscaler.yml"
+
 required:
   - name
   - region

--- a/specification/resources/kubernetes/models/cluster.yml
+++ b/specification/resources/kubernetes/models/cluster.yml
@@ -194,6 +194,9 @@ properties:
   rdma_shared_dev_plugin:
     $ref: "rdma_shared_dev_plugin.yml"
 
+  coredns_autoscaler:
+    $ref: "coredns_autoscaler.yml"
+
 required:
   - name
   - region

--- a/specification/resources/kubernetes/models/cluster_read.yml
+++ b/specification/resources/kubernetes/models/cluster_read.yml
@@ -187,6 +187,9 @@ properties:
   rdma_shared_dev_plugin:
     $ref: "rdma_shared_dev_plugin.yml"
 
+  coredns_autoscaler:
+    $ref: "coredns_autoscaler.yml"
+
 required:
   - name
   - region

--- a/specification/resources/kubernetes/models/cluster_read.yml
+++ b/specification/resources/kubernetes/models/cluster_read.yml
@@ -201,6 +201,9 @@ properties:
   rdma_shared_dev_plugin:
     $ref: "rdma_shared_dev_plugin.yml"
 
+  coredns_autoscaler:
+    $ref: "coredns_autoscaler.yml"
+
 required:
   - name
   - region

--- a/specification/resources/kubernetes/models/cluster_update.yml
+++ b/specification/resources/kubernetes/models/cluster_update.yml
@@ -66,5 +66,8 @@ properties:
   rdma_shared_dev_plugin:
     $ref: "rdma_shared_dev_plugin.yml"
 
+  coredns_autoscaler:
+    $ref: 'coredns_autoscaler.yml'
+
 required:
   - name

--- a/specification/resources/kubernetes/models/cluster_update.yml
+++ b/specification/resources/kubernetes/models/cluster_update.yml
@@ -71,5 +71,8 @@ properties:
   rdma_shared_dev_plugin:
     $ref: "rdma_shared_dev_plugin.yml"
 
+  coredns_autoscaler:
+    $ref: 'coredns_autoscaler.yml'
+
 required:
   - name

--- a/specification/resources/kubernetes/models/coredns_autoscaler.yml
+++ b/specification/resources/kubernetes/models/coredns_autoscaler.yml
@@ -1,0 +1,8 @@
+type: object
+nullable: true
+description: An object specifying whether the Cluster Proportional Autoscaler (CPA) add-on for CoreDNS should be enabled for the Kubernetes cluster.
+properties:
+  enabled:
+    type: boolean
+    description: Indicates whether the CoreDNS Cluster Proportional Autoscaler add-on is enabled.
+    example: true

--- a/specification/resources/kubernetes/responses/examples.yml
+++ b/specification/resources/kubernetes/responses/examples.yml
@@ -122,6 +122,8 @@ kubernetes_clusters_all:
         enabled: false
       rdma_shared_dev_plugin:
         enabled: false
+      coredns_autoscaler:
+        enabled: false
     meta:
       total: 1
 
@@ -248,6 +250,8 @@ kubernetes_single:
         enabled: false
       rdma_shared_dev_plugin:
         enabled: false
+      coredns_autoscaler:
+        enabled: false
 
 kubernetes_updated:
   value:
@@ -372,6 +376,8 @@ kubernetes_updated:
         enabled: false
       rdma_shared_dev_plugin:
         enabled: false
+      coredns_autoscaler:
+        enabled: false
 
 kubernetes_clusters_create_basic_response:
   value:
@@ -460,6 +466,8 @@ kubernetes_clusters_create_basic_response:
       nvidia_gpu_device_plugin:
         enabled: false
       rdma_shared_dev_plugin:
+        enabled: false
+      coredns_autoscaler:
         enabled: false
 
 kubernetes_clusters_multi_pool_response:

--- a/specification/resources/kubernetes/responses/examples.yml
+++ b/specification/resources/kubernetes/responses/examples.yml
@@ -127,6 +127,8 @@ kubernetes_clusters_all:
         enabled: false
       rdma_shared_dev_plugin:
         enabled: false
+      coredns_autoscaler:
+        enabled: false
     meta:
       total: 1
 
@@ -259,6 +261,8 @@ kubernetes_single:
         enabled: false
       rdma_shared_dev_plugin:
         enabled: false
+      coredns_autoscaler:
+        enabled: false
 
 kubernetes_updated:
   value:
@@ -388,6 +392,8 @@ kubernetes_updated:
         enabled: false
       rdma_shared_dev_plugin:
         enabled: false
+      coredns_autoscaler:
+        enabled: false
 
 kubernetes_clusters_create_basic_response:
   value:
@@ -481,6 +487,8 @@ kubernetes_clusters_create_basic_response:
       nvidia_gpu_device_plugin:
         enabled: false
       rdma_shared_dev_plugin:
+        enabled: false
+      coredns_autoscaler:
         enabled: false
 
 kubernetes_clusters_multi_pool_response:


### PR DESCRIPTION
New model: specification/resources/kubernetes/models/coredns_autoscaler.yml
- Referenced from:
  - models/cluster.yml
  - models/cluster_read.yml
  - models/cluster_update.yml
- Examples updated in specification/resources/kubernetes/responses/examples.yml where other plugin blocks are shown.

Referenced PRs - https://github.com/digitalocean/godo/pull/986
