### PR TITLE
Nfs access point apis

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -1974,6 +1974,20 @@ paths:
     delete:
       $ref: "resources/nfs/nfs_snapshot_delete.yml"
 
+  /v2/nfs/shares/{share_id}/access_points:
+    post:
+      $ref: "resources/nfs/nfs_access_point_create.yml"
+
+    get:
+      $ref: "resources/nfs/nfs_access_point_list.yml"
+
+  /v2/nfs/access_points/{access_point_id}:
+    get:
+      $ref: "resources/nfs/nfs_access_point_get.yml"
+
+    delete:
+      $ref: "resources/nfs/nfs_access_point_delete.yml"
+
   /v2/partner_network_connect/attachments:
     get:
       $ref: "resources/partner_network_connect/partner_attachment_list.yml"

--- a/specification/resources/nfs/examples/curl/nfs_access_point_create.yml
+++ b/specification/resources/nfs/examples/curl/nfs_access_point_create.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    -d '{"name": "other-vpc", "path": "/other-vpc", "vpc_id": "3f34cdb2-1e4f-4100-b5c7-f55f2762085f", "access_policy": {"anonuid": 65534, "anongid": 65534, "protocols": ["NFS4", "NFS"], "squash_config": "ROOT_SQUASH", "identity_enforcement_enabled": false}}' \
+    "https://api.digitalocean.com/v2/nfs/shares/baf4827c-6fa9-456f-9dbd-9ddfcacd0720/access_points"

--- a/specification/resources/nfs/examples/curl/nfs_access_point_delete.yml
+++ b/specification/resources/nfs/examples/curl/nfs_access_point_delete.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X DELETE \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/nfs/access_points/7659ce91-354d-4f61-9cda-ae2c7feb61d9"

--- a/specification/resources/nfs/examples/curl/nfs_access_point_get.yml
+++ b/specification/resources/nfs/examples/curl/nfs_access_point_get.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/nfs/access_points/becd9f04-8afa-4ccd-b03e-9676447df603"

--- a/specification/resources/nfs/examples/curl/nfs_access_point_list.yml
+++ b/specification/resources/nfs/examples/curl/nfs_access_point_list.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/nfs/shares/baf4827c-6fa9-456f-9dbd-9ddfcacd0720/access_points"

--- a/specification/resources/nfs/models/access_point_action_response.yml
+++ b/specification/resources/nfs/models/access_point_action_response.yml
@@ -1,0 +1,53 @@
+---
+type: object
+description: Response returned after starting an access point mutation.
+properties:
+  access_point:
+    $ref: "access_point_response.yml"
+  action:
+    type: object
+    description: The action that was submitted for the access point mutation.
+    properties:
+      id:
+        type: string
+        description: The unique identifier of the action.
+        example: "1"
+      region_slug:
+        type: string
+        description: The DigitalOcean region slug where the resource is located.
+        example: "atl1"
+      resource_id:
+        type: string
+        format: uuid
+        description: The unique identifier of the resource on which the action is being performed.
+        example: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+      resource_type:
+        type: string
+        enum: ["network_file_share"]
+        description: The type of resource on which the action is being performed.
+        example: "network_file_share"
+      started_at:
+        type: string
+        format: date-time
+        description: The timestamp when the action was started.
+        example: "2025-10-14T11:55:31.615157397Z"
+      status:
+        type: string
+        enum: ["in-progress", "completed", "errored"]
+        description: The current status of the action.
+        example: "in-progress"
+      type:
+        type: string
+        description: The type of action being performed. Access point mutations use CREATE_ACCESS_POINT and DELETE_ACCESS_POINT.
+        example: "CREATE_ACCESS_POINT"
+    required:
+      - region_slug
+      - resource_id
+      - resource_type
+      - started_at
+      - status
+      - type
+required:
+  - access_point
+  - action
+

--- a/specification/resources/nfs/models/access_point_action_response.yml
+++ b/specification/resources/nfs/models/access_point_action_response.yml
@@ -5,49 +5,7 @@ properties:
   access_point:
     $ref: "access_point_response.yml"
   action:
-    type: object
-    description: The action that was submitted for the access point mutation.
-    properties:
-      id:
-        type: string
-        description: The unique identifier of the action.
-        example: "1"
-      region_slug:
-        type: string
-        description: The DigitalOcean region slug where the resource is located.
-        example: "atl1"
-      resource_id:
-        type: string
-        format: uuid
-        description: The unique identifier of the resource on which the action is being performed.
-        example: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
-      resource_type:
-        type: string
-        enum: ["network_file_share"]
-        description: The type of resource on which the action is being performed.
-        example: "network_file_share"
-      started_at:
-        type: string
-        format: date-time
-        description: The timestamp when the action was started.
-        example: "2025-10-14T11:55:31.615157397Z"
-      status:
-        type: string
-        enum: ["in-progress", "completed", "errored"]
-        description: The current status of the action.
-        example: "in-progress"
-      type:
-        type: string
-        description: The type of action being performed. Access point mutations use CREATE_ACCESS_POINT and DELETE_ACCESS_POINT.
-        example: "CREATE_ACCESS_POINT"
-    required:
-      - region_slug
-      - resource_id
-      - resource_type
-      - started_at
-      - status
-      - type
+    $ref: "nfs_action.yml"
 required:
   - access_point
   - action
-

--- a/specification/resources/nfs/models/access_point_get_response.yml
+++ b/specification/resources/nfs/models/access_point_get_response.yml
@@ -1,0 +1,8 @@
+---
+type: object
+description: Response containing a single access point.
+properties:
+  access_point:
+    $ref: "access_point_response.yml"
+required:
+  - access_point

--- a/specification/resources/nfs/models/access_point_list_response.yml
+++ b/specification/resources/nfs/models/access_point_list_response.yml
@@ -7,15 +7,5 @@ properties:
     items:
       $ref: "access_point_response.yml"
     description: Array of access point objects.
-    example:
-      - id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
-        name: "my-access-point"
-        share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
-        path: "/exports/data"
-        status: "ACCESS_POINT_ACTIVE"
-        is_default: false
-        created_at: "2023-01-01T00:00:00Z"
-        updated_at: "2023-01-01T01:00:00Z"
 required:
   - access_points
-

--- a/specification/resources/nfs/models/access_point_list_response.yml
+++ b/specification/resources/nfs/models/access_point_list_response.yml
@@ -1,0 +1,21 @@
+---
+type: object
+description: Response containing a list of access points.
+properties:
+  access_points:
+    type: array
+    items:
+      $ref: "access_point_response.yml"
+    description: Array of access point objects.
+    example:
+      - id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+        name: "my-access-point"
+        share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
+        path: "/exports/data"
+        status: "ACCESS_POINT_ACTIVE"
+        is_default: false
+        created_at: "2023-01-01T00:00:00Z"
+        updated_at: "2023-01-01T01:00:00Z"
+required:
+  - access_points
+

--- a/specification/resources/nfs/models/access_point_request.yml
+++ b/specification/resources/nfs/models/access_point_request.yml
@@ -23,12 +23,12 @@ properties:
   vpc_id:
     type: string
     description: |
-      Optional VPC to mount this access point from. When unset (or set to a VPC the share
-      is already attached to), the access point inherits the share's VPC and storage gateway.
-      When set to a different VPC, a storage gateway is provisioned or reused in that VPC.
-    nullable: true
+      Required. The VPC this access point will be pinned to. A storage gateway is
+      provisioned (or reused) in this VPC, and the access point becomes mountable from
+      this VPC regardless of whether the parent share is currently attached to it.
     example: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
 required:
   - name
   - path
   - access_policy
+  - vpc_id

