### PR TITLE
Add custom evaluation metrics OpenAPI endpoints

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -2761,6 +2761,17 @@ paths:
       $ref: 'resources/gen-ai/genai_list_evaluation_metrics.yml'
 
 
+  /v2/gen-ai/custom_evaluation_metrics:
+    post:
+      $ref: 'resources/gen-ai/genai_create_custom_evaluation_metric.yml'
+
+  /v2/gen-ai/custom_evaluation_metrics/{metric_uuid}:
+    put:
+      $ref: 'resources/gen-ai/genai_update_custom_evaluation_metric.yml'
+    delete:
+      $ref: 'resources/gen-ai/genai_delete_custom_evaluation_metric.yml'
+
+
   /v2/gen-ai/evaluation_runs:
     post:
       $ref: 'resources/gen-ai/genai_run_evaluation_test_case.yml'

--- a/specification/resources/gen-ai/definitions.yml
+++ b/specification/resources/gen-ai/definitions.yml
@@ -1275,9 +1275,9 @@ apiAnthropicAPIKeyInfo:
   type: object
 apiAssociatedModelEvaluationPreset:
   description: |-
-    AssociatedModelEvaluationPreset identifies a saved model evaluation preset
-    that references a metric. Returned alongside custom metrics so the dashboard
-    can warn that deleting the metric will also delete these presets.
+    A saved model evaluation preset that references a metric. Returned alongside
+    custom metrics so you can see which presets depend on the metric; deleting the
+    metric will also delete these presets.
   properties:
     eval_preset_uuid:
       description: Unique identifier of the saved model evaluation preset that references
@@ -2773,8 +2773,8 @@ apiCustomEvaluationMetricConfig:
   properties:
     add_to_library:
       description: |-
-        When true, persist in the account metric library for reuse (Figma "Always show this metric").
-        When false, use for the current evaluation flow only. Set on create/update via config.
+        When true, the metric is saved to your account's metric library so it can be reused across evaluation runs.
+        When false, the metric is used only for the current evaluation flow.
       example: true
       type: boolean
     created_at:
@@ -2785,8 +2785,9 @@ apiCustomEvaluationMetricConfig:
       readOnly: true
       type: string
     deleted_at:
-      description: When set, the custom metric is soft-deleted and must not appear
-        in pickers. Server-assigned; ignored on create/update requests.
+      description: When set, the custom metric has been deleted and is no longer
+        available for use in evaluations. Server-assigned; ignored on create/update
+        requests.
       example: "2023-01-01T00:00:00Z"
       format: date-time
       readOnly: true
@@ -3257,7 +3258,7 @@ apiEvaluationMetric:
     associated_presets:
       description: |-
         Saved model evaluation presets that reference this metric. Populated for
-        custom metrics when listing metrics so the dashboard can warn that deleting
+        custom metrics so you can see which presets depend on the metric; deleting
         the metric will also delete these presets. Empty for built-in metrics.
       items:
         $ref: '#/apiAssociatedModelEvaluationPreset'

--- a/specification/resources/gen-ai/definitions.yml
+++ b/specification/resources/gen-ai/definitions.yml
@@ -2778,14 +2778,18 @@ apiCustomEvaluationMetricConfig:
       example: true
       type: boolean
     created_at:
+      description: Timestamp when the custom metric was created. Server-assigned;
+        ignored on create/update requests.
       example: "2023-01-01T00:00:00Z"
       format: date-time
+      readOnly: true
       type: string
     deleted_at:
       description: When set, the custom metric is soft-deleted and must not appear
-        in pickers.
+        in pickers. Server-assigned; ignored on create/update requests.
       example: "2023-01-01T00:00:00Z"
       format: date-time
+      readOnly: true
       type: string
     requires_ground_truth:
       description: |-
@@ -2798,8 +2802,11 @@ apiCustomEvaluationMetricConfig:
       example: example string
       type: string
     updated_at:
+      description: Timestamp when the custom metric was last updated. Server-assigned;
+        ignored on create/update requests.
       example: "2023-01-01T00:00:00Z"
       format: date-time
+      readOnly: true
       type: string
   type: object
 apiCustomModelStatus:

--- a/specification/resources/gen-ai/definitions.yml
+++ b/specification/resources/gen-ai/definitions.yml
@@ -1273,6 +1273,22 @@ apiAnthropicAPIKeyInfo:
       example: 123e4567-e89b-12d3-a456-426614174000
       type: string
   type: object
