### PR TITLE
Add Vector Databases API spec for public preview

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -583,6 +583,13 @@ tags:
 
       To interact with Uptime, you will generally send requests to the Uptime endpoint at `/v2/uptime/`.
 
+  - name: Vector Databases
+    description: |-
+      Vector DB provides APIs for provisioning and managing vector database instances
+      on DigitalOcean. By sending requests to the `/v2/vector-databases` endpoint,
+      you can list, create, update, resize, and delete vector database instances,
+      manage tags, retrieve admin credentials, and work with backups and restores.
+
   - name: "VPC NAT Gateways"
     description: |-
       [VPC NAT Gateways](https://docs.digitalocean.com/products/networking/vpc/how-to/create-nat-gateway/)
@@ -698,6 +705,7 @@ x-tagGroups:
       - SSH Keys
       - Tags
       - Uptime
+      - Vector Databases
       - VPC NAT Gateways
       - VPC Peerings
       - VPCs
@@ -2338,6 +2346,42 @@ paths:
       $ref: "resources/tags/tags_assign_resources.yml"
     delete:
       $ref: "resources/tags/tags_unassign_resources.yml"
+
+  /v2/vector-databases:
+    get:
+      $ref: "resources/vector_databases/vector_databases_list.yml"
+    post:
+      $ref: "resources/vector_databases/vector_databases_create.yml"
+
+  /v2/vector-databases/{id}:
+    get:
+      $ref: "resources/vector_databases/vector_databases_get.yml"
+    put:
+      $ref: "resources/vector_databases/vector_databases_update.yml"
+    delete:
+      $ref: "resources/vector_databases/vector_databases_delete.yml"
+
+  /v2/vector-databases/{id}/backups:
+    get:
+      $ref: "resources/vector_databases/vector_databases_list_backups.yml"
+
+  /v2/vector-databases/{id}/backups/{backup_id}/restore:
+    get:
+      $ref: "resources/vector_databases/vector_databases_get_restore_status.yml"
+    post:
+      $ref: "resources/vector_databases/vector_databases_restore_backup.yml"
+
+  /v2/vector-databases/{id}/credentials:
+    get:
+      $ref: "resources/vector_databases/vector_databases_get_credentials.yml"
+
+  /v2/vector-databases/{id}/resize:
+    post:
+      $ref: "resources/vector_databases/vector_databases_resize.yml"
+
+  /v2/vector-databases/{id}/tags:
+    put:
+      $ref: "resources/vector_databases/vector_databases_update_tags.yml"
 
   /v2/volumes:
     get:

--- a/specification/resources/vector_databases/examples/curl/vector_databases_create.yml
+++ b/specification/resources/vector_databases/examples/curl/vector_databases_create.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    -d '{"name": "my-vector-db", "region": "nyc3", "size": "medium", "tags": ["production"]}' \
+    "https://api.digitalocean.com/v2/vector-databases"

--- a/specification/resources/vector_databases/examples/curl/vector_databases_delete.yml
+++ b/specification/resources/vector_databases/examples/curl/vector_databases_delete.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X DELETE \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/vector-databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30"

--- a/specification/resources/vector_databases/examples/curl/vector_databases_get.yml
+++ b/specification/resources/vector_databases/examples/curl/vector_databases_get.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/vector-databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30"

--- a/specification/resources/vector_databases/examples/curl/vector_databases_get_credentials.yml
+++ b/specification/resources/vector_databases/examples/curl/vector_databases_get_credentials.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/vector-databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/credentials"

--- a/specification/resources/vector_databases/examples/curl/vector_databases_get_restore_status.yml
+++ b/specification/resources/vector_databases/examples/curl/vector_databases_get_restore_status.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/vector-databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/backups/vectordb-9cc10173-e9ea-4176-9dbc-a4cee4c4ff30-20240101-120000/restore"

--- a/specification/resources/vector_databases/examples/curl/vector_databases_list.yml
+++ b/specification/resources/vector_databases/examples/curl/vector_databases_list.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/vector-databases"

--- a/specification/resources/vector_databases/examples/curl/vector_databases_list_backups.yml
+++ b/specification/resources/vector_databases/examples/curl/vector_databases_list_backups.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/vector-databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/backups"

--- a/specification/resources/vector_databases/examples/curl/vector_databases_resize.yml
+++ b/specification/resources/vector_databases/examples/curl/vector_databases_resize.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    -d '{"size": "large"}' \
+    "https://api.digitalocean.com/v2/vector-databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/resize"

--- a/specification/resources/vector_databases/examples/curl/vector_databases_restore_backup.yml
+++ b/specification/resources/vector_databases/examples/curl/vector_databases_restore_backup.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    -d '{"id": "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30", "backup_id": "vectordb-9cc10173-e9ea-4176-9dbc-a4cee4c4ff30-20240101-120000"}' \
+    "https://api.digitalocean.com/v2/vector-databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/backups/vectordb-9cc10173-e9ea-4176-9dbc-a4cee4c4ff30-20240101-120000/restore"

--- a/specification/resources/vector_databases/examples/curl/vector_databases_update.yml
+++ b/specification/resources/vector_databases/examples/curl/vector_databases_update.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X PUT \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    -d '{"id": "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30", "config": {"default_quantization": "rq", "enable_auto_schema": true, "weaviate_version": "1.24.0"}}' \
+    "https://api.digitalocean.com/v2/vector-databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30"

--- a/specification/resources/vector_databases/examples/curl/vector_databases_update_tags.yml
+++ b/specification/resources/vector_databases/examples/curl/vector_databases_update_tags.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X PUT \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    -d '{"tags": ["production", "staging"]}' \
+    "https://api.digitalocean.com/v2/vector-databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/tags"

--- a/specification/resources/vector_databases/models/vector_database.yml
+++ b/specification/resources/vector_databases/models/vector_database.yml
@@ -1,0 +1,77 @@
+type: object
+
+description: VectorDB represents a provisioned vector database instance.
+
+properties:
+  id:
+    type: string
+    example: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
+    description: A unique ID that can be used to identify and reference a vector database.
+    readOnly: true
+  name:
+    type: string
+    example: my-vector-db
+    description: A unique, human-readable name referring to a vector database.
+  region:
+    type: string
+    example: nyc3
+    description: The slug identifier for the region where the vector database is located.
+  owner_uuid:
+    type: string
+    example: 8b3b4c5d-6e7f-8901-a234-567890bcdef0
+    description: The UUID of the account that owns the vector database.
+    readOnly: true
+  status:
+    type: string
+    enum:
+      - pending
+      - creating
+      - active
+      - errored
+      - deleting
+    example: active
+    description: 'Lifecycle state: pending, creating, active, errored, or deleting.'
+    readOnly: true
+  config:
+    allOf:
+      - $ref: './vector_database_config.yml'
+    description: Advanced configuration.
+  created_at:
+    type: string
+    format: date-time
+    example: '2024-01-11T18:37:36Z'
+    description: >-
+      A time value given in ISO8601 combined date and time format that represents
+      when the vector database was created.
+    readOnly: true
+  updated_at:
+    type: string
+    format: date-time
+    example: '2024-01-11T18:37:36Z'
+    description: >-
+      A time value given in ISO8601 combined date and time format that represents
+      when the vector database was last updated.
+    readOnly: true
+  endpoints:
+    allOf:
+      - $ref: './vector_database_endpoints.yml'
+    description: Connection endpoints for the database instance.
+    readOnly: true
+  size:
+    type: string
+    enum:
+      - small
+      - medium
+      - large
+    example: medium
+    description: 'Resource tier: small, medium, or large.'
+  tags:
+    type: array
+    items:
+      type: string
+    example:
+      - production
+    nullable: true
+    description: >-
+      An array of tags (as strings) to organize your vector database.
+      <br><br>Requires `tag:create` scope.

--- a/specification/resources/vector_databases/models/vector_database_backup.yml
+++ b/specification/resources/vector_databases/models/vector_database_backup.yml
@@ -1,0 +1,24 @@
+type: object
+
+description: Backup represents a single backup of a vector database.
+
+properties:
+  backup_id:
+    type: string
+    example: vectordb-9cc10173-e9ea-4176-9dbc-a4cee4c4ff30-20240101-120000
+    description: >-
+      Unique identifier for the backup (e.g., "vectordb-{uuid}-20240101-120000").
+  status:
+    type: string
+    example: SUCCESS
+    description: 'Status of the backup: SUCCESS.'
+  started_at:
+    type: string
+    format: date-time
+    example: '2024-01-01T12:00:00Z'
+    description: Timestamp when the backup process started.
+  completed_at:
+    type: string
+    format: date-time
+    example: '2024-01-01T12:05:00Z'
+    description: Timestamp when the backup process completed.

--- a/specification/resources/vector_databases/models/vector_database_config.yml
+++ b/specification/resources/vector_databases/models/vector_database_config.yml
@@ -1,0 +1,24 @@
+type: object
+
+description: VectorDBConfig holds optional, advanced cluster settings.
+
+properties:
+  default_quantization:
+    type: string
+    enum:
+      - rq
+      - pq
+      - bq
+      - sq
+    example: rq
+    description: >-
+      Default vector compression for new collections: rq, pq, bq, or sq. Empty
+      means platform default (rq).
+  enable_auto_schema:
+    type: boolean
+    example: true
+    description: Whether to enable automatic schema creation for new collections.
+  weaviate_version:
+    type: string
+    example: '1.24.0'
+    description: The Weaviate version running on the vector database cluster.

--- a/specification/resources/vector_databases/models/vector_database_credentials.yml
+++ b/specification/resources/vector_databases/models/vector_database_credentials.yml
@@ -1,0 +1,13 @@
+type: object
+
+properties:
+  user_id:
+    type: string
+    example: admin-user-abc123
+    description: >-
+      Weaviate DB user id from the cluster secret (opaque; matches what was
+      provisioned).
+  api_token:
+    type: string
+    example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+    description: API token for that user.

--- a/specification/resources/vector_databases/models/vector_database_endpoints.yml
+++ b/specification/resources/vector_databases/models/vector_database_endpoints.yml
@@ -1,0 +1,15 @@
+type: object
+
+description: VectorDBEndpoints contains the connection endpoints for a vector database instance.
+
+properties:
+  http:
+    type: string
+    example: https://my-db-abc123.vectordb.digitalocean.com
+    description: >-
+      HTTP endpoint (e.g. "https://my-db-abc123.vectordb.digitalocean.com").
+  grpc:
+    type: string
+    example: my-db-abc123.vectordb.digitalocean.com:443
+    description: >-
+      gRPC endpoint (e.g. "my-db-abc123.vectordb.digitalocean.com:443").

--- a/specification/resources/vector_databases/models/vector_database_restore_status.yml
+++ b/specification/resources/vector_databases/models/vector_database_restore_status.yml
@@ -1,0 +1,26 @@
+type: object
+
+properties:
+  backup_id:
+    type: string
+    example: vectordb-9cc10173-e9ea-4176-9dbc-a4cee4c4ff30-20240101-120000
+    description: The backup ID being restored.
+  status:
+    type: string
+    enum:
+      - STARTED
+      - TRANSFERRING
+      - TRANSFERRED
+      - FINALIZING
+      - SUCCESS
+      - FAILED
+      - CANCELLING
+      - CANCELED
+    example: STARTED
+    description: >-
+      Current status: STARTED, TRANSFERRING, TRANSFERRED, FINALIZING, SUCCESS,
+      FAILED, CANCELLING, CANCELED.
+  error:
+    type: string
+    example: ''
+    description: Error message if the restore failed.

--- a/specification/resources/vector_databases/parameters.yml
+++ b/specification/resources/vector_databases/parameters.yml
@@ -1,0 +1,17 @@
+id:
+  in: path
+  name: id
+  description: A unique identifier for a vector database.
+  required: true
+  example: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
+  schema:
+    type: string
+
+backup_id:
+  in: path
+  name: backup_id
+  description: A unique identifier for a vector database backup.
+  required: true
+  example: vectordb-9cc10173-e9ea-4176-9dbc-a4cee4c4ff30-20240101-120000
+  schema:
+    type: string

--- a/specification/resources/vector_databases/responses/vector_database.yml
+++ b/specification/resources/vector_databases/responses/vector_database.yml
@@ -1,0 +1,38 @@
+description: A JSON object with a key of `vector_db`.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        vector_db:
+          $ref: '../models/vector_database.yml'
+      required:
+        - vector_db
+    example:
+      vector_db:
+        id: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
+        name: my-vector-db
+        region: nyc3
+        owner_uuid: 8b3b4c5d-6e7f-8901-a234-567890bcdef0
+        status: active
+        config:
+          default_quantization: rq
+          enable_auto_schema: true
+          weaviate_version: '1.24.0'
+        created_at: '2024-01-11T18:37:36Z'
+        updated_at: '2024-01-11T18:37:36Z'
+        endpoints:
+          http: https://my-db-abc123.vectordb.digitalocean.com
+          grpc: my-db-abc123.vectordb.digitalocean.com:443
+        size: medium
+        tags:
+          - production

--- a/specification/resources/vector_databases/responses/vector_database_backups.yml
+++ b/specification/resources/vector_databases/responses/vector_database_backups.yml
@@ -1,0 +1,28 @@
+description: A JSON object with a key of `backups`.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        backups:
+          type: array
+          items:
+            $ref: '../models/vector_database_backup.yml'
+          description: List of available backups. Only backups with status SUCCESS are returned.
+      required:
+        - backups
+    example:
+      backups:
+        - backup_id: vectordb-9cc10173-e9ea-4176-9dbc-a4cee4c4ff30-20240101-120000
+          status: SUCCESS
+          started_at: '2024-01-01T12:00:00Z'
+          completed_at: '2024-01-01T12:05:00Z'

--- a/specification/resources/vector_databases/responses/vector_database_credentials.yml
+++ b/specification/resources/vector_databases/responses/vector_database_credentials.yml
@@ -1,0 +1,17 @@
+description: A JSON object containing admin credentials for the vector database.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/vector_database_credentials.yml'
+    example:
+      user_id: admin-user-abc123
+      api_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...

--- a/specification/resources/vector_databases/responses/vector_database_restore.yml
+++ b/specification/resources/vector_databases/responses/vector_database_restore.yml
@@ -1,0 +1,29 @@
+description: A JSON object with the initial status of a restore operation.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        backup_id:
+          type: string
+          example: vectordb-9cc10173-e9ea-4176-9dbc-a4cee4c4ff30-20240101-120000
+          description: The backup ID being restored.
+        status:
+          type: string
+          example: STARTED
+          description: Initial status of the restore operation (e.g., "STARTED").
+      required:
+        - backup_id
+        - status
+    example:
+      backup_id: vectordb-9cc10173-e9ea-4176-9dbc-a4cee4c4ff30-20240101-120000
+      status: STARTED

--- a/specification/resources/vector_databases/responses/vector_database_restore_status.yml
+++ b/specification/resources/vector_databases/responses/vector_database_restore_status.yml
@@ -1,0 +1,18 @@
+description: A JSON object with the current status of a restore operation.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/vector_database_restore_status.yml'
+    example:
+      backup_id: vectordb-9cc10173-e9ea-4176-9dbc-a4cee4c4ff30-20240101-120000
+      status: TRANSFERRING
+      error: ''

--- a/specification/resources/vector_databases/responses/vector_databases.yml
+++ b/specification/resources/vector_databases/responses/vector_databases.yml
@@ -1,0 +1,46 @@
+description: A JSON object with a key of `vector_dbs`.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        vector_dbs:
+          type: array
+          items:
+            $ref: '../models/vector_database.yml'
+        total:
+          type: integer
+          example: 1
+          description: Total number of vector databases.
+      required:
+        - vector_dbs
+        - total
+    example:
+      vector_dbs:
+        - id: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
+          name: my-vector-db
+          region: nyc3
+          owner_uuid: 8b3b4c5d-6e7f-8901-a234-567890bcdef0
+          status: active
+          config:
+            default_quantization: rq
+            enable_auto_schema: true
+            weaviate_version: '1.24.0'
+          created_at: '2024-01-11T18:37:36Z'
+          updated_at: '2024-01-11T18:37:36Z'
+          endpoints:
+            http: https://my-db-abc123.vectordb.digitalocean.com
+            grpc: my-db-abc123.vectordb.digitalocean.com:443
+          size: medium
+          tags:
+            - production
+      total: 1

--- a/specification/resources/vector_databases/vector_databases_create.yml
+++ b/specification/resources/vector_databases/vector_databases_create.yml
@@ -1,0 +1,89 @@
+operationId: vectorDatabases_create
+
+summary: Create a New Vector Database
+
+description: >-
+  To create a vector database, send a POST request to `/v2/vector-databases`.
+
+
+  The create response returns a JSON object with a key called `vector_db`. The value
+  of this is an object that contains the standard attributes associated with a vector
+  database. The initial value of the vector database's `status` attribute is
+  `creating`. When the database is ready to receive traffic, this changes to
+  `active`.
+
+
+  The embedded `endpoints` object contains the connection information needed to access
+  the vector database.
+
+tags:
+  - Vector Databases
+
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        required:
+          - name
+          - region
+          - size
+        properties:
+          name:
+            type: string
+            example: my-vector-db
+            description: Required. Human-readable name for the database.
+          region:
+            type: string
+            example: nyc3
+            description: Required. Region slug where the database will be provisioned.
+          size:
+            type: string
+            enum:
+              - small
+              - medium
+              - large
+            example: medium
+            description: 'Required. Resource tier: small, medium, or large.'
+          tags:
+            type: array
+            items:
+              type: string
+            example:
+              - production
+            description: A set of arbitrary tags to organize your vector database.
+      examples:
+        Create a New Vector Database:
+          value:
+            name: my-vector-db
+            region: nyc3
+            size: medium
+            tags:
+              - production
+
+responses:
+  '201':
+    $ref: 'responses/vector_database.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vector_databases_create.yml'
+
+security:
+  - bearer_auth:
+    - 'database:create'

--- a/specification/resources/vector_databases/vector_databases_delete.yml
+++ b/specification/resources/vector_databases/vector_databases_delete.yml
@@ -1,0 +1,43 @@
+operationId: vectorDatabases_delete
+
+summary: Destroy a Vector Database
+
+description: >-
+  To destroy a specific vector database, send a DELETE request to
+  `/v2/vector-databases/$VECTOR_DATABASE_ID`.
+
+
+  A status of 204 will be given. This indicates that the request was processed
+  successfully, but that no response body is needed.
+
+tags:
+  - Vector Databases
+
+parameters:
+  - $ref: 'parameters.yml#/id'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vector_databases_delete.yml'
+
+security:
+  - bearer_auth:
+    - 'database:delete'

--- a/specification/resources/vector_databases/vector_databases_get.yml
+++ b/specification/resources/vector_databases/vector_databases_get.yml
@@ -1,0 +1,47 @@
+operationId: vectorDatabases_get
+
+summary: Retrieve an Existing Vector Database
+
+description: >-
+  To show information about an existing vector database, send a GET request to
+  `/v2/vector-databases/$VECTOR_DATABASE_ID`.
+
+
+  The response will be a JSON object with a `vector_db` key. This will be set to an
+  object containing the standard vector database attributes.
+
+
+  The embedded `endpoints` object will contain the connection information needed to
+  access the vector database.
+
+tags:
+  - Vector Databases
+
+parameters:
+  - $ref: 'parameters.yml#/id'
+
+responses:
+  '200':
+    $ref: 'responses/vector_database.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vector_databases_get.yml'
+
+security:
+  - bearer_auth:
+    - 'database:read'

--- a/specification/resources/vector_databases/vector_databases_get_credentials.yml
+++ b/specification/resources/vector_databases/vector_databases_get_credentials.yml
@@ -1,0 +1,43 @@
+operationId: vectorDatabases_get_credentials
+
+summary: Retrieve Admin Credentials for a Vector Database
+
+description: >-
+  To retrieve the admin credentials for a vector database, send a GET request to
+  `/v2/vector-databases/$VECTOR_DATABASE_ID/credentials`.
+
+
+  The response will be a JSON object containing the `user_id` and `api_token` for the
+  Weaviate admin user provisioned on the cluster.
+
+tags:
+  - Vector Databases
+
+parameters:
+  - $ref: 'parameters.yml#/id'
+
+responses:
+  '200':
+    $ref: 'responses/vector_database_credentials.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vector_databases_get_credentials.yml'
+
+security:
+  - bearer_auth:
+    - 'database:read'

--- a/specification/resources/vector_databases/vector_databases_get_restore_status.yml
+++ b/specification/resources/vector_databases/vector_databases_get_restore_status.yml
@@ -1,0 +1,44 @@
+operationId: vectorDatabases_get_restore_status
+
+summary: Get Restore Status for a Vector Database Backup
+
+description: >-
+  To get the current status of a restore operation, send a GET request to
+  `/v2/vector-databases/$VECTOR_DATABASE_ID/backups/$BACKUP_ID/restore`.
+
+
+  The response will be a JSON object with the `backup_id`, current `status`, and an
+  `error` message if the restore failed.
+
+tags:
+  - Vector Databases
+
+parameters:
+  - $ref: 'parameters.yml#/id'
+  - $ref: 'parameters.yml#/backup_id'
+
+responses:
+  '200':
+    $ref: 'responses/vector_database_restore_status.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vector_databases_get_restore_status.yml'
+
+security:
+  - bearer_auth:
+    - 'database:read'

--- a/specification/resources/vector_databases/vector_databases_list.yml
+++ b/specification/resources/vector_databases/vector_databases_list.yml
@@ -1,0 +1,46 @@
+operationId: vectorDatabases_list
+
+summary: List All Vector Databases
+
+description: >-
+  To list all of the vector databases available on your account, send a GET request to
+  `/v2/vector-databases`. Use the `page` and `per_page` query parameters to paginate
+  through the results.
+
+
+  The result will be a JSON object with a `vector_dbs` key set to an array of vector
+  database objects, each of which will contain the standard vector database attributes,
+  and a `total` key with the total number of vector databases.
+
+tags:
+  - Vector Databases
+
+parameters:
+  - $ref: '../../shared/parameters.yml#/page'
+  - $ref: '../../shared/parameters.yml#/per_page'
+
+responses:
+  '200':
+    $ref: 'responses/vector_databases.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vector_databases_list.yml'
+
+security:
+  - bearer_auth:
+    - 'database:read'

--- a/specification/resources/vector_databases/vector_databases_list_backups.yml
+++ b/specification/resources/vector_databases/vector_databases_list_backups.yml
@@ -1,0 +1,46 @@
+operationId: vectorDatabases_list_backups
+
+summary: List Backups for a Vector Database
+
+description: >-
+  To list all of the available backups of a vector database, send a GET request to
+  `/v2/vector-databases/$VECTOR_DATABASE_ID/backups`.
+
+
+  Only backups with status SUCCESS are returned.
+
+
+  The result will be a JSON object with a `backups` key set to an array of backup
+  objects, each of which will contain the backup ID, status, and timestamps.
+
+tags:
+  - Vector Databases
+
+parameters:
+  - $ref: 'parameters.yml#/id'
+
+responses:
+  '200':
+    $ref: 'responses/vector_database_backups.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vector_databases_list_backups.yml'
+
+security:
+  - bearer_auth:
+    - 'database:read'

--- a/specification/resources/vector_databases/vector_databases_resize.yml
+++ b/specification/resources/vector_databases/vector_databases_resize.yml
@@ -1,0 +1,68 @@
+operationId: vectorDatabases_post_resize
+
+summary: Resize a Vector Database
+
+description: >-
+  To resize a vector database, send a POST request to
+  `/v2/vector-databases/$VECTOR_DATABASE_ID/resize`. The body of the request must
+  specify the target `size`.
+
+
+  The response will be a JSON object with a `vector_db` key set to the updated vector
+  database object.
+
+tags:
+  - Vector Databases
+
+parameters:
+  - $ref: 'parameters.yml#/id'
+
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        required:
+          - size
+        properties:
+          id:
+            type: string
+            example: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
+            description: ID of the vector database to resize.
+          size:
+            type: string
+            enum:
+              - small
+              - medium
+              - large
+            example: large
+            description: 'Required. Target resource tier: small, medium, or large.'
+      example:
+        size: large
+
+responses:
+  '200':
+    $ref: 'responses/vector_database.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vector_databases_resize.yml'
+
+security:
+  - bearer_auth:
+    - 'database:update'

--- a/specification/resources/vector_databases/vector_databases_restore_backup.yml
+++ b/specification/resources/vector_databases/vector_databases_restore_backup.yml
@@ -1,0 +1,67 @@
+operationId: vectorDatabases_post_restore_backup
+
+summary: Restore a Vector Database from a Backup
+
+description: >-
+  To restore a vector database from a backup, send a POST request to
+  `/v2/vector-databases/$VECTOR_DATABASE_ID/backups/$BACKUP_ID/restore`.
+
+
+  The restore is performed asynchronously; use the Get Restore Status endpoint to
+  monitor progress.
+
+
+  The response will be a JSON object with the `backup_id` and initial `status` of the
+  restore operation.
+
+tags:
+  - Vector Databases
+
+parameters:
+  - $ref: 'parameters.yml#/id'
+  - $ref: 'parameters.yml#/backup_id'
+
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          id:
+            type: string
+            example: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
+            description: Required. ID of the vector database.
+          backup_id:
+            type: string
+            example: vectordb-9cc10173-e9ea-4176-9dbc-a4cee4c4ff30-20240101-120000
+            description: Required. ID of the backup to restore from.
+      example:
+        id: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
+        backup_id: vectordb-9cc10173-e9ea-4176-9dbc-a4cee4c4ff30-20240101-120000
+
+responses:
+  '200':
+    $ref: 'responses/vector_database_restore.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vector_databases_restore_backup.yml'
+
+security:
+  - bearer_auth:
+    - 'database:update'

--- a/specification/resources/vector_databases/vector_databases_update.yml
+++ b/specification/resources/vector_databases/vector_databases_update.yml
@@ -1,0 +1,63 @@
+operationId: vectorDatabases_update
+
+summary: Update a Vector Database
+
+description: >-
+  To update the configuration of an existing vector database, send a PUT request to
+  `/v2/vector-databases/$VECTOR_DATABASE_ID`.
+
+
+  The response will be a JSON object with a `vector_db` key set to the updated vector
+  database object.
+
+tags:
+  - Vector Databases
+
+parameters:
+  - $ref: 'parameters.yml#/id'
+
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          id:
+            type: string
+            example: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
+            description: ID of the vector database to update.
+          config:
+            $ref: 'models/vector_database_config.yml'
+      example:
+        id: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
+        config:
+          default_quantization: rq
+          enable_auto_schema: true
+          weaviate_version: '1.24.0'
+
+responses:
+  '200':
+    $ref: 'responses/vector_database.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vector_databases_update.yml'
+
+security:
+  - bearer_auth:
+    - 'database:update'

--- a/specification/resources/vector_databases/vector_databases_update_tags.yml
+++ b/specification/resources/vector_databases/vector_databases_update_tags.yml
@@ -1,0 +1,70 @@
+operationId: vectorDatabases_update_tags
+
+summary: Update Tags on a Vector Database
+
+description: >-
+  To update the tags on an existing vector database, send a PUT request to
+  `/v2/vector-databases/$VECTOR_DATABASE_ID/tags`. The tags in the request body
+  replace all existing tags on the vector database.
+
+
+  The response will be a JSON object with a `vector_db` key set to the updated vector
+  database object.
+
+tags:
+  - Vector Databases
+
+parameters:
+  - $ref: 'parameters.yml#/id'
+
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        required:
+          - tags
+        properties:
+          id:
+            type: string
+            example: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
+            description: ID of the vector database to update tags for.
+          tags:
+            type: array
+            items:
+              type: string
+            example:
+              - production
+              - staging
+            description: Tags to set on the vector database. Replaces all existing tags.
+      example:
+        tags:
+          - production
+          - staging
+
+responses:
+  '200':
+    $ref: 'responses/vector_database.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vector_databases_update_tags.yml'
+
+security:
+  - bearer_auth:
+    - 'database:update'


### PR DESCRIPTION
**Summary**

Adds the Vector Databases API specification to the public API docs. All endpoints, models, responses, and curl examples follow the same pattern as the existing databases resource.

**Endpoints added**

GET /v2/vector-databases — List all vector databases
POST /v2/vector-databases — Create a vector database
GET /v2/vector-databases/{id} — Get a vector database
PUT /v2/vector-databases/{id} — Update config
DELETE /v2/vector-databases/{id} — Delete a vector database
POST /v2/vector-databases/{id}/resize — Resize
PUT /v2/vector-databases/{id}/tags — Update tags
GET /v2/vector-databases/{id}/credentials — Get admin credentials
GET /v2/vector-databases/{id}/backups — List backups
POST /v2/vector-databases/{id}/backups/{backup_id}/restore — Restore from backup
GET /v2/vector-databases/{id}/backups/{backup_id}/restore — Get restore status


11 endpoint definitions (vector_databases_*.yml)
6 models (vector_database, config, endpoints, backup, credentials, restore_status)
6 response definitions
11 curl examples
parameters.yml for path params
Wired into DigitalOcean-public.v2.yaml (tag, x-tagGroups, paths)


**Validation**
make bundle && make lint passes with 0 errors (5 pre-existing warnings, none from vector databases)
Source

Swagger spec: vectordb.swagger.json in Cthulhu (docode/src/do/teams/vector-db/public/)
Related ticket: [KBAAS-265](https://do-internal.atlassian.net/browse/KBAAS-265)
Related godo PR: digitalocean/godo#1015 (merged)

[KBAAS-265]: https://do-internal.atlassian.net/browse/KBAAS-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