--- a/specification/resources/nfs/models/access_point_request.yml
+++ b/specification/resources/nfs/models/access_point_request.yml
@@ -1,0 +1,27 @@
+---
+type: object
+description: Payload for creating a new access point on a share.
+properties:
+  name:
+    type: string
+    description: The name for the access point. Must be unique per share.
+    example: "my-access-point"
+  path:
+    type: string
+    description: The export sub-path. Must start with "/" and cannot be "/".
+    example: "/exports/data"
+  access_policy:
+    $ref: "access_policy.yml"
+  vpc_id:
+    type: string
+    description: |
+      Optional VPC to mount this access point from. When unset (or set to a VPC the share
+      is already attached to), the access point inherits the share's VPC and storage gateway.
+      When set to a different VPC, a storage gateway is provisioned or reused in that VPC.
+    nullable: true
+    example: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
+required:
+  - name
+  - path
+  - access_policy
+

--- a/specification/resources/nfs/models/access_point_request.yml
+++ b/specification/resources/nfs/models/access_point_request.yml
@@ -9,7 +9,7 @@ properties:
       characters and match `^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]$`.
       The name `default` is reserved (case-insensitive) for the implicit default
       access point created with each share.
-    example: "team-a"
+    example: "other-vpc"
   path:
     type: string
     description: |
@@ -17,7 +17,7 @@ properties:
       for the default access point), must be at most 1024 characters, may contain
       only alphanumerics, `-`, `_`, `.`, and `/`, and must not contain `..` path
       segments.
-    example: "/team-a"
+    example: "/other-vpc"
   access_policy:
     $ref: "access_policy.yml"
   vpc_id:
@@ -26,7 +26,7 @@ properties:
       Required. The VPC this access point will be pinned to. A storage gateway is
       provisioned (or reused) in this VPC, and the access point becomes mountable from
       this VPC regardless of whether the parent share is currently attached to it.
-    example: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
+    example: "3f34cdb2-1e4f-4100-b5c7-f55f2762085f"
 required:
   - name
   - path

--- a/specification/resources/nfs/models/access_point_request.yml
+++ b/specification/resources/nfs/models/access_point_request.yml
@@ -4,12 +4,20 @@ description: Payload for creating a new access point on a share.
 properties:
   name:
     type: string
-    description: The name for the access point. Must be unique per share.
-    example: "my-access-point"
+    description: |
+      The name for the access point. Must be unique per share. Must be 2–63
+      characters and match `^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]$`.
+      The name `default` is reserved (case-insensitive) for the implicit default
+      access point created with each share.
+    example: "team-a"
   path:
     type: string
-    description: The export sub-path. Must start with "/" and cannot be "/".
-    example: "/exports/data"
+    description: |
+      The export sub-path. Must start with `/`, must not be exactly `/` (reserved
+      for the default access point), must be at most 1024 characters, may contain
+      only alphanumerics, `-`, `_`, `.`, and `/`, and must not contain `..` path
+      segments.
+    example: "/team-a"
   access_policy:
     $ref: "access_policy.yml"
   vpc_id:
@@ -24,4 +32,3 @@ required:
   - name
   - path
   - access_policy
-

--- a/specification/resources/nfs/models/access_point_response.yml
+++ b/specification/resources/nfs/models/access_point_response.yml
@@ -11,7 +11,7 @@ properties:
   name:
     type: string
     description: The human-readable name of the access point. Must be unique per share.
-    example: "my-access-point"
+    example: "team-a"
   share_id:
     type: string
     format: uuid
@@ -20,8 +20,8 @@ properties:
     example: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
   path:
     type: string
-    description: The export sub-path for this access point. Must start with "/" and cannot be "/".
-    example: "/exports/data"
+    description: The export sub-path for this access point (always starts with `/`).
+    example: "/team-a"
   status:
     type: string
     enum: ["ACCESS_POINT_CREATING", "ACCESS_POINT_ACTIVE", "ACCESS_POINT_FAILED", "ACCESS_POINT_DELETED"]
@@ -68,4 +68,3 @@ required:
   - created_at
   - updated_at
   - is_default
-

--- a/specification/resources/nfs/models/access_point_response.yml
+++ b/specification/resources/nfs/models/access_point_response.yml
@@ -53,10 +53,10 @@ properties:
   vpc_id:
     type: string
     description: |
-      The VPC this access point is pinned to. When unset, the access point inherits
-      the parent share's VPC(s). When set, the access point is mountable from this
-      specific VPC with its own storage gateway.
-    nullable: true
+      The VPC this access point is pinned to. Every non-default access point owns its
+      own storage gateway in this VPC and is independent of the parent share's VPC
+      lifecycle: it remains mountable from this VPC regardless of whether the share is
+      currently attached to it.
     example: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
 required:
   - id

--- a/specification/resources/nfs/models/access_point_response.yml
+++ b/specification/resources/nfs/models/access_point_response.yml
@@ -11,7 +11,7 @@ properties:
   name:
     type: string
     description: The human-readable name of the access point. Must be unique per share.
-    example: "team-a"
+    example: "other-vpc"
   share_id:
     type: string
     format: uuid
@@ -21,7 +21,7 @@ properties:
   path:
     type: string
     description: The export sub-path for this access point (always starts with `/`).
-    example: "/team-a"
+    example: "/other-vpc"
   status:
     type: string
     enum: ["ACCESS_POINT_CREATING", "ACCESS_POINT_ACTIVE", "ACCESS_POINT_FAILED", "ACCESS_POINT_DELETED"]
@@ -41,10 +41,11 @@ properties:
     example: "2023-01-01T00:00:00Z"
   updated_at:
     type: string
-    format: date-time
-    description: The timestamp when the access point was last updated.
+    description: |
+      The timestamp when the access point was last updated. May be empty while the
+      access point is still being created.
     readOnly: true
-    example: "2023-01-01T01:00:00Z"
+    example: "2026-06-25T08:11:16Z"
   is_default:
     type: boolean
     description: Whether this is the share's default access point.
@@ -53,11 +54,10 @@ properties:
   vpc_id:
     type: string
     description: |
-      The VPC this access point is pinned to. Every non-default access point owns its
-      own storage gateway in this VPC and is independent of the parent share's VPC
-      lifecycle: it remains mountable from this VPC regardless of whether the share is
-      currently attached to it.
-    example: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
+      The VPC this access point is pinned to. Omitted on the default access point.
+      Every non-default access point owns its own storage gateway in this VPC and
+      is independent of the parent share's VPC lifecycle.
+    example: "3f34cdb2-1e4f-4100-b5c7-f55f2762085f"
 required:
   - id
   - name

--- a/specification/resources/nfs/models/access_point_response.yml
+++ b/specification/resources/nfs/models/access_point_response.yml
@@ -1,0 +1,71 @@
+---
+type: object
+description: Represents an NFS access point resource.
+properties:
+  id:
+    type: string
+    format: uuid
+    description: The unique identifier of the access point.
+    readOnly: true
+    example: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+  name:
+    type: string
+    description: The human-readable name of the access point. Must be unique per share.
+    example: "my-access-point"
+  share_id:
+    type: string
+    format: uuid
+    description: The unique identifier of the share this access point belongs to.
+    readOnly: true
+    example: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
+  path:
+    type: string
+    description: The export sub-path for this access point. Must start with "/" and cannot be "/".
+    example: "/exports/data"
+  status:
+    type: string
+    enum: ["ACCESS_POINT_CREATING", "ACCESS_POINT_ACTIVE", "ACCESS_POINT_FAILED", "ACCESS_POINT_DELETED"]
+    description: |
+      The current lifecycle status of an access point. There is no ACCESS_POINT_DELETING state:
+      DELETE soft-deletes the access point synchronously (mirroring share deletion);
+      the response of a delete request returns the access point already in ACCESS_POINT_DELETED.
+    readOnly: true
+    example: "ACCESS_POINT_ACTIVE"
+  access_policy:
+    $ref: "access_policy.yml"
+  created_at:
+    type: string
+    format: date-time
+    description: The timestamp when the access point was created.
+    readOnly: true
+    example: "2023-01-01T00:00:00Z"
+  updated_at:
+    type: string
+    format: date-time
+    description: The timestamp when the access point was last updated.
+    readOnly: true
+    example: "2023-01-01T01:00:00Z"
+  is_default:
+    type: boolean
+    description: Whether this is the share's default access point.
+    readOnly: true
+    example: false
+  vpc_id:
+    type: string
+    description: |
+      The VPC this access point is pinned to. When unset, the access point inherits
+      the parent share's VPC(s). When set, the access point is mountable from this
+      specific VPC with its own storage gateway.
+    nullable: true
+    example: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
+required:
+  - id
+  - name
+  - share_id
+  - path
+  - status
+  - access_policy
+  - created_at
+  - updated_at
+  - is_default
+

