### PR TITLE
Add INACTIVE status and performance_tier to NFS share response model.

### DIFF
--- a/specification/resources/nfs/models/nfs_response.yml
+++ b/specification/resources/nfs/models/nfs_response.yml
@@ -20,8 +20,10 @@ properties:
     example: "atl1"
   status:
     type: string
-    enum: [CREATING, ACTIVE, FAILED, DELETED]
-    description: The current status of the share.
+    enum: [CREATING, ACTIVE, INACTIVE, FAILED, DELETED]
+    description: |
+      The current status of the share. `INACTIVE` means the share exists but is
+      not attached to any VPC.
     readOnly: true
     example: "ACTIVE"
   created_at:
@@ -36,6 +38,10 @@ properties:
       type: string
     description: List of VPC IDs that should be able to access the share.
     example: ["796c6fe3-2a1d-4da2-9f3e-38239827dc91"]
+  performance_tier:
+    type: string
+    description: The performance tier of the share.
+    example: "PERFORMANCE_TIER_HIGH"
   mount_path:
     type: string
     description: Path at which the share will be available, to be mounted at a target of the user's choice within the client


### PR DESCRIPTION
## Summary
- Add `INACTIVE` to the NFS share `status` enum (share exists but is not attached to any VPC).
- Add `performance_tier` to the share response model.
These fields are returned by the cthulhu NFS public API but were missing from the public OpenAPI share model before the access points work.
## Test plan
- [x] `make lint` passes locally