### PR TITLE
DBAAS-8634: Document pg_allow_replication optional default and update path

### DIFF
--- a/specification/resources/databases/databases_add_user.yml
+++ b/specification/resources/databases/databases_add_user.yml
@@ -11,10 +11,14 @@ description: |
   When adding a user to a MySQL cluster, additional options can be configured in the
   `mysql_settings` object.
 
+  When adding a user to a PostgreSQL cluster, additional options can be configured in
+  the `settings` object (for example, `pg_allow_replication`). When
+  `pg_allow_replication` is omitted, it defaults to `false`.
+
   When adding a user to a Kafka cluster, additional options can be configured in
   the `settings` object.
 
-   When adding a user to a MongoDB cluster, additional options can be configured in
+  When adding a user to a MongoDB cluster, additional options can be configured in
   the `settings.mongo_user_settings` object.
 
   The response will be a JSON object with a key called `user`. The value of this will be an

--- a/specification/resources/databases/databases_get_user.yml
+++ b/specification/resources/databases/databases_get_user.yml
@@ -15,6 +15,9 @@ description: |
   For MySQL clusters, additional options will be contained in the `mysql_settings`
   object.
 
+  For PostgreSQL clusters, additional options will be contained in the `settings`
+  object (for example, `pg_allow_replication`).
+
   For Kafka clusters, additional options will be contained in the `settings` object.
 
   For MongoDB clusters, additional information will be contained in the mongo_user_settings object

--- a/specification/resources/databases/databases_list_users.yml
+++ b/specification/resources/databases/databases_list_users.yml
@@ -14,6 +14,11 @@ description: |
 
   For MySQL clusters, additional options will be contained in the mysql_settings object.
 
+  For PostgreSQL clusters, additional options will be contained in the `settings`
+  object (for example, `pg_allow_replication`).
+
+  For Kafka clusters, additional options will be contained in the `settings` object.
+
   For MongoDB clusters, additional information will be contained in the mongo_user_settings object
 
 tags:

--- a/specification/resources/databases/databases_update_user.yml
+++ b/specification/resources/databases/databases_update_user.yml
@@ -9,8 +9,14 @@ description: |
   **Note**: only `settings` can be updated via this type of request. If you wish to change the name of a user,
   you must recreate a new user.
 
+  For PostgreSQL clusters, you can update `settings.pg_allow_replication` to enable or
+  disable replication privileges for the user. When omitted, the value defaults to `false`.
+
+  For Kafka and OpenSearch clusters, additional options can be configured in the
+  `settings` object (for example, topic or index ACLs).
+
   The response will be a JSON object with a key called `user`. The value of this will be an
-  object that contains the name of the update database user, along with the `settings` object that
+  object that contains the name of the updated database user, along with the `settings` object that
   has been updated.
 
 tags:
@@ -33,6 +39,11 @@ requestBody:
         required:
           - settings
       examples:
+        Update User Postgres Replication Rights:
+          value:
+            settings:
+              pg_allow_replication: true
+
         Update User Kafka ACLs:
           value:
             settings:

--- a/specification/resources/databases/models/user_settings.yml
+++ b/specification/resources/databases/models/user_settings.yml
@@ -5,8 +5,10 @@ properties:
     type: boolean
     example: true
     description: |
-      For Postgres clusters, set to `true` for a user with replication rights.
-      This option is not currently supported for other database engines.
+      For PostgreSQL clusters, set to `true` to grant the user replication
+      privileges. When omitted on create or update, the value defaults to
+      `false` and replication privileges are not granted. This option is not
+      currently supported for other database engines.
   opensearch_acl:
     type: array
     items:

--- a/specification/resources/databases/responses/users.yml
+++ b/specification/resources/databases/responses/users.yml
@@ -21,6 +21,11 @@ content:
         - name: app-01
           role: normal
           password: jge5lfxtzhx42iff
+        - name: app-02
+          role: normal
+          password: z421iffftjge5lxh
+          settings:
+            pg_allow_replication: true
         - name: doadmin
           role: primary
           password: wv78n3zpz42xezd


### PR DESCRIPTION
Clarify that PostgreSQL user settings.pg_allow_replication defaults to false when omitted, and document create/update/read paths in the Public API spec.