--- a/specification/resources/nfs/models/access_policy.yml
+++ b/specification/resources/nfs/models/access_policy.yml
@@ -1,6 +1,9 @@
 ---
 type: object
-description: Provider-agnostic NFS access policy for an access point.
+description: |
+  Provider-agnostic NFS access policy for an access point. Network CIDRs are
+  managed by attach, detach, and managed-access workflows and are not part of
+  this policy.
 properties:
   anonuid:
     type: integer
@@ -14,9 +17,9 @@ properties:
     type: array
     items:
       type: string
-      enum: ["NFS", "NFS4"]
+      enum: ["NFS4", "NFS"]
     description: Allowed NFS protocols for this export.
-    example: ["NFS4"]
+    example: ["NFS4", "NFS"]
   squash_config:
     type: string
     enum: ["NO_SQUASH", "ROOT_SQUASH", "ALL_SQUASH"]
@@ -25,11 +28,10 @@ properties:
   identity_enforcement_enabled:
     type: boolean
     description: Whether identity enforcement is enabled for this export.
-    example: true
+    example: false
 required:
   - anonuid
   - anongid
   - protocols
   - squash_config
   - identity_enforcement_enabled
-

--- a/specification/resources/nfs/models/access_policy.yml
+++ b/specification/resources/nfs/models/access_policy.yml
@@ -1,0 +1,35 @@
+---
+type: object
+description: Provider-agnostic NFS access policy for an access point.
+properties:
+  anonuid:
+    type: integer
+    description: UID used for squashed users. Currently only 65534 is supported.
+    example: 65534
+  anongid:
+    type: integer
+    description: GID used for squashed users. Currently only 65534 is supported.
+    example: 65534
+  protocols:
+    type: array
+    items:
+      type: string
+      enum: ["NFS", "NFS4"]
+    description: Allowed NFS protocols for this export.
+    example: ["NFS4"]
+  squash_config:
+    type: string
+    enum: ["NO_SQUASH", "ROOT_SQUASH", "ALL_SQUASH"]
+    description: The squash mode applied to the access point export.
+    example: "ROOT_SQUASH"
+  identity_enforcement_enabled:
+    type: boolean
+    description: Whether identity enforcement is enabled for this export.
+    example: true
+required:
+  - anonuid
+  - anongid
+  - protocols
+  - squash_config
+  - identity_enforcement_enabled
+

--- a/specification/resources/nfs/models/nfs_action.yml
+++ b/specification/resources/nfs/models/nfs_action.yml
@@ -1,0 +1,45 @@
+---
+type: object
+description: The action that was submitted.
+properties:
+  id:
+    type: string
+    description: The unique identifier of the action.
+    example: "1"
+  region_slug:
+    type: string
+    description: The DigitalOcean region slug where the resource is located.
+    example: "atl1"
+  resource_id:
+    type: string
+    format: uuid
+    description: The unique identifier of the resource on which the action is being performed.
+    example: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+  resource_type:
+    type: string
+    enum: ["network_file_share", "network_file_share_snapshot"]
+    description: The type of resource on which the action is being performed.
+    example: "network_file_share"
+  started_at:
+    type: string
+    format: date-time
+    description: The timestamp when the action was started.
+    example: "2025-10-14T11:55:31.615157397Z"
+  status:
+    type: string
+    enum: ["in-progress", "completed", "errored"]
+    description: The current status of the action.
+    example: "in-progress"
+  type:
+    type: string
+    description: |
+      The type of action being performed. Share actions use values such as resize
+      and snapshot. Access point mutations use CREATE_ACCESS_POINT and DELETE_ACCESS_POINT.
+    example: "CREATE_ACCESS_POINT"
+required:
+  - region_slug
+  - resource_id
+  - resource_type
+  - started_at
+  - status
+  - type

--- a/specification/resources/nfs/models/nfs_action.yml
+++ b/specification/resources/nfs/models/nfs_action.yml
@@ -5,36 +5,39 @@ properties:
   id:
     type: string
     description: The unique identifier of the action.
-    example: "1"
+    example: "084c3b9c-2382-441b-92d4-10b095bb5d7c"
   region_slug:
     type: string
     description: The DigitalOcean region slug where the resource is located.
-    example: "atl1"
+    example: "s2r1"
   resource_id:
     type: string
     format: uuid
     description: The unique identifier of the resource on which the action is being performed.
-    example: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+    example: "7659ce91-354d-4f61-9cda-ae2c7feb61d9"
   resource_type:
     type: string
-    enum: ["network_file_share", "network_file_share_snapshot"]
-    description: The type of resource on which the action is being performed.
-    example: "network_file_share"
+    enum: ["SHARE", "SNAPSHOT"]
+    description: |
+      The type of resource on which the action is being performed. Access point
+      mutations return `SHARE` with `resource_id` set to the access point UUID.
+    example: "SHARE"
   started_at:
     type: string
     format: date-time
     description: The timestamp when the action was started.
-    example: "2025-10-14T11:55:31.615157397Z"
+    example: "2026-06-25T08:11:12Z"
   status:
     type: string
-    enum: ["in-progress", "completed", "errored"]
+    enum: ["IN_PROGRESS", "COMPLETED", "ACTION_FAILED"]
     description: The current status of the action.
-    example: "in-progress"
+    example: "IN_PROGRESS"
   type:
     type: string
     description: |
-      The type of action being performed. Share actions use values such as resize
-      and snapshot. Access point mutations use CREATE_ACCESS_POINT and DELETE_ACCESS_POINT.
+      The type of action being performed. Share actions use values such as
+      `RESIZE_SHARE` and `CREATE_SHARE`. Access point mutations use
+      `CREATE_ACCESS_POINT` and `DELETE_ACCESS_POINT`.
     example: "CREATE_ACCESS_POINT"
 required:
   - region_slug

--- a/specification/resources/nfs/models/nfs_actions_response.yml
+++ b/specification/resources/nfs/models/nfs_actions_response.yml
@@ -3,43 +3,6 @@ description: Action response of an NFS share.
 
 properties:
   action:
