### PR TITLE
Update spec to support project:assign_resource standardization

### DIFF
--- a/specification/resources/apps/models/apps_create_app_request.yml
+++ b/specification/resources/apps/models/apps_create_app_request.yml
@@ -5,7 +5,7 @@ properties:
     type: string
     description: |
       The ID of the project the app should be assigned to. If omitted, it will be assigned to your default project.
-      <br><br>Requires `project:update` scope.
+      <br><br>Requires `project:assign_resource` scope.
 required:
 - spec
 type: object

--- a/specification/resources/databases/models/database_cluster.yml
+++ b/specification/resources/databases/models/database_cluster.yml
@@ -142,7 +142,7 @@ properties:
     type: string
     format: uuid
     example: 9cc10173-e9ea-4176-9dbc-a4cee4c4ff30
-    description: The ID of the project that the database cluster is assigned to. If excluded when creating a new database cluster, it will be assigned to your default project.<br><br>Requires `project:update` scope.
+    description: The ID of the project that the database cluster is assigned to. If excluded when creating a new database cluster, it will be assigned to your default project.<br><br>Requires `project:assign_resource` scope.
   rules:
     type: array
     items:

--- a/specification/resources/projects/projects_assign_resources.yml
+++ b/specification/resources/projects/projects_assign_resources.yml
@@ -5,7 +5,7 @@ summary: Assign Resources to a Project
 description: |
   To assign resources to a project, send a POST request to `/v2/projects/$PROJECT_ID/resources`.
 
-  You must have both `project:update` and `<resource>:read` scopes to assign new resources. For example, to assign a Droplet to a project, include both the `project:update` and `droplet:read` scopes.
+  You must have both `project:assign_resource` and `<resource>:read` scopes to assign new resources. For example, to assign a Droplet to a project, include both the `project:assign_resource` and `droplet:read` scopes. The `project:update` scope also grants `project:assign_resource`.
 
 tags:
   - Project Resources
@@ -55,4 +55,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'project:update'
+    - 'project:assign_resource'

--- a/specification/resources/projects/projects_assign_resources_default.yml
+++ b/specification/resources/projects/projects_assign_resources_default.yml
@@ -5,7 +5,7 @@ summary: Assign Resources to Default Project
 description: |
   To assign resources to your default project, send a POST request to `/v2/projects/default/resources`.
 
-  You must have both project:update and <resource>:read scopes to assign new resources. For example, to assign a Droplet to the default project, include both the `project:update` and `droplet:read` scopes.
+  You must have both `project:assign_resource` and `<resource>:read` scopes to assign new resources. For example, to assign a Droplet to the default project, include both the `project:assign_resource` and `droplet:read` scopes. The `project:update` scope also grants `project:assign_resource`.
 
 tags:
   - Project Resources
@@ -52,4 +52,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'project:update'
+    - 'project:assign_resource'


### PR DESCRIPTION
This PR updates the API spec to support the new standardization of `project:assign_resource`. 