### PR TITLE
Hide Secrets Manager from public API docs until GA

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -540,9 +540,10 @@ tags:
       An action object is returned. These objects hold the current status of the
       requested action.
 
+  # Secrets Manager omitted from this tag description until GA; paths commented out below.
   - name: Security
     description: |-
-      Security endpoints for CSPM scans, scan findings, settings, and Secrets Manager.
+      Security CSPM endpoints for scans, scan findings, and settings.
 
   - name: Sizes
     description: |-
@@ -2331,30 +2332,34 @@ paths:
     delete:
       $ref: "resources/security/security_suppression_delete.yml"
 
-  /v2/security/secrets:
-    get:
-      $ref: "resources/security/security_secrets_list.yml"
-
-    post:
-      $ref: "resources/security/security_secret_create.yml"
-
-  /v2/security/secrets/{secret}:
-    get:
-      $ref: "resources/security/security_secret_get.yml"
-
-    put:
-      $ref: "resources/security/security_secret_update.yml"
-
-    delete:
-      $ref: "resources/security/security_secret_delete.yml"
-
-  /v2/security/secrets/{secret}/versions:
-    get:
-      $ref: "resources/security/security_secret_list_versions.yml"
-
-  /v2/security/secrets/{secret}/restore:
-    post:
-      $ref: "resources/security/security_secret_restore.yml"
+  # Secrets Manager endpoints are temporarily commented out so they are not
+  # published in the public API docs until the product is generally available.
+  # The operation/model files remain under resources/security/ for easy restore.
+  #
+  # /v2/security/secrets:
+  #   get:
+  #     $ref: "resources/security/security_secrets_list.yml"
+  #
+  #   post:
+  #     $ref: "resources/security/security_secret_create.yml"
+  #
+  # /v2/security/secrets/{secret}:
+  #   get:
+  #     $ref: "resources/security/security_secret_get.yml"
+  #
+  #   put:
+  #     $ref: "resources/security/security_secret_update.yml"
+  #
+  #   delete:
+  #     $ref: "resources/security/security_secret_delete.yml"
+  #
+  # /v2/security/secrets/{secret}/versions:
+  #   get:
+  #     $ref: "resources/security/security_secret_list_versions.yml"
+  #
+  # /v2/security/secrets/{secret}/restore:
+  #   post:
+  #     $ref: "resources/security/security_secret_restore.yml"
 
   /v2/sizes:
     get:


### PR DESCRIPTION
## Summary
- Temporarily comment out Secrets Manager paths (`/v2/security/secrets*`) in the public OpenAPI root so they are not published to docs.digitalocean.com
- Keep the Secrets Manager operation/model/example files under `resources/security/` so they can be restored by uncommenting
- Update the Security tag description to CSPM-only while Secrets Manager remains unpublished

Customers are discovering Secrets Manager via public docs and receiving 403s because the product is not generally available.

## Test plan
- [x] `make lint` passes locally
- [x] Confirm Redoc/docs preview no longer lists Secrets Manager endpoints under Security
- [x] Confirm CSPM Security endpoints still appear
- [ ] After merge, verify https://docs.digitalocean.com/reference/api/reference/security/ no longer shows List/Get/Create/Update/Delete Secret endpoints


Made with [Cursor](https://cursor.com)