-    type: object
-    description: The action that was submitted.
-    properties:
-      region_slug:
-        type: string
-        description: The DigitalOcean region slug where the resource is located.
-        example: "atl1"
-      resource_id:
-        type: string
-        format: uuid
-        description: The unique identifier of the resource on which the action is being performed.
-        example: "b5eb9e60-6750-4f3f-90b6-8296966eaf35"
-      resource_type:
-        type: string
-        enum: ["network_file_share", "network_file_share_snapshot"]
-        description: The type of resource on which the action is being performed.
-        example: "network_file_share"
-      started_at:
-        type: string
-        format: date-time
-        description: The timestamp when the action was started.
-        example: "2025-10-14T11:55:31.615157397Z"
-      status:
-        type: string
-        enum: ["in-progress", "completed", "errored"]
-        description: The current status of the action.
-        example: "in-progress"
-      type:
-        type: string
-        description: The type of action being performed.
-        example: "resize"
-    required:
-      - region_slug
-      - resource_id
-      - resource_type
-      - started_at
-      - status
-      - type
+    $ref: "nfs_action.yml"
 required:
   - action

--- a/specification/resources/nfs/models/nfs_api_error.yml
+++ b/specification/resources/nfs/models/nfs_api_error.yml
@@ -1,0 +1,15 @@
+---
+type: object
+description: A standard NFS API error response object.
+properties:
+  code:
+    type: string
+    description: A service-defined error code.
+    example: "MISSING_NAME"
+  message:
+    type: string
+    description: A human-readable description of the error.
+    example: "name is required"
+required:
+  - code
+  - message

--- a/specification/resources/nfs/models/nfs_response.yml
+++ b/specification/resources/nfs/models/nfs_response.yml
@@ -50,6 +50,11 @@ properties:
     type: string
     description: The host IP of the NFS server that will be accessible from the associated VPC
     example: "10.128.32.2"
+  access_points:
+    type: array
+    items:
+      $ref: 'access_point_response.yml'
+    description: Access points configured on this share. The default access point is returned first.
 required:
   - id
   - name

--- a/specification/resources/nfs/nfs_access_point_create.yml
+++ b/specification/resources/nfs/nfs_access_point_create.yml
@@ -8,6 +8,10 @@ description: |
 
   A successful request will return the newly created access point and an action object.
 
+  The parent share must be in `ACTIVE` or `INACTIVE` status. Validation failures and
+  precondition errors (such as an ineligible share state) return `400 Bad Request`.
+  Duplicate name or path conflicts return `409 Conflict`.
+
 tags:
   - NFS
 
@@ -30,8 +34,8 @@ requestBody:
       examples:
         Basic Access Point:
           value:
-            name: "my-access-point"
-            path: "/exports/data"
+            name: "team-a"
+            path: "/team-a"
             access_policy:
               anonuid: 65534
               anongid: 65534
@@ -52,6 +56,9 @@ responses:
   '404':
     $ref: '../../shared/responses/not_found.yml'
 
+  '409':
+    $ref: '../../shared/responses/conflict.yml'
+
   '429':
     $ref: '../../shared/responses/too_many_requests.yml'
 
@@ -64,4 +71,3 @@ responses:
 security:
   - bearer_auth:
       - "nfs:create"
-

--- a/specification/resources/nfs/nfs_access_point_create.yml
+++ b/specification/resources/nfs/nfs_access_point_create.yml
@@ -1,0 +1,67 @@
+operationId: nfs_create_access_point
+
+summary: Create an NFS access point
+
+description: |
+  To create a new access point on an NFS share, send a POST request to
+  `/v2/nfs/shares/{share_id}/access_points`.
+
+  A successful request will return the newly created access point and an action object.
+
+tags:
+  - NFS
+
+parameters:
+  - name: share_id
+    in: path
+    required: true
+    schema:
+      type: string
+      format: uuid
+    description: The unique identifier of the NFS share.
+    example: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
+
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: 'models/access_point_request.yml'
+      examples:
+        Basic Access Point:
+          value:
+            name: "my-access-point"
+            path: "/exports/data"
+            access_policy:
+              anonuid: 65534
+              anongid: 65534
+              protocols: ["NFS4"]
+              squash_config: "ROOT_SQUASH"
+              identity_enforcement_enabled: true
+
+responses:
+  '201':
+    $ref: 'responses/access_point_create.yml'
+
+  '400':
+    $ref: 'responses/bad_request.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+security:
+  - bearer_auth:
+      - "nfs:create"
+

--- a/specification/resources/nfs/nfs_access_point_create.yml
+++ b/specification/resources/nfs/nfs_access_point_create.yml
@@ -23,7 +23,7 @@ parameters:
       type: string
       format: uuid
     description: The unique identifier of the NFS share.
-    example: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
+    example: "baf4827c-6fa9-456f-9dbd-9ddfcacd0720"
 
 requestBody:
   required: true
@@ -34,22 +34,22 @@ requestBody:
       examples:
         Basic Access Point:
           value:
-            name: "team-a"
-            path: "/team-a"
-            vpc_id: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
+            name: "other-vpc"
+            path: "/other-vpc"
+            vpc_id: "3f34cdb2-1e4f-4100-b5c7-f55f2762085f"
             access_policy:
               anonuid: 65534
               anongid: 65534
-              protocols: ["NFS4"]
+              protocols: ["NFS4", "NFS"]
               squash_config: "ROOT_SQUASH"
-              identity_enforcement_enabled: true
+              identity_enforcement_enabled: false
 
 responses:
   '201':
     $ref: 'responses/access_point_create.yml'
 
   '400':
-    $ref: 'responses/bad_request.yml'
+    $ref: 'responses/access_point_bad_request.yml'
 
   '401':
     $ref: '../../shared/responses/unauthorized.yml'
@@ -68,6 +68,9 @@ responses:
 
   default:
     $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/nfs_access_point_create.yml'
 
 security:
   - bearer_auth:

--- a/specification/resources/nfs/nfs_access_point_create.yml
+++ b/specification/resources/nfs/nfs_access_point_create.yml
@@ -36,6 +36,7 @@ requestBody:
           value:
             name: "team-a"
             path: "/team-a"
+            vpc_id: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
             access_policy:
               anonuid: 65534
               anongid: 65534

--- a/specification/resources/nfs/nfs_access_point_create.yml
+++ b/specification/resources/nfs/nfs_access_point_create.yml
@@ -16,14 +16,7 @@ tags:
   - NFS
 
 parameters:
-  - name: share_id
-    in: path
-    required: true
-    schema:
-      type: string
-      format: uuid
-    description: The unique identifier of the NFS share.
-    example: "baf4827c-6fa9-456f-9dbd-9ddfcacd0720"
+  - $ref: "parameters.yml#/share_id_path"
 
 requestBody:
   required: true
@@ -58,7 +51,7 @@ responses:
     $ref: '../../shared/responses/not_found.yml'
 
   '409':
-    $ref: '../../shared/responses/conflict.yml'
+    $ref: 'responses/access_point_conflict.yml'
 
   '429':
     $ref: '../../shared/responses/too_many_requests.yml'

--- a/specification/resources/nfs/nfs_access_point_delete.yml
+++ b/specification/resources/nfs/nfs_access_point_delete.yml
@@ -1,0 +1,47 @@
+operationId: nfs_delete_access_point
+
+summary: Delete an NFS access point
+
+description: |
+  To delete an NFS access point, send a DELETE request to
+  `/v2/nfs/access_points/{access_point_id}`.
+
+  A successful request will soft-delete the access point and return the deleted access point
+  with status `ACCESS_POINT_DELETED` and an action object indicating the delete operation.
+
+tags:
+  - NFS
+
+parameters:
+  - name: access_point_id
+    in: path
+    required: true
+    schema:
+      type: string
+      format: uuid
+    description: The unique identifier of the NFS access point.
+    example: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+
+responses:
+  "200":
+    $ref: "responses/access_point_delete.yml"
+
+  "401":
+    $ref: "../../shared/responses/unauthorized.yml"
+
+  "404":
+    $ref: "../../shared/responses/not_found.yml"
+
+  "429":
+    $ref: "../../shared/responses/too_many_requests.yml"
+
+  "500":
+    $ref: "../../shared/responses/server_error.yml"
+
+  default:
+    $ref: "../../shared/responses/unexpected_error.yml"
+
+security:
+  - bearer_auth:
+      - "nfs:delete"
+