+apiAssociatedModelEvaluationPreset:
+  description: |-
+    AssociatedModelEvaluationPreset identifies a saved model evaluation preset
+    that references a metric. Returned alongside custom metrics so the dashboard
+    can warn that deleting the metric will also delete these presets.
+  properties:
+    eval_preset_uuid:
+      description: Unique identifier of the saved model evaluation preset that references
+        the metric.
+      example: '"12345678-1234-1234-1234-123456789012"'
+      type: string
+    name:
+      description: Display name of the saved model evaluation preset.
+      example: '"My evaluation preset"'
+      type: string
+  type: object
 apiAuditHeader:
   description: An alternative way to provide auth information. for internal use only.
   properties:
@@ -2159,6 +2175,22 @@ apiCreateChatbotOutput:
     chatbot:
       $ref: '#/apiChatbot'
   type: object
+apiCreateCustomEvaluationMetricInputPublic:
+  properties:
+    config:
+      $ref: '#/apiCustomEvaluationMetricConfig'
+    description:
+      example: '"Scores adherence to our support macros"'
+      type: string
+    metric_name:
+      example: '"My domain tone metric"'
+      type: string
+  type: object
+apiCreateCustomEvaluationMetricOutput:
+  properties:
+    metric:
+      $ref: '#/apiEvaluationMetric'
+  type: object
 apiCreateDataSourceFileUploadPresignedUrlsInputPublic:
   description: Request for pre-signed URL's to upload files for KB Data Sources
   properties:
@@ -2734,6 +2766,42 @@ apiCustomModelImportJob:
       example: 123e4567-e89b-12d3-a456-426614174000
       type: string
   type: object
+apiCustomEvaluationMetricConfig:
+  description: |-
+    Configuration for a custom model-evaluation metric scored by an LLM judge.
+    Prompt and model response are always included in the judge context.
+  properties:
+    add_to_library:
+      description: |-
+        When true, persist in the account metric library for reuse (Figma "Always show this metric").
+        When false, use for the current evaluation flow only. Set on create/update via config.
+      example: true
+      type: boolean
+    created_at:
+      example: "2023-01-01T00:00:00Z"
+      format: date-time
+      type: string
+    deleted_at:
+      description: When set, the custom metric is soft-deleted and must not appear
+        in pickers.
+      example: "2023-01-01T00:00:00Z"
+      format: date-time
+      type: string
+    requires_ground_truth:
+      description: |-
+        When true, each row must provide ground truth and it is included in the judge context.
+        When false, ground truth is not required and is not sent to the judge.
+      example: true
+      type: boolean
+    scoring_prompt:
+      description: Instructions for the judge model (multi-line).
+      example: example string
+      type: string
+    updated_at:
+      example: "2023-01-01T00:00:00Z"
+      format: date-time
+      type: string
+  type: object
 apiCustomModelStatus:
   default: STATUS_UNSPECIFIED
   description: Import and deployment status of the custom model
@@ -2841,6 +2909,12 @@ apiDeleteCustomModelInputPublic:
   properties:
     uuid:
       example: 123e4567-e89b-12d3-a456-426614174000
+apiDeleteCustomEvaluationMetricInputPublic:
+  properties:
+    metric_uuid:
+      example: '"12345678-1234-1234-1234-123456789012"'
+apiDeleteCustomEvaluationMetricOutput:
+  type: object
 apiDeleteCustomModelOutput:
   description: Response containing delete operation status (internal)
   properties:
@@ -3173,8 +3247,18 @@ apiEvaluationDatasetType:
   type: string
 apiEvaluationMetric:
   properties:
+    associated_presets:
+      description: |-
+        Saved model evaluation presets that reference this metric. Populated for
+        custom metrics when listing metrics so the dashboard can warn that deleting
+        the metric will also delete these presets. Empty for built-in metrics.
+      items:
+        $ref: '#/apiAssociatedModelEvaluationPreset'
+      type: array
     category:
       $ref: '#/apiEvaluationMetricCategory'
+    custom_eval_config:
+      $ref: '#/apiCustomEvaluationMetricConfig'
     description:
       example: example string
       type: string
@@ -3212,6 +3296,8 @@ apiEvaluationMetric:
       example: 123
       format: float
       type: number
+    source:
+      $ref: '#/apiEvaluationMetricSource'
   type: object
 apiEvaluationMetricCategory:
   default: METRIC_CATEGORY_UNSPECIFIED
@@ -3250,6 +3336,16 @@ apiEvaluationMetricResult:
       example: example string
       type: string
   type: object
+apiEvaluationMetricSource:
+  default: EVALUATION_METRIC_SOURCE_UNSPECIFIED
+  description: Distinguishes platform catalog metrics from user-defined LLM-as-judge
+    metrics.
+  enum:
+  - EVALUATION_METRIC_SOURCE_UNSPECIFIED
+  - EVALUATION_METRIC_SOURCE_BUILTIN
+  - EVALUATION_METRIC_SOURCE_CUSTOM
+  example: EVALUATION_METRIC_SOURCE_UNSPECIFIED
+  type: string
 apiEvaluationMetricType:
   default: METRIC_TYPE_UNSPECIFIED
   enum:
