### PR TITLE
DBAAS-8142: Add GET/PUT /v2/databases/{uuid}/do_settings

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -1042,6 +1042,12 @@ paths:
     put:
       $ref: "resources/databases/databases_update_firewall_rules.yml"
 
+  /v2/databases/{database_cluster_uuid}/do_settings:
+    get:
+      $ref: "resources/databases/databases_get_do_settings.yml"
+    put:
+      $ref: "resources/databases/databases_update_do_settings.yml"
+
   /v2/databases/{database_cluster_uuid}/maintenance:
     put:
       $ref: "resources/databases/databases_update_maintenanceWindow.yml"

--- a/specification/resources/databases/databases_get_do_settings.yml
+++ b/specification/resources/databases/databases_get_do_settings.yml
@@ -1,0 +1,43 @@
+operationId: databases_get_do_settings
+
+summary: Retrieve DO Settings for a Database Cluster
+
+description: >-
+  To retrieve the DigitalOcean-specific settings for a database cluster, send a
+  GET request to `/v2/databases/$DATABASE_ID/do_settings`.
+
+  The response will include the current `service_cnames` configuration.
+
+tags:
+  - Databases
+
+parameters:
+  - $ref: 'parameters.yml#/database_cluster_uuid'
+
+responses:
+  '200':
+    $ref: 'responses/do_settings.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/databases_get_do_settings.yml'
+  - $ref: 'examples/go/databases_get_do_settings.yml'
+  - $ref: 'examples/python/databases_get_do_settings.yml'
+
+security:
+  - bearer_auth:
+    - 'database:read'

--- a/specification/resources/databases/databases_update_do_settings.yml
+++ b/specification/resources/databases/databases_update_do_settings.yml
@@ -1,0 +1,75 @@
+operationId: databases_update_do_settings
+
+summary: Update DO Settings for a Database Cluster
+
+description: >-
+  To update the DigitalOcean-specific settings for a database cluster, send a
+  PUT request to `/v2/databases/$DATABASE_ID/do_settings`.
+
+  Currently, the only supported setting is `service_cnames`, which allows you
+  to specify custom DNS names (CNAMEs) to be included in the TLS certificate
+  Subject Alternative Names (SANs) for the database cluster nodes. This
+  enables TLS verification when connecting via a custom hostname.
+
+  After updating, the database nodes will be replaced to apply the new
+  certificate. This process is performed as a rolling replacement and does not
+  cause downtime.
+
+  To clear all custom CNAMEs, send an empty array or omit the field.
+
+tags:
+  - Databases
+
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        required:
+          - do_settings
+        properties:
+          do_settings:
+            $ref: 'models/do_settings.yml'
+      example:
+        do_settings:
+          service_cnames:
+            - "db.example.com"
+            - "db-replica.example.com"
+
+parameters:
+  - $ref: 'parameters.yml#/database_cluster_uuid'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '400':
+    $ref: '../../shared/responses/bad_request.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '422':
+    $ref: '../../shared/responses/unprocessable_entity.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/databases_update_do_settings.yml'
+  - $ref: 'examples/go/databases_update_do_settings.yml'
+  - $ref: 'examples/python/databases_update_do_settings.yml'
+
+security:
+  - bearer_auth:
+    - 'database:update'

--- a/specification/resources/databases/examples/curl/databases_get_do_settings.yml
+++ b/specification/resources/databases/examples/curl/databases_get_do_settings.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/do_settings"

--- a/specification/resources/databases/examples/curl/databases_update_do_settings.yml
+++ b/specification/resources/databases/examples/curl/databases_update_do_settings.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X PUT \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    -d '{"do_settings": {"service_cnames": ["db.example.com", "db-replica.example.com"]}}' \
+    "https://api.digitalocean.com/v2/databases/9cc10173-e9ea-4176-9dbc-a4cee4c4ff30/do_settings"

--- a/specification/resources/databases/examples/go/databases_get_do_settings.yml
+++ b/specification/resources/databases/examples/go/databases_get_do_settings.yml
@@ -1,0 +1,17 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "os"
+
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      token := os.Getenv("DIGITALOCEAN_TOKEN")
+
+      client := godo.NewFromToken(token)
+      ctx := context.TODO()
+
+      doSettings, _, err := client.Databases.GetDOSettings(ctx, "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30")
+  }