--- a/specification/resources/nfs/nfs_access_point_delete.yml
+++ b/specification/resources/nfs/nfs_access_point_delete.yml
@@ -23,14 +23,14 @@ parameters:
       type: string
       format: uuid
     description: The unique identifier of the NFS access point.
-    example: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+    example: "7659ce91-354d-4f61-9cda-ae2c7feb61d9"
 
 responses:
   "200":
     $ref: "responses/access_point_delete.yml"
 
   "400":
-    $ref: "responses/bad_request.yml"
+    $ref: "responses/access_point_bad_request.yml"
 
   "401":
     $ref: "../../shared/responses/unauthorized.yml"
@@ -46,6 +46,9 @@ responses:
 
   default:
     $ref: "../../shared/responses/unexpected_error.yml"
+
+x-codeSamples:
+  - $ref: "examples/curl/nfs_access_point_delete.yml"
 
 security:
   - bearer_auth:

--- a/specification/resources/nfs/nfs_access_point_delete.yml
+++ b/specification/resources/nfs/nfs_access_point_delete.yml
@@ -16,14 +16,7 @@ tags:
   - NFS
 
 parameters:
-  - name: access_point_id
-    in: path
-    required: true
-    schema:
-      type: string
-      format: uuid
-    description: The unique identifier of the NFS access point.
-    example: "7659ce91-354d-4f61-9cda-ae2c7feb61d9"
+  - $ref: "parameters.yml#/access_point_id"
 
 responses:
   "200":

--- a/specification/resources/nfs/nfs_access_point_delete.yml
+++ b/specification/resources/nfs/nfs_access_point_delete.yml
@@ -9,6 +9,9 @@ description: |
   A successful request will soft-delete the access point and return the deleted access point
   with status `ACCESS_POINT_DELETED` and an action object indicating the delete operation.
 
+  The default access point (`is_default: true`) cannot be deleted. Access points already
+  in `ACCESS_POINT_DELETED` or `ACCESS_POINT_FAILED` status return `400 Bad Request`.
+
 tags:
   - NFS
 
@@ -25,6 +28,9 @@ parameters:
 responses:
   "200":
     $ref: "responses/access_point_delete.yml"
+
+  "400":
+    $ref: "responses/bad_request.yml"
 
   "401":
     $ref: "../../shared/responses/unauthorized.yml"
@@ -44,4 +50,3 @@ responses:
 security:
   - bearer_auth:
       - "nfs:delete"
-

--- a/specification/resources/nfs/nfs_access_point_get.yml
+++ b/specification/resources/nfs/nfs_access_point_get.yml
@@ -1,0 +1,45 @@
+operationId: nfs_get_access_point
+
+summary: Get an NFS access point
+
+description: |
+  To get an NFS access point, send a GET request to `/v2/nfs/access_points/{access_point_id}`.
+
+  A successful request will return the NFS access point.
+
+tags:
+  - NFS
+
+parameters:
+  - name: access_point_id
+    in: path
+    required: true
+    schema:
+      type: string
+      format: uuid
+    description: The unique identifier of the NFS access point.
+    example: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+
+responses:
+  "200":
+    $ref: "responses/access_point_get.yml"
+
+  "401":
+    $ref: "../../shared/responses/unauthorized.yml"
+
+  "404":
+    $ref: "../../shared/responses/not_found.yml"
+
+  "429":
+    $ref: "../../shared/responses/too_many_requests.yml"
+
+  "500":
+    $ref: "../../shared/responses/server_error.yml"
+
+  default:
+    $ref: "../../shared/responses/unexpected_error.yml"
+
+security:
+  - bearer_auth:
+      - "nfs:read"
+

--- a/specification/resources/nfs/nfs_access_point_get.yml
+++ b/specification/resources/nfs/nfs_access_point_get.yml
@@ -11,14 +11,7 @@ tags:
   - NFS
 
 parameters:
-  - name: access_point_id
-    in: path
-    required: true
-    schema:
-      type: string
-      format: uuid
-    description: The unique identifier of the NFS access point.
-    example: "becd9f04-8afa-4ccd-b03e-9676447df603"
+  - $ref: "parameters.yml#/access_point_id"
 
 responses:
   "200":

--- a/specification/resources/nfs/nfs_access_point_get.yml
+++ b/specification/resources/nfs/nfs_access_point_get.yml
@@ -18,7 +18,7 @@ parameters:
       type: string
       format: uuid
     description: The unique identifier of the NFS access point.
-    example: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+    example: "becd9f04-8afa-4ccd-b03e-9676447df603"
 
 responses:
   "200":
@@ -38,6 +38,9 @@ responses:
 
   default:
     $ref: "../../shared/responses/unexpected_error.yml"
+
+x-codeSamples:
+  - $ref: "examples/curl/nfs_access_point_get.yml"
 
 security:
   - bearer_auth:

--- a/specification/resources/nfs/nfs_access_point_list.yml
+++ b/specification/resources/nfs/nfs_access_point_list.yml
@@ -14,14 +14,7 @@ tags:
   - NFS
 
 parameters:
-  - name: share_id
-    in: path
-    required: true
-    schema:
-      type: string
-      format: uuid
-    description: The unique identifier of the NFS share.
-    example: "baf4827c-6fa9-456f-9dbd-9ddfcacd0720"
+  - $ref: "parameters.yml#/share_id_path"
 
   - name: status
     in: query
@@ -39,6 +32,9 @@ parameters:
 responses:
   "200":
     $ref: "responses/access_point_list.yml"
+
+  "400":
+    $ref: "responses/access_point_bad_request.yml"
 
   "401":
     $ref: "../../shared/responses/unauthorized.yml"
@@ -60,4 +56,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-      - "nfs:read"
+      - "nfs:list"

--- a/specification/resources/nfs/nfs_access_point_list.yml
+++ b/specification/resources/nfs/nfs_access_point_list.yml
@@ -1,0 +1,60 @@
+operationId: nfs_list_access_points
+
+summary: List NFS access points for a share
+
+description: |
+  To list access points for an NFS share, send a GET request to
+  `/v2/nfs/shares/{share_id}/access_points`. You may use query parameters to filter
+  by status.
+
+  A successful request will return a list of NFS access points.
+
+tags:
+  - NFS
+
+parameters:
+  - name: share_id
+    in: path
+    required: true
+    schema:
+      type: string
+      format: uuid
+    description: The unique identifier of the NFS share.
+    example: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
+
+  - name: status
+    in: query
+    required: false
+    schema:
+      type: string
+      enum:
+        - "ACCESS_POINT_CREATING"
+        - "ACCESS_POINT_ACTIVE"
+        - "ACCESS_POINT_FAILED"
+        - "ACCESS_POINT_DELETED"
+    description: Filter access points by status.
+    example: "ACCESS_POINT_ACTIVE"
+
+responses:
+  "200":
+    $ref: "responses/access_point_list.yml"
+
+  "401":
+    $ref: "../../shared/responses/unauthorized.yml"
+
+  "404":
+    $ref: "../../shared/responses/not_found.yml"
+
+  "429":
+    $ref: "../../shared/responses/too_many_requests.yml"
+
+  "500":
+    $ref: "../../shared/responses/server_error.yml"
+
+  default:
+    $ref: "../../shared/responses/unexpected_error.yml"
+
+security:
+  - bearer_auth:
+      - "nfs:read"
+