@@ -8039,6 +8135,25 @@ apiUpdateChatbotOutput:
   properties:
     chatbot:
       $ref: '#/apiChatbot'
+  type: object
+apiUpdateCustomEvaluationMetricInputPublic:
+  properties:
+    config:
+      $ref: '#/apiCustomEvaluationMetricConfig'
+    description:
+      example: example string
+      type: string
+    metric_name:
+      example: '"My domain tone metric"'
+      type: string
+    metric_uuid:
+      example: '"12345678-1234-1234-1234-123456789012"'
+      type: string
+  type: object
+apiUpdateCustomEvaluationMetricOutput:
+  properties:
+    metric:
+      $ref: '#/apiEvaluationMetric'
   type: object
 apiUpdateCustomModelMetadataInputPublic:
   description: Request to update custom model metadata (public)

--- a/specification/resources/gen-ai/definitions.yml
+++ b/specification/resources/gen-ai/definitions.yml
@@ -2771,12 +2771,6 @@ apiCustomEvaluationMetricConfig:
     Configuration for a custom model-evaluation metric scored by an LLM judge.
     Prompt and model response are always included in the judge context.
   properties:
-    add_to_library:
-      description: |-
-        When true, the metric is saved to your account's metric library so it can be reused across evaluation runs.
-        When false, the metric is used only for the current evaluation flow.
-      example: true
-      type: boolean
     created_at:
       description: Timestamp when the custom metric was created. Server-assigned;
         ignored on create/update requests.

--- a/specification/resources/gen-ai/examples/curl/genai_create_custom_evaluation_metric.yml
+++ b/specification/resources/gen-ai/examples/curl/genai_create_custom_evaluation_metric.yml
@@ -1,0 +1,15 @@
+lang: cURL
+source: |-
+  curl -X POST \
+    -H "Content-Type: application/json"  \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/gen-ai/custom_evaluation_metrics" \
+    -d '{
+      "metric_name": "My domain tone metric",
+      "description": "Scores adherence to our support macros",
+      "config": {
+        "add_to_library": true,
+        "requires_ground_truth": true,
+        "scoring_prompt": "Grade for brand tone and factuality."
+      }
+    }'

--- a/specification/resources/gen-ai/examples/curl/genai_create_custom_evaluation_metric.yml
+++ b/specification/resources/gen-ai/examples/curl/genai_create_custom_evaluation_metric.yml
@@ -8,7 +8,6 @@ source: |-
       "metric_name": "My domain tone metric",
       "description": "Scores adherence to our support macros",
       "config": {
-        "add_to_library": true,
         "requires_ground_truth": true,
         "scoring_prompt": "Grade for brand tone and factuality."
       }

--- a/specification/resources/gen-ai/examples/curl/genai_delete_custom_evaluation_metric.yml
+++ b/specification/resources/gen-ai/examples/curl/genai_delete_custom_evaluation_metric.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X DELETE \
+    -H "Content-Type: application/json"  \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/gen-ai/custom_evaluation_metrics/e51dba65-cf7a-11ef-bf8f-4e013e2ddde4"

--- a/specification/resources/gen-ai/examples/curl/genai_update_custom_evaluation_metric.yml
+++ b/specification/resources/gen-ai/examples/curl/genai_update_custom_evaluation_metric.yml
@@ -1,0 +1,16 @@
+lang: cURL
+source: |-
+  curl -X PUT \
+    -H "Content-Type: application/json"  \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/gen-ai/custom_evaluation_metrics/e51dba65-cf7a-11ef-bf8f-4e013e2ddde4" \
+    -d '{
+      "metric_uuid": "e51dba65-cf7a-11ef-bf8f-4e013e2ddde4",
+      "metric_name": "My domain tone metric",
+      "description": "Scores adherence to our support macros",
+      "config": {
+        "add_to_library": true,
+        "requires_ground_truth": true,
+        "scoring_prompt": "Grade for brand tone and factuality."
+      }
+    }'

--- a/specification/resources/gen-ai/examples/curl/genai_update_custom_evaluation_metric.yml
+++ b/specification/resources/gen-ai/examples/curl/genai_update_custom_evaluation_metric.yml
@@ -9,7 +9,6 @@ source: |-
       "metric_name": "My domain tone metric",
       "description": "Scores adherence to our support macros",
       "config": {
-        "add_to_library": true,
         "requires_ground_truth": true,
         "scoring_prompt": "Grade for brand tone and factuality."
       }

