### PR TITLE
Document model evaluation preset list and get endpoints

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -2789,6 +2789,14 @@ paths:
       $ref: 'resources/gen-ai/genai_list_model_evaluation_metrics.yml'
 
 
+  /v2/gen-ai/model_evaluation_presets:
+    get:
+      $ref: 'resources/gen-ai/genai_list_model_evaluation_presets.yml'
+
+
+  /v2/gen-ai/model_evaluation_presets/{eval_preset_uuid}:
+    get:
+      $ref: 'resources/gen-ai/genai_get_model_evaluation_preset.yml'
 
 
   /v2/gen-ai/model_evaluation_runs:

--- a/specification/resources/gen-ai/examples/curl/genai_get_model_evaluation_preset.yml
+++ b/specification/resources/gen-ai/examples/curl/genai_get_model_evaluation_preset.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json"  \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/gen-ai/model_evaluation_presets/123e4567-e89b-12d3-a456-426614174000"

--- a/specification/resources/gen-ai/examples/curl/genai_list_model_evaluation_presets.yml
+++ b/specification/resources/gen-ai/examples/curl/genai_list_model_evaluation_presets.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json"  \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/gen-ai/model_evaluation_presets"

--- a/specification/resources/gen-ai/genai_get_model_evaluation_preset.yml
+++ b/specification/resources/gen-ai/genai_get_model_evaluation_preset.yml
@@ -1,0 +1,42 @@
+description: To retrieve a saved model evaluation preset, send a GET request to `/v2/genai/model_evaluation_presets/{eval_preset_uuid}`.
+operationId: genai_get_model_evaluation_preset
+parameters:
+- description: UUID of the evaluation preset.
+  example: '"123e4567-e89b-12d3-a456-426614174000"'
+  in: path
+  name: eval_preset_uuid
+  required: true
+  schema:
+    type: string
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          $ref: ./definitions.yml#/apiGetModelEvaluationPresetOutput
+    description: A successful response.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+  "401":
+    $ref: ../../shared/responses/unauthorized.yml
+  "404":
+    $ref: ../../shared/responses/not_found.yml
+  "429":
+    $ref: ../../shared/responses/too_many_requests.yml
+  "500":
+    $ref: ../../shared/responses/server_error.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+security:
+- bearer_auth:
+  - genai:read
+summary: Retrieve Model Evaluation Preset
+tags:
+- GradientAI Platform
+x-codeSamples:
+- $ref: examples/curl/genai_get_model_evaluation_preset.yml

--- a/specification/resources/gen-ai/genai_list_model_evaluation_presets.yml
+++ b/specification/resources/gen-ai/genai_list_model_evaluation_presets.yml
@@ -1,0 +1,34 @@
+description: To list all saved model evaluation presets, send a GET request to `/v2/genai/model_evaluation_presets`.
+operationId: genai_list_model_evaluation_presets
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          $ref: ./definitions.yml#/apiListModelEvaluationPresetsOutput
+    description: A successful response.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+  "401":
+    $ref: ../../shared/responses/unauthorized.yml
+  "404":
+    $ref: ../../shared/responses/not_found.yml
+  "429":
+    $ref: ../../shared/responses/too_many_requests.yml
+  "500":
+    $ref: ../../shared/responses/server_error.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+security:
+- bearer_auth:
+  - genai:read
+summary: List Model Evaluation Presets
+tags:
+- GradientAI Platform
+x-codeSamples:
+- $ref: examples/curl/genai_list_model_evaluation_presets.yml


### PR DESCRIPTION
## Summary
- Document `GET /v2/gen-ai/model_evaluation_presets` (list saved evaluation presets)
- Document `GET /v2/gen-ai/model_evaluation_presets/{eval_preset_uuid}` (retrieve preset by UUID)
- Add cURL examples for both endpoints