--- a/specification/resources/nfs/nfs_access_point_list.yml
+++ b/specification/resources/nfs/nfs_access_point_list.yml
@@ -7,7 +7,8 @@ description: |
   `/v2/nfs/shares/{share_id}/access_points`. You may use query parameters to filter
   by status.
 
-  A successful request will return a list of NFS access points.
+  A successful request will return a list of NFS access points ordered with the default
+  access point first, then by `created_at` ascending.
 
 tags:
   - NFS
@@ -57,4 +58,3 @@ responses:
 security:
   - bearer_auth:
       - "nfs:read"
-

--- a/specification/resources/nfs/nfs_access_point_list.yml
+++ b/specification/resources/nfs/nfs_access_point_list.yml
@@ -21,7 +21,7 @@ parameters:
       type: string
       format: uuid
     description: The unique identifier of the NFS share.
-    example: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
+    example: "baf4827c-6fa9-456f-9dbd-9ddfcacd0720"
 
   - name: status
     in: query
@@ -54,6 +54,9 @@ responses:
 
   default:
     $ref: "../../shared/responses/unexpected_error.yml"
+
+x-codeSamples:
+  - $ref: "examples/curl/nfs_access_point_list.yml"
 
 security:
   - bearer_auth:

--- a/specification/resources/nfs/parameters.yml
+++ b/specification/resources/nfs/parameters.yml
@@ -59,3 +59,23 @@ share_id:
   schema:
     type: string
   example: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
+
+share_id_path:
+  in: path
+  name: share_id
+  description: The unique identifier of the NFS share.
+  required: true
+  schema:
+    type: string
+    format: uuid
+  example: baf4827c-6fa9-456f-9dbd-9ddfcacd0720
+
+access_point_id:
+  in: path
+  name: access_point_id
+  description: The unique identifier of the NFS access point.
+  required: true
+  schema:
+    type: string
+    format: uuid
+  example: becd9f04-8afa-4ccd-b03e-9676447df603

--- a/specification/resources/nfs/responses/access_point_bad_request.yml
+++ b/specification/resources/nfs/responses/access_point_bad_request.yml
@@ -1,0 +1,25 @@
+description: >-
+  The request could not be processed due to invalid arguments or an ineligible
+  access point state.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/nfs_api_error.yml'
+    examples:
+      Missing required field:
+        value:
+          code: MISSING_NAME
+          message: name is required
+      Cannot delete default access point:
+        value:
+          code: InvalidArgument
+          message: the default access point cannot be deleted

--- a/specification/resources/nfs/responses/access_point_bad_request.yml
+++ b/specification/resources/nfs/responses/access_point_bad_request.yml
@@ -23,3 +23,7 @@ content:
         value:
           code: InvalidArgument
           message: the default access point cannot be deleted
+      Invalid status filter:
+        value:
+          code: INVALID_ACCESS_POINT_STATUS
+          message: invalid access point status

--- a/specification/resources/nfs/responses/access_point_conflict.yml
+++ b/specification/resources/nfs/responses/access_point_conflict.yml
@@ -1,0 +1,21 @@
+description: >-
+  The request could not be completed because an access point with the same name
+  or path already exists on this share.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/nfs_api_error.yml'
+    examples:
+      Duplicate name or path:
+        value:
+          code: AlreadyExists
+          message: access point with this name or path already exists for this share

--- a/specification/resources/nfs/responses/access_point_create.yml
+++ b/specification/resources/nfs/responses/access_point_create.yml
@@ -19,9 +19,9 @@ content:
         value:
           access_point:
             id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
-            name: "my-access-point"
+            name: "team-a"
             share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
-            path: "/exports/data"
+            path: "/team-a"
             status: "ACCESS_POINT_CREATING"
             is_default: false
             created_at: "2023-01-01T00:00:00Z"
@@ -40,4 +40,3 @@ content:
             type: "CREATE_ACCESS_POINT"
             status: "in-progress"
             started_at: "2023-01-01T00:00:00Z"
-

--- a/specification/resources/nfs/responses/access_point_create.yml
+++ b/specification/resources/nfs/responses/access_point_create.yml
@@ -1,0 +1,43 @@
+description: >-
+  The response will be a JSON object containing the created access point and an action object.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/access_point_action_response.yml'
+
+    examples:
+      Creating Access Point:
+        value:
+          access_point:
+            id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+            name: "my-access-point"
+            share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
+            path: "/exports/data"
+            status: "ACCESS_POINT_CREATING"
+            is_default: false
+            created_at: "2023-01-01T00:00:00Z"
+            updated_at: "2023-01-01T00:00:00Z"
+            access_policy:
+              anonuid: 65534
+              anongid: 65534
+              protocols: ["NFS4"]
+              squash_config: "ROOT_SQUASH"
+              identity_enforcement_enabled: true
+          action:
+            id: "1"
+            region_slug: "atl1"
+            resource_id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+            resource_type: "network_file_share"
+            type: "CREATE_ACCESS_POINT"
+            status: "in-progress"
+            started_at: "2023-01-01T00:00:00Z"
+

--- a/specification/resources/nfs/responses/access_point_create.yml
+++ b/specification/resources/nfs/responses/access_point_create.yml
@@ -18,26 +18,26 @@ content:
       Creating Access Point:
         value:
           access_point:
-            id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
-            name: "team-a"
-            share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
-            path: "/team-a"
-            vpc_id: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
+            id: "7659ce91-354d-4f61-9cda-ae2c7feb61d9"
+            name: "other-vpc"
+            share_id: "baf4827c-6fa9-456f-9dbd-9ddfcacd0720"
+            path: "/other-vpc"
+            vpc_id: "3f34cdb2-1e4f-4100-b5c7-f55f2762085f"
             status: "ACCESS_POINT_CREATING"
             is_default: false
-            created_at: "2023-01-01T00:00:00Z"
-            updated_at: "2023-01-01T00:00:00Z"
+            created_at: "2026-06-25T08:11:12Z"
+            updated_at: ""
             access_policy:
               anonuid: 65534
               anongid: 65534
-              protocols: ["NFS4"]
+              protocols: ["NFS4", "NFS"]
               squash_config: "ROOT_SQUASH"
-              identity_enforcement_enabled: true
+              identity_enforcement_enabled: false
           action:
-            id: "1"
-            region_slug: "atl1"
-            resource_id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
-            resource_type: "network_file_share"
+            id: "084c3b9c-2382-441b-92d4-10b095bb5d7c"
+            region_slug: "s2r1"
+            resource_id: "7659ce91-354d-4f61-9cda-ae2c7feb61d9"
+            resource_type: "SHARE"
             type: "CREATE_ACCESS_POINT"
-            status: "in-progress"
-            started_at: "2023-01-01T00:00:00Z"
+            status: "IN_PROGRESS"
+            started_at: "2026-06-25T08:11:12Z"

--- a/specification/resources/nfs/responses/access_point_create.yml
+++ b/specification/resources/nfs/responses/access_point_create.yml
@@ -22,6 +22,7 @@ content:
             name: "team-a"
             share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
             path: "/team-a"
+            vpc_id: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
             status: "ACCESS_POINT_CREATING"
             is_default: false
             created_at: "2023-01-01T00:00:00Z"

--- a/specification/resources/nfs/responses/access_point_delete.yml
+++ b/specification/resources/nfs/responses/access_point_delete.yml
@@ -23,6 +23,7 @@ content:
             name: "team-a"
             share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
             path: "/team-a"
+            vpc_id: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
             status: "ACCESS_POINT_DELETED"
             is_default: false
             created_at: "2023-01-01T00:00:00Z"

--- a/specification/resources/nfs/responses/access_point_delete.yml
+++ b/specification/resources/nfs/responses/access_point_delete.yml
@@ -19,26 +19,26 @@ content:
       Deleted Access Point:
         value:
           access_point:
