### PR TITLE
Add Embeddings to x-tagGroups

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -692,6 +692,7 @@ x-tagGroups:
     tags:
       - Inference Introduction
       - Agent Inference
+      - Embeddings
       - Serverless Inference
 
 paths:


### PR DESCRIPTION
The `Embeddings` tag was added in #1161 but not listed under any `x-tagGroups` entry. Without a group, the tag renders as an orphaned top-level entry in the product docs nav instead of nesting under **Inference APIs** alongside Agent and Serverless Inference.

This adds `Embeddings` to the `Inference APIs` group.