### PR TITLE
doks: document the isolated_workers field

### DIFF
--- a/specification/resources/kubernetes/examples.yml
+++ b/specification/resources/kubernetes/examples.yml
@@ -3,6 +3,7 @@ kubernetes_clusters_basic_request:
     name: prod-cluster-01
     region: nyc1
     version: 1.18.6-do.0
+    isolated_workers: false
     node_pools:
     - size: s-1vcpu-2gb
       count: 3
@@ -17,6 +18,7 @@ kubernetes_clusters_multi_pool_request:
     name: prod-cluster-01
     region: nyc1
     version: 1.18.6-do.0
+    isolated_workers: false
     tags:
     - production
     - web-team

--- a/specification/resources/kubernetes/examples/curl/kubernetes_create_cluster.yml
+++ b/specification/resources/kubernetes/examples/curl/kubernetes_create_cluster.yml
@@ -3,5 +3,5 @@ source: |-
   curl -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-    -d '{"name": "prod-cluster-01","region": "nyc1","version": "1.14.1-do.4","vpc_uuid": "c33931f2-a26a-4e61-b85c-4e95a2ec431b","worker_subnet_uuid": "cbd79771-23eb-49be-b5ea-59cc56222622","tags": ["production","web-team"],"node_pools": [{"size": "s-1vcpu-2gb","count": 3,"name": "frontend-pool","tags": ["frontend"],"labels": {"service": "frontend", "priority": "high"}},{"size": "c-4","count": 2,"name": "backend-pool"}]}' \
+    -d '{"name": "prod-cluster-01","region": "nyc1","version": "1.14.1-do.4","vpc_uuid": "c33931f2-a26a-4e61-b85c-4e95a2ec431b","worker_subnet_uuid": "cbd79771-23eb-49be-b5ea-59cc56222622","isolated_workers": false,"tags": ["production","web-team"],"node_pools": [{"size": "s-1vcpu-2gb","count": 3,"name": "frontend-pool","tags": ["frontend"],"labels": {"service": "frontend", "priority": "high"}},{"size": "c-4","count": 2,"name": "backend-pool"}]}' \
     "https://api.digitalocean.com/v2/kubernetes/clusters"

--- a/specification/resources/kubernetes/examples/go/kubernetes_create_cluster.yml
+++ b/specification/resources/kubernetes/examples/go/kubernetes_create_cluster.yml
@@ -17,6 +17,7 @@ source: |-
           Name:        "prod-cluster-01",
           RegionSlug:  "nyc1",
           VersionSlug: "1.14.1-do.4",
+          IsolatedWorkers: false,
           Tags:        []string{"production", "web-team"},
           NodePools: []*godo.KubernetesNodePoolCreateRequest{
               &godo.KubernetesNodePoolCreateRequest{

--- a/specification/resources/kubernetes/examples/python/kubernetes_create_cluster.yml
+++ b/specification/resources/kubernetes/examples/python/kubernetes_create_cluster.yml
@@ -9,6 +9,7 @@ source: |-
     "name": "prod-cluster-01",
     "region": "nyc1",
     "version": "1.18.6-do.0",
+    "isolated_workers": False,
     "node_pools": [
       {
         "size": "s-1vcpu-2gb",

--- a/specification/resources/kubernetes/examples/ruby/kubernetes_create_cluster.yml
+++ b/specification/resources/kubernetes/examples/ruby/kubernetes_create_cluster.yml
@@ -8,6 +8,7 @@ source: |-
     name: 'prod-cluster-01',
     region: 'nyc1',
     version: '1.14.1-do.4',
+    isolated_workers: false,
     tags: ['production', 'web-team'],
     node_pools: [
       {

--- a/specification/resources/kubernetes/models/cluster.yml
+++ b/specification/resources/kubernetes/models/cluster.yml
@@ -104,6 +104,15 @@ properties:
     description: A boolean value indicating whether the cluster will be
       automatically upgraded to new patch releases during its maintenance window.
 
+  isolated_workers:
+    type: boolean
+    default: false
+    example: false
+    description: A boolean value indicating whether worker nodes in the cluster
+      are not assigned public IP addresses. When omitted on create, the default
+      value is false. When enabled, a NAT gateway must exist in the VPC where
+      the cluster is created.
+
   status:
     type: object
     readOnly: true

--- a/specification/resources/kubernetes/models/cluster_read.yml
+++ b/specification/resources/kubernetes/models/cluster_read.yml
@@ -100,6 +100,15 @@ properties:
     description: A boolean value indicating whether the cluster will be
       automatically upgraded to new patch releases during its maintenance window.
 
+  isolated_workers:
+    type: boolean
+    default: false
+    example: false
+    description: A boolean value indicating whether worker nodes in the cluster
+      are not assigned public IP addresses. When omitted on create, the default
+      value is false. When enabled, a NAT gateway must exist in the VPC where
+      the cluster is created.
+
   status:
     type: object
     readOnly: true

--- a/specification/resources/kubernetes/responses/examples.yml
+++ b/specification/resources/kubernetes/responses/examples.yml
@@ -90,6 +90,7 @@ kubernetes_clusters_all:
         duration: 4h0m0s
         day: any
       auto_upgrade: false
+      isolated_workers: false
       status:
         state: provisioning
         message: provisioning
@@ -227,6 +228,7 @@ kubernetes_single:
         duration: 4h0m0s
         day: any
       auto_upgrade: false
+      isolated_workers: false
       status:
         state: running
       created_at: '2018-11-15T16:00:11Z'
@@ -360,6 +362,7 @@ kubernetes_updated:
         duration: 4h0m0s
         day: any
       auto_upgrade: true
+      isolated_workers: false
       status:
         state: running
       created_at: '2018-11-15T16:00:11Z'
@@ -457,6 +460,7 @@ kubernetes_clusters_create_basic_response:
         duration: 4h0m0s
         day: any
       auto_upgrade: false
+      isolated_workers: false
       status:
         state: provisioning
         message: provisioning
@@ -593,6 +597,7 @@ kubernetes_clusters_multi_pool_response:
         duration: 4h0m0s
         day: any
       auto_upgrade: false
+      isolated_workers: false
       status:
         state: provisioning
         message: provisioning


### PR DESCRIPTION
The field is only available to be set on k8s cluster create. And has prerequisite of NAT GW in the same VPC as cluster for isolated workers to be supported. 