-            id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
-            name: "team-a"
-            share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
-            path: "/team-a"
-            vpc_id: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
+            id: "7659ce91-354d-4f61-9cda-ae2c7feb61d9"
+            name: "other-vpc"
+            share_id: "baf4827c-6fa9-456f-9dbd-9ddfcacd0720"
+            path: "/other-vpc"
+            vpc_id: "3f34cdb2-1e4f-4100-b5c7-f55f2762085f"
             status: "ACCESS_POINT_DELETED"
             is_default: false
-            created_at: "2023-01-01T00:00:00Z"
-            updated_at: "2023-01-01T02:00:00Z"
+            created_at: "2026-06-25T08:11:12Z"
+            updated_at: "2026-06-25T08:14:14Z"
             access_policy:
               anonuid: 65534
               anongid: 65534
-              protocols: ["NFS4"]
+              protocols: ["NFS4", "NFS"]
               squash_config: "ROOT_SQUASH"
               identity_enforcement_enabled: false
           action:
-            id: "2"
-            region_slug: "atl1"
-            resource_id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
-            resource_type: "network_file_share"
+            id: "3fa0d618-6f8b-4245-9c0f-e16f9e295949"
+            region_slug: "s2r1"
+            resource_id: "7659ce91-354d-4f61-9cda-ae2c7feb61d9"
+            resource_type: "SHARE"
             type: "DELETE_ACCESS_POINT"
-            status: "in-progress"
-            started_at: "2023-01-01T02:00:00Z"
+            status: "IN_PROGRESS"
+            started_at: "2026-06-25T08:14:14Z"

--- a/specification/resources/nfs/responses/access_point_delete.yml
+++ b/specification/resources/nfs/responses/access_point_delete.yml
@@ -1,0 +1,44 @@
+description: >-
+  The response will be a JSON object containing the deleted access point (marked as DELETED)
+  and an action object indicating the delete operation.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/access_point_action_response.yml'
+
+    examples:
+      Deleted Access Point:
+        value:
+          access_point:
+            id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+            name: "my-access-point"
+            share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
+            path: "/exports/data"
+            status: "ACCESS_POINT_DELETED"
+            is_default: false
+            created_at: "2023-01-01T00:00:00Z"
+            updated_at: "2023-01-01T02:00:00Z"
+            access_policy:
+              anonuid: 65534
+              anongid: 65534
+              protocols: ["NFS4"]
+              squash_config: "ROOT_SQUASH"
+              identity_enforcement_enabled: true
+          action:
+            id: "2"
+            region_slug: "atl1"
+            resource_id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+            resource_type: "network_file_share"
+            type: "DELETE_ACCESS_POINT"
+            status: "completed"
+            started_at: "2023-01-01T02:00:00Z"
+

--- a/specification/resources/nfs/responses/access_point_delete.yml
+++ b/specification/resources/nfs/responses/access_point_delete.yml
@@ -20,9 +20,9 @@ content:
         value:
           access_point:
             id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
-            name: "my-access-point"
+            name: "team-a"
             share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
-            path: "/exports/data"
+            path: "/team-a"
             status: "ACCESS_POINT_DELETED"
             is_default: false
             created_at: "2023-01-01T00:00:00Z"
@@ -32,13 +32,12 @@ content:
               anongid: 65534
               protocols: ["NFS4"]
               squash_config: "ROOT_SQUASH"
-              identity_enforcement_enabled: true
+              identity_enforcement_enabled: false
           action:
             id: "2"
             region_slug: "atl1"
             resource_id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
             resource_type: "network_file_share"
             type: "DELETE_ACCESS_POINT"
-            status: "completed"
+            status: "in-progress"
             started_at: "2023-01-01T02:00:00Z"
-

--- a/specification/resources/nfs/responses/access_point_get.yml
+++ b/specification/resources/nfs/responses/access_point_get.yml
@@ -13,21 +13,16 @@ headers:
 content:
   application/json:
     schema:
-      type: object
-      properties:
-        access_point:
-          $ref: '../models/access_point_response.yml'
-      required:
-        - access_point
+      $ref: '../models/access_point_get_response.yml'
 
     examples:
       Active Access Point:
         value:
           access_point:
             id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
-            name: "my-access-point"
+            name: "team-a"
             share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
-            path: "/exports/data"
+            path: "/team-a"
             status: "ACCESS_POINT_ACTIVE"
             is_default: false
             created_at: "2023-01-01T00:00:00Z"
@@ -37,5 +32,4 @@ content:
               anongid: 65534
               protocols: ["NFS4"]
               squash_config: "ROOT_SQUASH"
-              identity_enforcement_enabled: true
-
+              identity_enforcement_enabled: false

--- a/specification/resources/nfs/responses/access_point_get.yml
+++ b/specification/resources/nfs/responses/access_point_get.yml
@@ -23,6 +23,7 @@ content:
             name: "team-a"
             share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
             path: "/team-a"
+            vpc_id: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
             status: "ACCESS_POINT_ACTIVE"
             is_default: false
             created_at: "2023-01-01T00:00:00Z"

--- a/specification/resources/nfs/responses/access_point_get.yml
+++ b/specification/resources/nfs/responses/access_point_get.yml
@@ -1,0 +1,41 @@
+description: >-
+  The response will be a JSON object with a key called `access_point`. The value will
+  be an object containing the standard attributes associated with an NFS access point.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        access_point:
+          $ref: '../models/access_point_response.yml'
+      required:
+        - access_point
+
+    examples:
+      Active Access Point:
+        value:
+          access_point:
+            id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+            name: "my-access-point"
+            share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
+            path: "/exports/data"
+            status: "ACCESS_POINT_ACTIVE"
+            is_default: false
+            created_at: "2023-01-01T00:00:00Z"
+            updated_at: "2023-01-01T01:00:00Z"
+            access_policy:
+              anonuid: 65534
+              anongid: 65534
+              protocols: ["NFS4"]
+              squash_config: "ROOT_SQUASH"
+              identity_enforcement_enabled: true
+

--- a/specification/resources/nfs/responses/access_point_get.yml
+++ b/specification/resources/nfs/responses/access_point_get.yml
@@ -16,21 +16,20 @@ content:
       $ref: '../models/access_point_get_response.yml'
 
     examples:
-      Active Access Point:
+      Default Access Point:
         value:
           access_point:
-            id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
-            name: "team-a"
-            share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
-            path: "/team-a"
-            vpc_id: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
+            id: "becd9f04-8afa-4ccd-b03e-9676447df603"
+            name: "default"
+            share_id: "baf4827c-6fa9-456f-9dbd-9ddfcacd0720"
+            path: "/"
             status: "ACCESS_POINT_ACTIVE"
-            is_default: false
-            created_at: "2023-01-01T00:00:00Z"
-            updated_at: "2023-01-01T01:00:00Z"
+            is_default: true
+            created_at: "2026-06-25T08:10:29Z"
+            updated_at: "2026-06-25T08:10:37Z"
             access_policy:
               anonuid: 65534
               anongid: 65534
-              protocols: ["NFS4"]
+              protocols: ["NFS4", "NFS"]
               squash_config: "ROOT_SQUASH"
               identity_enforcement_enabled: false

--- a/specification/resources/nfs/responses/access_point_list.yml
+++ b/specification/resources/nfs/responses/access_point_list.yml
@@ -19,18 +19,32 @@ content:
       List of Access Points:
         value:
           access_points:
-            - id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
-              name: "team-a"
-              share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
-              path: "/team-a"
-              vpc_id: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
+            - id: "becd9f04-8afa-4ccd-b03e-9676447df603"
+              name: "default"
+              share_id: "baf4827c-6fa9-456f-9dbd-9ddfcacd0720"
+              path: "/"
               status: "ACCESS_POINT_ACTIVE"