--- a/specification/resources/databases/examples/go/databases_update_do_settings.yml
+++ b/specification/resources/databases/examples/go/databases_update_do_settings.yml
@@ -1,0 +1,27 @@
+lang: Go
+source: |-
+  import (
+      "context"
+      "os"
+
+      "github.com/digitalocean/godo"
+  )
+
+  func main() {
+      token := os.Getenv("DIGITALOCEAN_TOKEN")
+
+      client := godo.NewFromToken(token)
+      ctx := context.TODO()
+
+      dbID := "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30"
+
+      req := godo.DatabaseUpdateDOSettingsRequest{
+          DOSettings: &godo.DOSettings{
+              ServiceCnames: []string{
+                  "db.example.com",
+                  "db-replica.example.com",
+              },
+          },
+      }
+      _, err := client.Databases.UpdateDOSettings(ctx, dbID, &req)
+  }

--- a/specification/resources/databases/examples/python/databases_get_do_settings.yml
+++ b/specification/resources/databases/examples/python/databases_get_do_settings.yml
@@ -1,0 +1,8 @@
+lang: Python
+source: |-
+  import os
+  from pydo import Client
+
+  client = Client(token=os.environ.get("DIGITALOCEAN_TOKEN"))
+
+  resp = client.databases.get_do_settings(database_cluster_uuid="9cc10173-e9ea-4176-9dbc-a4cee4c4ff30")

--- a/specification/resources/databases/examples/python/databases_update_do_settings.yml
+++ b/specification/resources/databases/examples/python/databases_update_do_settings.yml
@@ -1,0 +1,17 @@
+lang: Python
+source: |-
+  import os
+  from pydo import Client
+
+  client = Client(token=os.environ.get("DIGITALOCEAN_TOKEN"))
+
+  req = {
+      "do_settings": {
+          "service_cnames": ["db.example.com", "db-replica.example.com"]
+      }
+  }
+
+  resp = client.databases.update_do_settings(
+      database_cluster_uuid="9cc10173-e9ea-4176-9dbc-a4cee4c4ff30",
+      body=req
+  )

--- a/specification/resources/databases/responses/do_settings.yml
+++ b/specification/resources/databases/responses/do_settings.yml
@@ -1,0 +1,24 @@
+description: A JSON object with a key of `do_settings`.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        do_settings:
+          $ref: '../models/do_settings.yml'
+      required:
+        - do_settings
+    example:
+      do_settings:
+        service_cnames:
+          - "db.example.com"
+          - "api.myapp.io"


### PR DESCRIPTION
## Summary

Adds the dedicated DO settings endpoint to the public API spec:

- **GET** `/v2/databases/{database_cluster_uuid}/do_settings` — retrieve current service CNAMEs
- **PUT** `/v2/databases/{database_cluster_uuid}/do_settings` — update service CNAMEs (204 on success)

Backend shipped in [cthulhu #154593](https://github.internal.digitalocean.com/digitalocean/cthulhu/pull/154593). Model (`do_settings.yml`) and create/replica fields already merged in #1137.

## Test plan

- [x] `make bundle` passes (zero Spectral errors)
- [x] Bundled spec contains both GET and PUT for `/do_settings`
- [x] Stage2 live validation against deployed backend (user `8142845`, cluster `bkp-st2-doset-mysql-0619` / `ccadf744-1481-43ab-b25f-128a79f2c3bd`):

| Case | Expected | Result |
|------|----------|--------|
| GET baseline | 200, `service_cnames: []` | PASS |
| PUT set cnames (`api.myapp.io`, `a1.x.com`) | 204 | PASS |
| GET after set | 200, cnames match | PASS |
| PUT clear (`service_cnames: []`) | 204 | PASS |
| GET after clear | 200, `service_cnames: []` | PASS |
| PUT invalid field (`per_table_metrics`) | 422 | PASS |
| PUT missing `do_settings` (`{}`) | 400 | PASS |