### PR TITLE
Add p2p_oci_registry_plugin to k8s response

### DIFF
--- a/specification/resources/kubernetes/models/cluster.yml
+++ b/specification/resources/kubernetes/models/cluster.yml
@@ -182,6 +182,9 @@ properties:
   routing_agent:
     $ref: "routing_agent.yml"
 
+  p2p_oci_registry_plugin:
+    $ref: "p2p_oci_registry_plugin.yml"
+
   amd_gpu_device_plugin:
     $ref: "amd_gpu_device_plugin.yml"
 

--- a/specification/resources/kubernetes/models/cluster_read.yml
+++ b/specification/resources/kubernetes/models/cluster_read.yml
@@ -204,6 +204,9 @@ properties:
   coredns_autoscaler:
     $ref: "coredns_autoscaler.yml"
 
+  p2p_oci_registry_plugin:
+    $ref: "p2p_oci_registry_plugin.yml"
+
 required:
   - name
   - region

--- a/specification/resources/kubernetes/models/cluster_update.yml
+++ b/specification/resources/kubernetes/models/cluster_update.yml
@@ -59,6 +59,9 @@ properties:
   routing_agent:
     $ref: 'routing_agent.yml'
 
+  p2p_oci_registry_plugin:
+    $ref: "p2p_oci_registry_plugin.yml"
+
   amd_gpu_device_plugin:
     $ref: "amd_gpu_device_plugin.yml"
 

--- a/specification/resources/kubernetes/models/p2p_oci_registry_plugin.yml
+++ b/specification/resources/kubernetes/models/p2p_oci_registry_plugin.yml
@@ -1,0 +1,8 @@
+type: object
+nullable: true
+description: An object specifying whether the Peer-to-peer OCI registry component should be enabled for the Kubernetes cluster.
+properties:
+  enabled:
+    type: boolean
+    description: Indicates whether the Peer-to-peer OCI registry component is enabled.
+    example: true

--- a/specification/resources/kubernetes/responses/examples.yml
+++ b/specification/resources/kubernetes/responses/examples.yml
@@ -129,6 +129,8 @@ kubernetes_clusters_all:
         enabled: false
       coredns_autoscaler:
         enabled: false
+      p2p_oci_registry_plugin:
+        enabled: false
     meta:
       total: 1
 
@@ -263,6 +265,8 @@ kubernetes_single:
         enabled: false
       coredns_autoscaler:
         enabled: false
+      p2p_oci_registry_plugin:
+        enabled: false
 
 kubernetes_updated:
   value:
@@ -394,6 +398,8 @@ kubernetes_updated:
         enabled: false
       coredns_autoscaler:
         enabled: false
+      p2p_oci_registry_plugin:
+        enabled: false
 
 kubernetes_clusters_create_basic_response:
   value:
@@ -489,6 +495,8 @@ kubernetes_clusters_create_basic_response:
       rdma_shared_dev_plugin:
         enabled: false
       coredns_autoscaler:
+        enabled: false
+      p2p_oci_registry_plugin:
         enabled: false
 
 kubernetes_clusters_multi_pool_response:


### PR DESCRIPTION
Adding p2p_oci_registry_plugin to k8s response.

<img width="1425" height="688" alt="Screenshot 2026-07-08 at 4 23 34 PM" src="https://github.com/user-attachments/assets/9da3b304-d517-467c-9d73-34d6a7d50348" />
<img width="794" height="129" alt="Screenshot 2026-07-08 at 4 23 57 PM" src="https://github.com/user-attachments/assets/14f84a43-c7f9-4dbf-84cf-7436a6c0bd8b" />