-              is_default: false
-              created_at: "2023-01-01T00:00:00Z"
-              updated_at: "2023-01-01T01:00:00Z"
+              is_default: true
+              created_at: "2026-06-25T08:10:29Z"
+              updated_at: "2026-06-25T08:10:37Z"
               access_policy:
                 anonuid: 65534
                 anongid: 65534
-                protocols: ["NFS4"]
+                protocols: ["NFS4", "NFS"]
+                squash_config: "ROOT_SQUASH"
+                identity_enforcement_enabled: false
+            - id: "7659ce91-354d-4f61-9cda-ae2c7feb61d9"
+              name: "other-vpc"
+              share_id: "baf4827c-6fa9-456f-9dbd-9ddfcacd0720"
+              path: "/other-vpc"
+              vpc_id: "3f34cdb2-1e4f-4100-b5c7-f55f2762085f"
+              status: "ACCESS_POINT_ACTIVE"
+              is_default: false
+              created_at: "2026-06-25T08:11:12Z"
+              updated_at: "2026-06-25T08:11:16Z"
+              access_policy:
+                anonuid: 65534
+                anongid: 65534
+                protocols: ["NFS4", "NFS"]
                 squash_config: "ROOT_SQUASH"
                 identity_enforcement_enabled: false

--- a/specification/resources/nfs/responses/access_point_list.yml
+++ b/specification/resources/nfs/responses/access_point_list.yml
@@ -1,0 +1,43 @@
+description: >-
+  The response will be a JSON object with a key called `access_points`. The value will
+  be an array of objects containing the standard attributes associated with NFS access points.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        access_points:
+          type: array
+          items:
+            $ref: '../models/access_point_response.yml'
+      required:
+        - access_points
+
+    examples:
+      List of Access Points:
+        value:
+          access_points:
+            - id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
+              name: "my-access-point"
+              share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
+              path: "/exports/data"
+              status: "ACCESS_POINT_ACTIVE"
+              is_default: false
+              created_at: "2023-01-01T00:00:00Z"
+              updated_at: "2023-01-01T01:00:00Z"
+              access_policy:
+                anonuid: 65534
+                anongid: 65534
+                protocols: ["NFS4"]
+                squash_config: "ROOT_SQUASH"
+                identity_enforcement_enabled: true
+

--- a/specification/resources/nfs/responses/access_point_list.yml
+++ b/specification/resources/nfs/responses/access_point_list.yml
@@ -13,23 +13,16 @@ headers:
 content:
   application/json:
     schema:
-      type: object
-      properties:
-        access_points:
-          type: array
-          items:
-            $ref: '../models/access_point_response.yml'
-      required:
-        - access_points
+      $ref: '../models/access_point_list_response.yml'
 
     examples:
       List of Access Points:
         value:
           access_points:
             - id: "a1b2c3d4-e5f6-4a5b-9c8d-1e2f3a4b5c6d"
-              name: "my-access-point"
+              name: "team-a"
               share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
-              path: "/exports/data"
+              path: "/team-a"
               status: "ACCESS_POINT_ACTIVE"
               is_default: false
               created_at: "2023-01-01T00:00:00Z"
@@ -39,5 +32,4 @@ content:
                 anongid: 65534
                 protocols: ["NFS4"]
                 squash_config: "ROOT_SQUASH"
-                identity_enforcement_enabled: true
-
+                identity_enforcement_enabled: false

--- a/specification/resources/nfs/responses/access_point_list.yml
+++ b/specification/resources/nfs/responses/access_point_list.yml
@@ -23,6 +23,7 @@ content:
               name: "team-a"
               share_id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
               path: "/team-a"
+              vpc_id: "796c6fe3-2a1d-4da2-9f3e-38239827dc91"
               status: "ACCESS_POINT_ACTIVE"
               is_default: false
               created_at: "2023-01-01T00:00:00Z"

--- a/specification/resources/nfs/responses/nfs_actions.yml
+++ b/specification/resources/nfs/responses/nfs_actions.yml
@@ -12,3 +12,15 @@ content:
   application/json:
     schema:
       $ref: '../models/nfs_actions_response.yml'
+
+    examples:
+      Resize Share Action:
+        value:
+          action:
+            id: "084c3b9c-2382-441b-92d4-10b095bb5d7c"
+            region_slug: "atl1"
+            resource_id: "baf4827c-6fa9-456f-9dbd-9ddfcacd0720"
+            resource_type: "SHARE"
+            type: "RESIZE_SHARE"
+            status: "IN_PROGRESS"
+            started_at: "2026-06-25T08:11:12Z"

--- a/specification/resources/nfs/responses/nfs_get.yml
+++ b/specification/resources/nfs/responses/nfs_get.yml
@@ -19,12 +19,43 @@ content:
       Active Share:
         value:
           share:
-            id: "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
+            id: "baf4827c-6fa9-456f-9dbd-9ddfcacd0720"
             name: "sammy-share-drive"
             size_gib: 1024
             region: "atl1"
             status: "ACTIVE"
             created_at: "2023-01-01T00:00:00Z"
             vpc_ids: ["796c6fe3-2a1d-4da2-9f3e-38239827dc91"]
+            performance_tier: "PERFORMANCE_TIER_HIGH"
             mount_path: "/123456/your-nfs-share-uuid"
             host: "10.128.32.2"
+            access_points:
+              - id: "becd9f04-8afa-4ccd-b03e-9676447df603"
+                name: "default"
+                share_id: "baf4827c-6fa9-456f-9dbd-9ddfcacd0720"
+                path: "/"
+                status: "ACCESS_POINT_ACTIVE"
+                is_default: true
+                created_at: "2026-06-25T08:10:29Z"
+                updated_at: "2026-06-25T08:10:37Z"
+                access_policy:
+                  anonuid: 65534
+                  anongid: 65534
+                  protocols: ["NFS4", "NFS"]
+                  squash_config: "ROOT_SQUASH"
+                  identity_enforcement_enabled: false
+              - id: "7659ce91-354d-4f61-9cda-ae2c7feb61d9"
+                name: "other-vpc"
+                share_id: "baf4827c-6fa9-456f-9dbd-9ddfcacd0720"
+                path: "/other-vpc"
+                vpc_id: "3f34cdb2-1e4f-4100-b5c7-f55f2762085f"
+                status: "ACCESS_POINT_ACTIVE"
+                is_default: false
+                created_at: "2026-06-25T08:11:12Z"
+                updated_at: "2026-06-25T08:11:16Z"
+                access_policy:
+                  anonuid: 65534
+                  anongid: 65534
+                  protocols: ["NFS4", "NFS"]
+                  squash_config: "ROOT_SQUASH"
+                  identity_enforcement_enabled: false


### PR DESCRIPTION
## Summary

Adds NFS access point CRUD endpoints to the public OpenAPI spec, aligned with the cthulhu sharesvc/publicapi implementation.

- `POST /v2/nfs/shares/{share_id}/access_points` — create access point
- `GET /v2/nfs/shares/{share_id}/access_points` — list access points (optional status filter)
- `GET /v2/nfs/access_points/{access_point_id}` — get access point
- `DELETE /v2/nfs/access_points/{access_point_id}` — delete access point
- `access_points` array on share GET/LIST responses

Gen1 scope: Create, Get, List, Delete only. `UpdateAccessPointPolicy` is intentionally omitted (not yet supported in sharesvc).

Supersedes #1191 — includes original spec plus review fixes (validation docs, correct delete action status, shared action schema, error responses).

## Test plan

- [x] `make bundle` passes
- [x] `make lint` passes (0 errors)