### PR TITLE
Complete databases firewall PUT description (PDOCS-4399)

### DIFF
--- a/specification/resources/databases/databases_update_firewall_rules.yml
+++ b/specification/resources/databases/databases_update_firewall_rules.yml
@@ -11,8 +11,7 @@ description: >-
   provided, any Droplet or Kubernetes node with that tag applied to it will
   have access. The firewall is limited to 100 rules (or trusted sources). You
   cannot add IPv6 addresses as trusted sources. For additional limits, see your
-  database engine's limits page, for example
-  [PostgreSQL Limits](https://docs.digitalocean.com/products/databases/postgresql/details/limits/).
+  database engine's limits page.
   When possible, we recommend
   [placing your databases into a VPC network](https://docs.digitalocean.com/products/networking/vpc/)
   to limit access to them instead of using a firewall.

--- a/specification/resources/databases/databases_update_firewall_rules.yml
+++ b/specification/resources/databases/databases_update_firewall_rules.yml
@@ -9,12 +9,15 @@ description: >-
   able to open connections to the database. You may limit connections to
   specific Droplets, Kubernetes clusters, or IP addresses. When a tag is
   provided, any Droplet or Kubernetes node with that tag applied to it will
-  have access. The firewall is limited to 100 rules (or trusted sources). When
-  possible, we recommend
+  have access. The firewall is limited to 100 rules (or trusted sources). You
+  cannot add IPv6 addresses as trusted sources. For additional limits, see your
+  database engine's limits page, for example
+  [PostgreSQL Limits](https://docs.digitalocean.com/products/databases/postgresql/details/limits/).
+  When possible, we recommend
   [placing your databases into a VPC network](https://docs.digitalocean.com/products/networking/vpc/)
   to limit access to them instead of using a firewall.
 
-  A successful
+  A successful request returns a 204 status code with no content.
 
 tags:
   - Databases


### PR DESCRIPTION
## Summary
- Fix truncated `databases_update_firewall_rules` description that ended mid-sentence at "A successful".
- Document that IPv6 addresses cannot be added as trusted sources, and point readers to their database engine's limits page.
- Completes OpenAPI half of PDOCS-4399 (product-docs Secure/limits updates are in digitalocean/product-docs#6420).

## Test plan
- [x] `make lint` passes locally
- [ ] Confirm Spec Preview / Redoc shows full PUT description with IPv6 note and limits guidance
- [ ] After merge, verify product-docs daily regeneration updates the Databases API reference