--- a/specification/resources/gen-ai/genai_create_custom_evaluation_metric.yml
+++ b/specification/resources/gen-ai/genai_create_custom_evaluation_metric.yml
@@ -1,0 +1,40 @@
+description: To create a custom LLM-as-judge metric for model evaluation, send a POST
+  request to `/v2/gen-ai/custom_evaluation_metrics`.
+operationId: genai_create_custom_evaluation_metric
+requestBody:
+  content:
+    application/json:
+      schema:
+        $ref: ./definitions.yml#/apiCreateCustomEvaluationMetricInputPublic
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          $ref: ./definitions.yml#/apiCreateCustomEvaluationMetricOutput
+    description: A successful response.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+  "401":
+    $ref: ../../shared/responses/unauthorized.yml
+  "404":
+    $ref: ../../shared/responses/not_found.yml
+  "429":
+    $ref: ../../shared/responses/too_many_requests.yml
+  "500":
+    $ref: ../../shared/responses/server_error.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+security:
+- bearer_auth:
+  - genai:create
+summary: Create Custom Evaluation Metric
+tags:
+- GradientAI Platform
+x-codeSamples:
+- $ref: examples/curl/genai_create_custom_evaluation_metric.yml

--- a/specification/resources/gen-ai/genai_delete_custom_evaluation_metric.yml
+++ b/specification/resources/gen-ai/genai_delete_custom_evaluation_metric.yml
@@ -1,0 +1,43 @@
+description: To soft-delete a custom model evaluation metric, send a DELETE request
+  to `/v2/gen-ai/custom_evaluation_metrics/{metric_uuid}`.
+operationId: genai_delete_custom_evaluation_metric
+parameters:
+- description: UUID of the custom metric to delete.
+  example: '"123e4567-e89b-12d3-a456-426614174000"'
+  in: path
+  name: metric_uuid
+  required: true
+  schema:
+    type: string
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          $ref: ./definitions.yml#/apiDeleteCustomEvaluationMetricOutput
+    description: A successful response.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+  "401":
+    $ref: ../../shared/responses/unauthorized.yml
+  "404":
+    $ref: ../../shared/responses/not_found.yml
+  "429":
+    $ref: ../../shared/responses/too_many_requests.yml
+  "500":
+    $ref: ../../shared/responses/server_error.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+security:
+- bearer_auth:
+  - genai:delete
+summary: Delete Custom Evaluation Metric
+tags:
+- GradientAI Platform
+x-codeSamples:
+- $ref: examples/curl/genai_delete_custom_evaluation_metric.yml

--- a/specification/resources/gen-ai/genai_update_custom_evaluation_metric.yml
+++ b/specification/resources/gen-ai/genai_update_custom_evaluation_metric.yml
@@ -1,0 +1,48 @@
+description: To update a custom metric (issuing a new metric UUID), send a PUT request
+  to `/v2/gen-ai/custom_evaluation_metrics/{metric_uuid}`.
+operationId: genai_update_custom_evaluation_metric
+parameters:
+- description: UUID of the custom metric to update.
+  example: '"123e4567-e89b-12d3-a456-426614174000"'
+  in: path
+  name: metric_uuid
+  required: true
+  schema:
+    type: string
+requestBody:
+  content:
+    application/json:
+      schema:
+        $ref: ./definitions.yml#/apiUpdateCustomEvaluationMetricInputPublic
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          $ref: ./definitions.yml#/apiUpdateCustomEvaluationMetricOutput
+    description: A successful response.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+  "401":
+    $ref: ../../shared/responses/unauthorized.yml
+  "404":
+    $ref: ../../shared/responses/not_found.yml
+  "429":
+    $ref: ../../shared/responses/too_many_requests.yml
+  "500":
+    $ref: ../../shared/responses/server_error.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+security:
+- bearer_auth:
+  - genai:update
+summary: Update Custom Evaluation Metric
+tags:
+- GradientAI Platform
+x-codeSamples:
+- $ref: examples/curl/genai_update_custom_evaluation_metric.yml


### PR DESCRIPTION
## Summary
- add OpenAPI operations for custom evaluation metrics create/update/delete under the GenAI section
- align request/response schemas and shared metric fields with the Cthulhu proto-generated contract
- add curl examples for create, update (path metric UUID), and delete (path metric UUID)

## Test plan
- [x] Run `npm run lint -- specification/DigitalOcean-public.v2.yaml`
- [x] Confirm no linter errors in modified files via IDE diagnostics
- [x] Verify branch diff is scoped to custom metric OpenAPI files only

Made with [Cursor](https://cursor.com)