### PR TITLE
gen-ai: remove deprecated save_as_preset field

### DIFF
--- a/specification/resources/gen-ai/definitions.yml
+++ b/specification/resources/gen-ai/definitions.yml
@@ -2425,11 +2425,6 @@ apiCreateModelEvaluationRunInputPublic:
     preset_name:
       example: example name
       type: string
-    save_as_preset:
-      description: "If true, saves the inline config as a reusable preset  \nIgnored
-        when eval_preset_uuid is provided."
-      example: true
-      type: boolean
     source:
       description: Source of the run creation (api, sdk, cli).
       example: example string


### PR DESCRIPTION
## Summary
- Removes the deprecated `save_as_preset` boolean property from `apiCreateModelEvaluationRunInputPublic` in `specification/resources/gen-ai/definitions.yml`.
- This field has been superseded by `preset_save_sections`, which allows selecting individual preset sections to save instead of an all-or-nothing boolean.
- Mirrors the removal of the corresponding deprecated `save_as_preset` field from the gen-ai API's proto definition.
- Scoped narrowly to this field removal; this PR does not attempt to reconcile other pre-existing drift between this fork and the source spec for unrelated gen-ai endpoints.

## Test plan
- `make bundle` succeeds with no new warnings/errors introduced by this change.
- Confirmed no other references to `save_as_preset` remain in the spec.

Made with [Cursor](https://cursor.com)