### PR TITLE
Add Hosted Agents /v2/agents/configs OpenAPI (MARSOHS-741)

### DIFF
--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -60,6 +60,15 @@ tags:
       The Add-Ons API allows you to manage these resources, including creating, listing, and retrieving
       details about specific add-on resources.
 
+  - name: Agents
+    description: |-
+      Hosted Agents sessions API (`/v2/agents/sessions`). Sessions represent a
+      managed agent + sandbox pair. Product provenance is exposed via
+      `session.origin` (`direct` | `simulation` | `evaluation`). ListSessions
+      omits simulation and evaluation sessions server-side so customer surfaces
+      stay free of product-owned internal runs; GetSession by session_id still
+      returns those sessions for the owning product workflow.
+
   - name: Apps
     description: |-
       App Platform is a Platform-as-a-Service (PaaS) offering from DigitalOcean that allows
@@ -780,6 +789,62 @@ paths:
   /v2/add-ons/saas/{resource_uuid}/plan:
     patch:
       $ref: "resources/addons/addons_update_plan.yml"
+
+  /v2/agents/sessions:
+    get:
+      $ref: "resources/agents/agents_list_sessions.yml"
+    post:
+      $ref: "resources/agents/agents_create_session.yml"
+  /v2/agents/sessions/policy/validate:
+    post:
+      $ref: "resources/agents/agents_validate_session_policy.yml"
+  /v2/agents/sessions/sandbox/sizes:
+    get:
+      $ref: "resources/agents/agents_list_session_sandbox_sizes.yml"
+  /v2/agents/sessions/{session_id}:
+    delete:
+      $ref: "resources/agents/agents_delete_session.yml"
+    get:
+      $ref: "resources/agents/agents_get_session.yml"
+  /v2/agents/sessions/{session_id}/hitl/{request_id}:
+    post:
+      $ref: "resources/agents/agents_post_session_hitl.yml"
+  /v2/agents/sessions/{session_id}/input:
+    post:
+      $ref: "resources/agents/agents_create_session_input.yml"
+  /v2/agents/sessions/{session_id}/pause:
+    post:
+      $ref: "resources/agents/agents_post_session_pause.yml"
+  /v2/agents/sessions/{session_id}/resume:
+    post:
+      $ref: "resources/agents/agents_post_session_resume.yml"
+  /v2/agents/sessions/{session_id}/sandbox/exec:
+    post:
+      $ref: "resources/agents/agents_post_session_sandbox_exec.yml"
+  /v2/agents/sessions/{session_id}/stream:
+    get:
+      $ref: "resources/agents/agents_get_session_stream.yml"
+  /v2/agents/sessions/{session_id}/workspace/download:
+    get:
+      $ref: "resources/agents/agents_get_session_workspace_download.yml"
+  /v2/agents/sessions/{session_id}/workspace/transfers:
+    post:
+      $ref: "resources/agents/agents_create_session_workspace_transfer.yml"
+  /v2/agents/sessions/{session_id}/workspace/transfers/{transfer_id}:
+    get:
+      $ref: "resources/agents/agents_get_session_workspace_transfer.yml"
+  /v2/agents/sessions/{session_id}/workspace/transfers/{transfer_id}/cancel:
+    post:
+      $ref: "resources/agents/agents_cancel_session_workspace_transfer.yml"
+  /v2/agents/sessions/{session_id}/workspace/transfers/{transfer_id}/commit:
+    post:
+      $ref: "resources/agents/agents_commit_session_workspace_transfer.yml"
+  /v2/agents/sessions/{session_id}/workspace/transfers/{transfer_id}/part-upload-urls:
+    post:
+      $ref: "resources/agents/agents_create_session_workspace_part_upload_urls.yml"
+  /v2/agents/sessions/{session_id}/workspace/upload:
+    post:
+      $ref: "resources/agents/agents_create_session_workspace_upload.yml"
 
   /v2/apps:
     get:

--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -60,6 +60,15 @@ tags:
       The Add-Ons API allows you to manage these resources, including creating, listing, and retrieving
       details about specific add-on resources.
 
+  - name: Agents
+    description: |-
+      Hosted Agents sessions API (`/v2/agents/sessions`). Sessions represent a
+      managed agent + sandbox pair. Product provenance is exposed via
+      `session.origin` (`direct` | `simulation` | `evaluation`). ListSessions
+      omits simulation and evaluation sessions server-side so customer surfaces
+      stay free of product-owned internal runs; GetSession by session_id still
+      returns those sessions for the owning product workflow.
+
   - name: Apps
     description: |-
       App Platform is a Platform-as-a-Service (PaaS) offering from DigitalOcean that allows
@@ -790,6 +799,62 @@ paths:
   /v2/add-ons/saas/{resource_uuid}/plan:
     patch:
       $ref: "resources/addons/addons_update_plan.yml"
+
+  /v2/agents/sessions:
+    get:
+      $ref: "resources/agents/agents_list_sessions.yml"
+    post:
+      $ref: "resources/agents/agents_create_session.yml"
+  /v2/agents/sessions/policy/validate:
+    post:
+      $ref: "resources/agents/agents_validate_session_policy.yml"
+  /v2/agents/sessions/sandbox/sizes:
+    get:
+      $ref: "resources/agents/agents_list_session_sandbox_sizes.yml"
+  /v2/agents/sessions/{session_id}:
+    delete:
+      $ref: "resources/agents/agents_delete_session.yml"
+    get:
+      $ref: "resources/agents/agents_get_session.yml"
+  /v2/agents/sessions/{session_id}/hitl/{request_id}:
+    post:
+      $ref: "resources/agents/agents_post_session_hitl.yml"
+  /v2/agents/sessions/{session_id}/input:
+    post:
+      $ref: "resources/agents/agents_create_session_input.yml"
+  /v2/agents/sessions/{session_id}/pause:
+    post:
+      $ref: "resources/agents/agents_post_session_pause.yml"
+  /v2/agents/sessions/{session_id}/resume:
+    post:
+      $ref: "resources/agents/agents_post_session_resume.yml"
+  /v2/agents/sessions/{session_id}/sandbox/exec:
+    post:
+      $ref: "resources/agents/agents_post_session_sandbox_exec.yml"
+  /v2/agents/sessions/{session_id}/stream:
+    get:
+      $ref: "resources/agents/agents_get_session_stream.yml"
+  /v2/agents/sessions/{session_id}/workspace/download:
+    get:
+      $ref: "resources/agents/agents_get_session_workspace_download.yml"
+  /v2/agents/sessions/{session_id}/workspace/transfers:
+    post:
+      $ref: "resources/agents/agents_create_session_workspace_transfer.yml"
+  /v2/agents/sessions/{session_id}/workspace/transfers/{transfer_id}:
+    get:
+      $ref: "resources/agents/agents_get_session_workspace_transfer.yml"
+  /v2/agents/sessions/{session_id}/workspace/transfers/{transfer_id}/cancel:
+    post:
+      $ref: "resources/agents/agents_cancel_session_workspace_transfer.yml"
+  /v2/agents/sessions/{session_id}/workspace/transfers/{transfer_id}/commit:
+    post:
+      $ref: "resources/agents/agents_commit_session_workspace_transfer.yml"
+  /v2/agents/sessions/{session_id}/workspace/transfers/{transfer_id}/part-upload-urls:
+    post:
+      $ref: "resources/agents/agents_create_session_workspace_part_upload_urls.yml"
+  /v2/agents/sessions/{session_id}/workspace/upload:
+    post:
+      $ref: "resources/agents/agents_create_session_workspace_upload.yml"
 
   /v2/apps:
     get:

--- a/specification/DigitalOcean-public.v2.yaml
+++ b/specification/DigitalOcean-public.v2.yaml
@@ -62,12 +62,16 @@ tags:
 
   - name: Agents
     description: |-
-      Hosted Agents sessions API (`/v2/agents/sessions`). Sessions represent a
-      managed agent + sandbox pair. Product provenance is exposed via
-      `session.origin` (`direct` | `simulation` | `evaluation`). ListSessions
+      Hosted Agents API under `/v2/agents`. Sessions (`/v2/agents/sessions`)
+      represent a managed agent + sandbox pair. Product provenance is exposed
+      via `session.origin` (`direct` | `simulation` | `evaluation`). ListSessions
       omits simulation and evaluation sessions server-side so customer surfaces
       stay free of product-owned internal runs; GetSession by session_id still
       returns those sessions for the owning product workflow.
+
+      Agent Configs (`/v2/agents/configs`) are immutable team-scoped manifests
+      that sessions can be created from. Soft-delete releases the active name
+      while keeping `config_id` resolvable for existing sessions.
 
   - name: Apps
     description: |-
@@ -800,6 +804,19 @@ paths:
     patch:
       $ref: "resources/addons/addons_update_plan.yml"
 
+  /v2/agents/configs:
+    get:
+      $ref: "resources/agents/agents_list_configs.yml"
+    post:
+      $ref: "resources/agents/agents_create_config.yml"
+  /v2/agents/configs/{config_id}:
+    get:
+      $ref: "resources/agents/agents_get_config.yml"
+    delete:
+      $ref: "resources/agents/agents_delete_config.yml"
+  /v2/agents/configs/{config_id}/sessions:
+    get:
+      $ref: "resources/agents/agents_list_config_sessions.yml"
   /v2/agents/sessions:
     get:
       $ref: "resources/agents/agents_list_sessions.yml"

--- a/specification/resources/agents/agents_cancel_session_workspace_transfer.yml
+++ b/specification/resources/agents/agents_cancel_session_workspace_transfer.yml
@@ -1,0 +1,70 @@
+operationId: agents_cancel_session_workspace_transfer
+summary: Cancel a staged workspace transfer.
+description: 'Aborts an in-flight transfer. Idempotent: cancelling an already-terminal transfer returns
+  `aborted: false` with the current status. The request body is optional.'
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+- in: path
+  name: transfer_id
+  required: true
+  description: The workspace transfer identifier.
+  schema:
+    type: string
+    example: tr_example
+  example: tr_example
+requestBody:
+  required: false
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          reason:
+            type: string
+            description: Optional caller-visible audit/debug context.
+            example: example
+responses:
+  '200':
+    description: Cancel processed.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/workspace_transfer_cancelled
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '501':
+    description: Cancel is not supported by the active sandbox driver.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_cancel_session_workspace_transfer.yml
+security:
+- bearer_auth:
+  - agents:create

--- a/specification/resources/agents/agents_commit_session_workspace_transfer.yml
+++ b/specification/resources/agents/agents_commit_session_workspace_transfer.yml
@@ -1,0 +1,86 @@
+operationId: agents_commit_session_workspace_transfer
+summary: Finalize a staged upload.
+description: Upload only. Call once, after all parts have been uploaded. Completes the multipart upload
+  and starts the asynchronous import into the workspace. Responds 202; poll the transfer until `completed`
+  or `failed`.
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+- in: path
+  name: transfer_id
+  required: true
+  description: The workspace transfer identifier.
+  schema:
+    type: string
+    example: tr_example
+  example: tr_example
+requestBody:
+  required: false
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          sha256:
+            type: string
+            description: Optional lowercase hex SHA-256. Must match the value supplied at create when
+              both are set.
+            example: example
+responses:
+  '202':
+    description: Upload committed; import in progress.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/workspace_upload_committed
+  '400':
+    description: Missing transfer_id, sha256 mismatch, or invalid JSON.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '409':
+    description: Transfer is not in a committable state.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '501':
+    description: Staged upload is not supported by the active sandbox driver.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_commit_session_workspace_transfer.yml
+security:
+- bearer_auth:
+  - agents:create

--- a/specification/resources/agents/agents_create_config.yml
+++ b/specification/resources/agents/agents_create_config.yml
@@ -1,7 +1,7 @@
 operationId: agents_create_config
 summary: Create an Agent Config (manifest + secrets in one request).
 description: Accepts name, agents.yaml text, and optional write-only secret values in one request. Responses
-  never echo secret values; GET/create may include credential slot metadata with configured:true. Configs
+  never echo secret values; GET/create may include credential slot metadata (name/source/provider only). Configs
   are immutable after create.
 tags:
 - Agents

--- a/specification/resources/agents/agents_create_config.yml
+++ b/specification/resources/agents/agents_create_config.yml
@@ -1,0 +1,69 @@
+operationId: agents_create_config
+summary: Create an Agent Config (manifest + secrets in one request).
+description: Accepts name, agents.yaml text, and optional write-only secret values in one request. Responses
+  never echo secret values; GET/create may include credential slot metadata with configured:true. Configs
+  are immutable after create.
+tags:
+- Agents
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: models/definitions.yml#/agent_config_create_request
+  description: Unified Agent Config create body. secrets/oauth_assignments are write-only and never returned.
+responses:
+  '201':
+    description: Config created.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/agent_config_response
+  '400':
+    description: Invalid name, JSON wrapper, or agents.yaml manifest.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '409':
+    description: An active config with this name already exists for the team.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '413':
+    description: Request body exceeds 1 MiB.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '415':
+    description: Content-Type is not application/json.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_create_config.yml
+security:
+- bearer_auth:
+  - agents:create

--- a/specification/resources/agents/agents_create_session.yml
+++ b/specification/resources/agents/agents_create_session.yml
@@ -1,0 +1,128 @@
+operationId: agents_create_session
+summary: CreateSession provisions a sandbox and starts the requested agent.
+description: 'Returns once the session row is allocated. The sandbox boot completes asynchronously; clients
+  observe SESSION_STATUS_PROVISIONING → READY via StreamSession.
+
+
+  Two mutually exclusive request forms are selected by Content-Type. Existing YAML callers send a raw
+  customer `agents.yaml` Agent manifest with `application/x-yaml`, `application/yaml`, `text/yaml`, or
+  `text/x-yaml`; this flow is unchanged. Definition-backed callers send the strict `CreateSessionDefinitionRequest`
+  JSON object with `application/json`. Unknown JSON fields, including team identity, are rejected. An
+  omitted revision_id pins the definition''s current immutable revision.
+
+
+  Definition-backed execution requires an exactly matching credential binding set when the selected revision
+  declares logical secrets. Static values are fetched only by their persisted name/region/version and
+  are never returned or persisted. OAuth bindings currently fail closed with 501.
+
+
+  Every successful create atomically persists value-free execution provenance and an allowlisted agent-spec
+  audit snapshot. The team and user identity are taken from the authenticated principal, never the body.
+  `X-Device-UUID` (if present) is persisted on the session row.'
+tags:
+- Agents
+parameters:
+- in: header
+  name: X-Device-UUID
+  required: false
+  description: Optional hardware device id forwarded by doctl. Persisted on the session row for lifecycle
+    attribution. Values over 128 bytes are ignored.
+  schema:
+    type: string
+    example: device-uuid-example
+  example: device-uuid-example
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: models/definitions.yml#/create_session_definition_request
+    application/x-yaml: &id001
+      schema:
+        $ref: models/definitions.yml#/agent_manifest
+    application/yaml: *id001
+    text/yaml: *id001
+    text/x-yaml: *id001
+  description: Either a raw AgentManifest with a YAML Content-Type or CreateSessionDefinitionRequest with
+    application/json. The forms are mutually exclusive by Content-Type.
+responses:
+  '200':
+    description: Session row allocated; sandbox boot continues asynchronously.
+    headers: &id002
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/create_session_response
+  '400':
+    description: Invalid manifest/reference JSON, incompatible or missing binding set, env collision,
+      credential limit violation, or invalid session/origin identifier.
+    headers: *id002
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '403':
+    description: Secrets Manager denied access to a pinned credential.
+    headers: *id002
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '409':
+    description: Team is at the active-session quota, a live session name already exists, or the binding
+      set targets another revision.
+    headers: *id002
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '413':
+    description: JSON reference body exceeds 16 KiB or YAML body exceeds 1 MiB.
+    headers: *id002
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '415':
+    description: Unsupported Content-Type.
+    headers: *id002
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '501':
+    description: The selected binding set contains an OAuth assignment; execution-time OAuth brokering
+      is not available yet.
+    headers: *id002
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '503':
+    description: Secrets Manager is unavailable.
+    headers: *id002
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_create_session.yml
+security:
+- bearer_auth:
+  - agents:create

--- a/specification/resources/agents/agents_create_session_input.yml
+++ b/specification/resources/agents/agents_create_session_input.yml
@@ -1,0 +1,72 @@
+operationId: agents_create_session_input
+summary: SendInput delivers a user chat message into the session.
+description: The agent observes it on its next turn and emits subsequent events via StreamSession. The
+  input is forwarded to the owning microVM's OHR inbound surface, which attributes it to a run and returns
+  the run id.
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: models/definitions.yml#/send_input_request
+responses:
+  '200':
+    description: Input accepted and attributed to a run.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/send_input_response
+  '400':
+    description: Malformed JSON or empty text.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '403':
+    description: Session belongs to another team.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '409':
+    description: Session is not in a state that accepts input (not READY/DETACHED, or has no sandbox).
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_create_session_input.yml
+security:
+- bearer_auth:
+  - agents:create

--- a/specification/resources/agents/agents_create_session_workspace_part_upload_urls.yml
+++ b/specification/resources/agents/agents_create_session_workspace_part_upload_urls.yml
@@ -1,0 +1,91 @@
+operationId: agents_create_session_workspace_part_upload_urls
+summary: Mint presigned PUT URLs for one or more multipart upload parts.
+description: Upload only. Pass one or more 1-based `part_numbers`; the response returns a presigned `upload_url`
+  per part (all sharing one `expires_at`), so a client can drive parallel part uploads without a round
+  trip per part. PUT each part's bytes directly to its URL (bypassing harness-api). If URLs expire before
+  the PUT, request them again.
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+- in: path
+  name: transfer_id
+  required: true
+  description: The workspace transfer identifier.
+  schema:
+    type: string
+    example: tr_example
+  example: tr_example
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        required:
+        - part_numbers
+        properties:
+          part_numbers:
+            type: array
+            items:
+              type: integer
+              format: int32
+              example: 1
+            description: 1-based part indices to presign (single or batched).
+responses:
+  '200':
+    description: Presigned PUT URLs for the requested parts.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/workspace_part_upload_urls
+  '400':
+    description: Missing transfer_id, empty part_numbers, or a part number < 1, or invalid JSON.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '409':
+    description: Transfer is not in a state that accepts part uploads.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '501':
+    description: Staged upload is not supported by the active sandbox driver.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_create_session_workspace_part_upload_urls.yml
+security:
+- bearer_auth:
+  - agents:create

--- a/specification/resources/agents/agents_create_session_workspace_transfer.yml
+++ b/specification/resources/agents/agents_create_session_workspace_transfer.yml
@@ -1,0 +1,147 @@
+operationId: agents_create_session_workspace_transfer
+summary: Start a staged (large-file) workspace transfer.
+description: 'Creates an asynchronous, object-storage-backed transfer for payloads larger than the streaming
+  path supports (> ~50 MiB). Bulk bytes never traverse harness-api: the client PUTs/GETs presigned DO
+  Spaces URLs directly.
+
+
+  Set `direction` to `upload` or `download`.
+
+  - `upload`: responds 201 with `transfer_id` + `part_size`; the client then requests per-part presigned
+  PUT URLs, uploads them to Spaces, and calls `commit`.
+
+  - `download`: responds 202 with `transfer_id`; the client polls GET until `completed` and then fetches
+  `download_url` from Spaces.
+
+
+  Upload and cancel currently return 501 until the sandbox backend RPCs ship; download is live.'
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        required:
+        - direction
+        - path
+        properties:
+          direction:
+            type: string
+            enum:
+            - upload
+            - download
+            description: Transfer direction.
+            example: upload
+          path:
+            type: string
+            description: Workspace-relative path. Destination for upload, source for download. Paths that
+              escape the workspace root are rejected.
+            example: example
+          is_archive:
+            type: boolean
+            description: Upload only. When true, the payload is a tar the guest extracts at `path`.
+            example: true
+          as_archive:
+            type: boolean
+            description: Download only. When true, `path` is exported as a tar stream.
+            example: true
+          size_bytes:
+            type: string
+            format: int64
+            description: Optional total payload size. Validated against the maximum staged object size
+              (50 GiB); a larger value returns 413.
+            example: example
+          sha256:
+            type: string
+            description: Optional lowercase hex SHA-256 of the full payload. If set on an upload, it must
+              match on commit.
+            example: example
+responses:
+  '201':
+    description: Upload transfer created; proceed to request part upload URLs.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/workspace_transfer_created
+  '202':
+    description: Download transfer accepted; poll the transfer until completed.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/workspace_transfer_created
+  '400':
+    description: Missing/invalid direction or path, or invalid JSON.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '403':
+    description: Path resolves outside the workspace, or the session belongs to another team.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '409':
+    description: Session has no sandbox, or the sandbox is not ready.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '413':
+    description: Declared size exceeds the maximum staged object size.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '501':
+    description: Staged transfer (or this direction) is not supported by the active sandbox driver.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '502':
+    description: Upstream sandbox transfer coordination failed.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_create_session_workspace_transfer.yml
+security:
+- bearer_auth:
+  - agents:create

--- a/specification/resources/agents/agents_create_session_workspace_upload.yml
+++ b/specification/resources/agents/agents_create_session_workspace_upload.yml
@@ -1,0 +1,131 @@
+operationId: agents_create_session_workspace_upload
+summary: Upload a file or tar archive into the session's sandbox workspace.
+description: Streams the raw request body to a path inside the sandbox workspace. Concurrent transfers
+  (upload + download) are capped server-side; over the cap the request blocks and may return 503. The
+  optional `X-Content-Sha256` request header carries a hex digest the guest verifies after the full payload
+  is written.
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+- in: query
+  name: path
+  required: true
+  description: Destination path inside the sandbox workspace. Relative paths resolve under the workspace
+    root; paths that escape the workspace are rejected. Required.
+  schema:
+    type: string
+    example: example
+  example: example
+- in: query
+  name: is_archive
+  required: false
+  description: If true, the body is a tar stream that the guest extracts under `path`. Defaults to false
+    (single file).
+  schema:
+    type: boolean
+    example: true
+  example: true
+- in: header
+  name: X-Content-Sha256
+  required: false
+  description: Optional hex SHA-256 of the full payload. The guest verifies it after writing; a mismatch
+    returns 400.
+  schema:
+    type: string
+    example: example
+  example: example
+requestBody:
+  required: true
+  content:
+    application/octet-stream:
+      schema:
+        type: string
+        format: binary
+        example: example
+  description: Raw file bytes (or tar stream when is_archive=true). Capped at 500 MiB.
+responses:
+  '200':
+    description: Upload committed.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/workspace_upload_response
+  '400':
+    description: Missing path, invalid query parameter, invalid path, or SHA-256 mismatch.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '403':
+    description: Path resolves outside the workspace, or the session belongs to another team.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '409':
+    description: Session has no sandbox, or the sandbox is not ready.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '413':
+    description: Payload exceeds the maximum allowed size.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '501':
+    description: Workspace file transfer is not supported by the active sandbox driver.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '502':
+    description: Upstream sandbox transfer failed.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '503':
+    description: Workspace transfer capacity exhausted; retry later.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_create_session_workspace_upload.yml
+security:
+- bearer_auth:
+  - agents:create

--- a/specification/resources/agents/agents_delete_config.yml
+++ b/specification/resources/agents/agents_delete_config.yml
@@ -1,0 +1,54 @@
+operationId: agents_delete_config
+summary: Soft-delete an Agent Config.
+description: Releases the active team-scoped name; the config row is retained (soft delete), so sessions
+  created from it keep a resolvable config_id.
+tags:
+- Agents
+parameters:
+- in: path
+  name: config_id
+  required: true
+  description: The Agent Config UUID.
+  schema:
+    type: string
+    format: uuid
+    example: 019fb39c-14d9-7080-933e-b9b90e25acda
+  example: 019fb39c-14d9-7080-933e-b9b90e25acda
+responses:
+  '204':
+    description: Config soft-deleted; no response body.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+  '400':
+    description: config_id is not a UUID.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_delete_config.yml
+security:
+- bearer_auth:
+  - agents:delete

--- a/specification/resources/agents/agents_delete_session.yml
+++ b/specification/resources/agents/agents_delete_session.yml
@@ -1,0 +1,61 @@
+operationId: agents_delete_session
+summary: DestroySession tears down the sandbox and marks the session DESTROYED.
+description: Persistent workspace contents are retained per tenant policy. Returns 204 No Content on success.
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+- in: header
+  name: X-Device-UUID
+  required: false
+  description: Optional hardware device id forwarded by doctl. Recorded on the session row as the device
+    that performed the destroy.
+  schema:
+    type: string
+    example: device-uuid-example
+  example: device-uuid-example
+responses:
+  '204':
+    description: Session destroyed; no response body.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '403':
+    description: Session belongs to another team.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_delete_session.yml
+security:
+- bearer_auth:
+  - agents:delete

--- a/specification/resources/agents/agents_get_config.yml
+++ b/specification/resources/agents/agents_get_config.yml
@@ -1,0 +1,52 @@
+operationId: agents_get_config
+summary: Get an active Agent Config and its manifest.
+description: Returns one team-scoped Agent Config including the sanitized manifest and redacted credential
+  slot metadata. Secret values are never returned.
+tags:
+- Agents
+parameters:
+- in: path
+  name: config_id
+  required: true
+  description: The Agent Config UUID.
+  schema:
+    type: string
+    format: uuid
+    example: 019fb39c-14d9-7080-933e-b9b90e25acda
+  example: 019fb39c-14d9-7080-933e-b9b90e25acda
+responses:
+  '200':
+    description: The team-scoped config.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/agent_config_response
+  '400':
+    description: config_id is not a UUID.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_get_config.yml
+security:
+- bearer_auth:
+  - agents:read

--- a/specification/resources/agents/agents_get_session.yml
+++ b/specification/resources/agents/agents_get_session.yml
@@ -1,0 +1,50 @@
+operationId: agents_get_session
+summary: GetSession returns the current snapshot of a session.
+description: GetSession returns the current snapshot of a session.
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+responses:
+  '200':
+    description: A successful response.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/get_session_response
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '403':
+    description: Session belongs to another team.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_get_session.yml
+security:
+- bearer_auth:
+  - agents:read

--- a/specification/resources/agents/agents_get_session_stream.yml
+++ b/specification/resources/agents/agents_get_session_stream.yml
@@ -1,0 +1,89 @@
+operationId: agents_get_session_stream
+summary: StreamSession is the server-streaming event feed.
+description: 'Returns a `text/event-stream` (SSE) feed that drives the interactive TUI / Web Console.
+  Supports both live attach and historical replay (replay_from cursor). Survives client disconnect — sessions
+  live server-side and reattach is supported from any machine.
+
+
+  Each SSE message is framed as:
+
+  ```
+
+  id: <event_id>
+
+  event: <event type, e.g. run.started>
+
+  data: <JSON StreamEvent>
+
+
+  ```
+
+  A leading comment line (`: connected to <session_id>`) is sent on open. Errors that occur before the
+  stream starts are returned as a JSON error envelope; once the event-stream has started, failures simply
+  close the connection.'
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+- in: query
+  name: replay_from
+  required: false
+  description: Optional replay cursor. Empty means "live from now". A previous event_id means "replay
+    events strictly after that id, then go live".
+  schema:
+    type: string
+    example: example
+  example: example
+- in: query
+  name: replay_only
+  required: false
+  description: If true, only replay; close the stream when caught up. Otherwise the stream stays open
+    for live events. `doctl agents logs` sets this with an empty replay_from to read full history.
+  schema:
+    type: boolean
+    example: true
+  example: true
+responses:
+  '200':
+    description: An SSE stream of session events (text/event-stream). The schema describes the JSON payload
+      carried in each event's `data:` field.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/stream_event
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '403':
+    description: Session belongs to another team.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_get_session_stream.yml
+security:
+- bearer_auth:
+  - agents:read

--- a/specification/resources/agents/agents_get_session_workspace_download.yml
+++ b/specification/resources/agents/agents_get_session_workspace_download.yml
@@ -1,0 +1,128 @@
+operationId: agents_get_session_workspace_download
+summary: Download a file or tar archive from the session's sandbox workspace.
+description: 'Streams the workspace payload back as `application/octet-stream` using chunked transfer
+  encoding, followed by a fixed integrity footer.
+
+
+  Response body layout: `<payload>` + `<footer>`, where the footer is exactly 73 bytes: `DOWSSHA1` (8
+  bytes) + 64-char lowercase SHA-256 hex + `\n`. The client MUST strip the trailing 73 bytes before saving,
+  verify SHA-256(payload) equals the footer digest, and treat a tail that does not match this shape (magic
+  + 64 hex + newline) as a failed (truncated/corrupt) transfer.
+
+
+  Other metadata:
+
+  - `X-Workspace-Is-Archive: true` when the payload is a tar archive.
+
+  - `X-Workspace-Size-Bytes` is a progress hint (not Content-Length) and excludes the footer.
+
+  - The `X-Content-Sha256` trailer also carries the digest but is best-effort: edge proxies may strip
+  HTTP trailers, so the body footer is authoritative.
+
+
+  Concurrent transfers (upload + download) are capped server-side; over the cap the request blocks and
+  may return 503.'
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+- in: query
+  name: path
+  required: true
+  description: Source path inside the sandbox workspace. Relative paths resolve under the workspace root;
+    paths that escape the workspace are rejected. Required.
+  schema:
+    type: string
+    example: example
+  example: example
+- in: query
+  name: as_archive
+  required: false
+  description: If true, the guest returns a tar stream of `path` (e.g. for a directory). Defaults to false
+    (single file).
+  schema:
+    type: boolean
+    example: true
+  example: true
+responses:
+  '200':
+    description: Streaming workspace payload (octet-stream) followed by a fixed 73-byte integrity footer
+      (`DOWSSHA1` + 64-char sha256 hex + newline). The digest is also delivered best-effort in the X-Content-Sha256
+      trailer.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          type: string
+          format: binary
+          example: example
+  '400':
+    description: Missing path, invalid query parameter, or invalid path.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '403':
+    description: Path resolves outside the workspace, or the session belongs to another team.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '409':
+    description: Session has no sandbox, or the sandbox is not ready.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '501':
+    description: Workspace file transfer is not supported by the active sandbox driver.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '502':
+    description: Upstream sandbox transfer failed.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '503':
+    description: Workspace transfer capacity exhausted; retry later.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_get_session_workspace_download.yml
+security:
+- bearer_auth:
+  - agents:read

--- a/specification/resources/agents/agents_get_session_workspace_transfer.yml
+++ b/specification/resources/agents/agents_get_session_workspace_transfer.yml
@@ -1,0 +1,67 @@
+operationId: agents_get_session_workspace_transfer
+summary: Get the status of a staged workspace transfer.
+description: Returns the current transfer state. For a completed download the response also carries a
+  freshly minted presigned GET `download_url` (its TTL starts at poll time) and the payload `sha256` for
+  client-side verification.
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+- in: path
+  name: transfer_id
+  required: true
+  description: The workspace transfer identifier.
+  schema:
+    type: string
+    example: tr_example
+  example: tr_example
+responses:
+  '200':
+    description: Current transfer status.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/workspace_transfer_status
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '403':
+    description: The session belongs to another team.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '501':
+    description: Staged transfer is not supported by the active sandbox driver.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_get_session_workspace_transfer.yml
+security:
+- bearer_auth:
+  - agents:read

--- a/specification/resources/agents/agents_list_config_sessions.yml
+++ b/specification/resources/agents/agents_list_config_sessions.yml
@@ -1,0 +1,93 @@
+operationId: agents_list_config_sessions
+summary: List the sessions created from one Agent Config.
+description: Enumerates the caller's team sessions whose session was created from this durable Agent Config.
+  Keyset-paginated on an opaque cursor, newest first, same shape and status semantics as GET /v2/agents/sessions.
+tags:
+- Agents
+parameters:
+- in: path
+  name: config_id
+  required: true
+  description: The Agent Config UUID.
+  schema:
+    type: string
+    format: uuid
+    example: 019fb39c-14d9-7080-933e-b9b90e25acda
+  example: 019fb39c-14d9-7080-933e-b9b90e25acda
+- in: query
+  name: page_size
+  required: false
+  description: Page size. Defaults to 50 when omitted or non-positive; values above 200 are clamped to
+    200.
+  schema:
+    type: integer
+    format: int32
+    minimum: 1
+    maximum: 200
+    default: 50
+    example: 50
+  example: 50
+- in: query
+  name: page_token
+  required: false
+  description: Opaque keyset cursor returned by the previous page. Empty starts from the beginning.
+  schema:
+    type: string
+    example: ''
+  example: ''
+- in: query
+  name: status
+  required: false
+  description: Optional filter on session status. Empty / SESSION_STATUS_UNSPECIFIED still hides destroyed
+    and failed sessions by default; SESSION_STATUS_ALL opts out and returns every session regardless of
+    status.
+  schema:
+    type: string
+    enum:
+    - SESSION_STATUS_UNSPECIFIED
+    - SESSION_STATUS_PROVISIONING
+    - SESSION_STATUS_READY
+    - SESSION_STATUS_DETACHED
+    - SESSION_STATUS_DESTROYING
+    - SESSION_STATUS_DESTROYED
+    - SESSION_STATUS_FAILED
+    - SESSION_STATUS_PAUSED
+    - SESSION_STATUS_ALL
+    example: SESSION_STATUS_READY
+  example: SESSION_STATUS_READY
+responses:
+  '200':
+    description: A page of sessions created from the config.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/list_sessions_response
+  '400':
+    description: Invalid pagination input or config_id.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_list_config_sessions.yml
+security:
+- bearer_auth:
+  - agents:read

--- a/specification/resources/agents/agents_list_configs.yml
+++ b/specification/resources/agents/agents_list_configs.yml
@@ -1,0 +1,61 @@
+operationId: agents_list_configs
+summary: List active Agent Configs for the caller's team.
+description: Returns lightweight team-scoped config metadata without loading or returning manifest JSON.
+  Soft-deleted configs are excluded.
+tags:
+- Agents
+parameters:
+- in: query
+  name: page_size
+  required: false
+  description: Page size. Defaults to 50 when omitted. Values above 200 are rejected.
+  schema:
+    type: integer
+    format: int32
+    minimum: 1
+    maximum: 200
+    default: 50
+    example: 50
+  example: 50
+- in: query
+  name: page_token
+  required: false
+  description: Opaque keyset cursor returned by the previous page.
+  schema:
+    type: string
+    example: ''
+  example: ''
+responses:
+  '200':
+    description: A page of active Agent Configs.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/list_agent_configs_response
+  '400':
+    description: Invalid pagination input.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_list_configs.yml
+security:
+- bearer_auth:
+  - agents:read

--- a/specification/resources/agents/agents_list_session_sandbox_sizes.yml
+++ b/specification/resources/agents/agents_list_session_sandbox_sizes.yml
@@ -1,0 +1,37 @@
+operationId: agents_list_session_sandbox_sizes
+summary: ListSandboxSizes returns the customer-selectable sandbox (microVM) size catalog.
+description: Read-only catalog the UI (and other clients) render as the size picker, instead of hardcoding
+  the list. The set is the single source of truth shared with create-time validation and the default-size
+  fallback, so every `slug` returned here is accepted by CreateSession as spec.sandbox.sizeSlug. Sizes
+  are returned smallest-to-largest. Static and safe to cache; independent of team/session; no pagination.
+tags:
+- Agents
+responses:
+  '200':
+    description: The supported sandbox sizes.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/sandbox_sizes_response
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_list_session_sandbox_sizes.yml
+security:
+- bearer_auth:
+  - agents:read

--- a/specification/resources/agents/agents_list_sessions.yml
+++ b/specification/resources/agents/agents_list_sessions.yml
@@ -1,0 +1,91 @@
+operationId: agents_list_sessions
+summary: ListSessions enumerates sessions for the caller's tenant.
+description: Keyset-paginated on an opaque cursor. Results are scoped to the authenticated team. Simulation
+  and evaluation sessions are omitted from the list so customer surfaces (doctl, Console, pydo) stay free
+  of product-owned internal runs; GetSession by session_id still returns those sessions for the owning
+  product workflow.
+tags:
+- Agents
+parameters:
+- in: query
+  name: page_size
+  required: false
+  description: Page size. Defaults to 50 when omitted or non-positive.
+  schema:
+    type: integer
+    format: int32
+    example: 50
+  example: 50
+- in: query
+  name: page_token
+  required: false
+  description: Optional pagination cursor (opaque). Empty starts from the beginning.
+  schema:
+    type: string
+    example: ''
+  example: ''
+- in: query
+  name: status
+  required: false
+  description: Optional filter on session status. Empty / SESSION_STATUS_UNSPECIFIED means no filter (return
+    sessions in any state).
+  schema:
+    type: string
+    enum:
+    - SESSION_STATUS_UNSPECIFIED
+    - SESSION_STATUS_PROVISIONING
+    - SESSION_STATUS_READY
+    - SESSION_STATUS_DETACHED
+    - SESSION_STATUS_DESTROYING
+    - SESSION_STATUS_DESTROYED
+    - SESSION_STATUS_FAILED
+    example: SESSION_STATUS_UNSPECIFIED
+  example: SESSION_STATUS_UNSPECIFIED
+- in: query
+  name: name
+  required: false
+  description: Optional exact-name filter (case-insensitive). Returns the single live (non-terminal) session
+    that currently holds this name for the caller's team, or an empty list if none does. Matches the live
+    holder only, so historical terminal rows and reused names never make it ambiguous (per-team live-name
+    uniqueness bounds it to at most one). This is how clients (doctl / Console) resolve a session name
+    to its id; the {session_id} path stays UUID-only.
+  schema:
+    type: string
+    example: demo-agent
+  example: demo-agent
+responses:
+  '200':
+    description: A successful response.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/list_sessions_response
+  '400':
+    description: Invalid page_token.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_list_sessions.yml
+security:
+- bearer_auth:
+  - agents:read

--- a/specification/resources/agents/agents_post_session_hitl.yml
+++ b/specification/resources/agents/agents_post_session_hitl.yml
@@ -1,0 +1,84 @@
+operationId: agents_post_session_hitl
+summary: ResolveHITL records the user's decision on a pending HITL request.
+description: harness-api forwards the decision into the owning microVM via the inbound runtime.v1.OHR.ResolveHITL
+  RPC (dialed through the guest-fronting proxy), which unblocks the gated agent action. The resolution
+  is also echoed to all attached clients as a HITLResolved event on StreamSession. Returns 204 No Content
+  on success.
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+- in: path
+  name: request_id
+  required: true
+  description: The HITL request identifier.
+  schema:
+    type: string
+    example: hitl_example
+  example: hitl_example
+- in: header
+  name: X-Device-UUID
+  required: false
+  description: Optional hardware device id forwarded by doctl. Recorded on the resulting HITL decision.
+  schema:
+    type: string
+    example: device-uuid-example
+  example: device-uuid-example
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: models/definitions.yml#/resolve_hitl_request
+responses:
+  '204':
+    description: Decision recorded; no response body.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+  '400':
+    description: Malformed JSON or missing outcome.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '403':
+    description: Session belongs to another team.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_post_session_hitl.yml
+security:
+- bearer_auth:
+  - agents:create

--- a/specification/resources/agents/agents_post_session_pause.yml
+++ b/specification/resources/agents/agents_post_session_pause.yml
@@ -1,0 +1,76 @@
+operationId: agents_post_session_pause
+summary: PauseSession freezes the session's microVM sandbox.
+description: Supported on microvm-substrate sessions only; dewdrop/docker sessions return 501 Not Implemented.
+  Paused sessions count against quota. Clients learn state via GetSession/ListSessions; no live session.updated
+  event is emitted.
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+- in: header
+  name: X-Device-UUID
+  required: false
+  description: Optional hardware device id forwarded by doctl. Recorded for audit.
+  schema:
+    type: string
+    example: device-uuid-example
+  example: device-uuid-example
+responses:
+  '204':
+    description: Session paused.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '403':
+    description: Session belongs to another team.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '409':
+    description: Session is not in a pauseable state (must be READY or DETACHED).
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '501':
+    description: Pause is not supported for this session's substrate (docker/dewdrop).
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_post_session_pause.yml
+security:
+- bearer_auth:
+  - agents:create

--- a/specification/resources/agents/agents_post_session_resume.yml
+++ b/specification/resources/agents/agents_post_session_resume.yml
@@ -1,0 +1,76 @@
+operationId: agents_post_session_resume
+summary: ResumeSession explicitly thaws a PAUSED session's microVM sandbox.
+description: Only valid for microvm-substrate sessions; dewdrop/docker sessions return 501 Not Implemented.
+  Implicit resume also occurs when SendInput or ResolveHITL is called on a paused session. Returns synchronously
+  once the sandbox is ready.
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+- in: header
+  name: X-Device-UUID
+  required: false
+  description: Optional hardware device id forwarded by doctl. Recorded for audit.
+  schema:
+    type: string
+    example: device-uuid-example
+  example: device-uuid-example
+responses:
+  '204':
+    description: Session resumed.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '403':
+    description: Session belongs to another team.
+    headers: &id001
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '409':
+    description: Session is not PAUSED.
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '501':
+    description: Resume is not supported for this session's substrate (docker/dewdrop).
+    headers: *id001
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_post_session_resume.yml
+security:
+- bearer_auth:
+  - agents:create

--- a/specification/resources/agents/agents_post_session_sandbox_exec.yml
+++ b/specification/resources/agents/agents_post_session_sandbox_exec.yml
@@ -1,0 +1,58 @@
+operationId: agents_post_session_sandbox_exec
+summary: ExecInSandbox runs a one-shot command inside the session's sandbox.
+description: 'Wire-only at Private Beta: the route is mounted but always returns 501 Not Implemented.
+  doctl `agents sandbox exec` ships at Framework Private Beta.'
+tags:
+- Agents
+parameters:
+- in: path
+  name: session_id
+  required: true
+  description: The session UUID.
+  schema:
+    type: string
+    example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+responses:
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '501':
+    description: ExecInSandbox is wire-only at Private Beta.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+  '200':
+    description: Successful response.
+    headers:
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          type: object
+          additionalProperties: true
+x-codeSamples:
+- $ref: examples/curl/agents_post_session_sandbox_exec.yml
+security:
+- bearer_auth:
+  - agents:create

--- a/specification/resources/agents/agents_validate_session_policy.yml
+++ b/specification/resources/agents/agents_validate_session_policy.yml
@@ -1,0 +1,67 @@
+operationId: agents_validate_session_policy
+summary: ValidatePolicy checks a manifest's tool-permission policy against the agent's capabilities without
+  creating a session.
+description: 'Stateless preflight: parses the same `agents.yaml` Agent manifest as CreateSession and runs
+  the identical resolve + validate pipeline against the capability descriptor stamped on the selected
+  template''s image (resolved per-request via the sandbox, not a separate registry). Returns per-rule
+  verdicts. Nothing is provisioned or persisted.
+
+
+  Each rule is validated against the descriptor for the (agent, version) the template resolves to and
+  gets a verdict: `exact`, `degraded`, `unsupported`, or `unverified`. `ok` is false when any strict rule
+  is unsupported or unverified — i.e. CreateSession would reject the policy for that agent. An empty `spec.permissions`
+  returns `ok: true` with no verdicts. Because it shares the create path''s descriptor lookup, the verdicts
+  match what CreateSession would compute.'
+tags:
+- Agents
+requestBody:
+  required: true
+  content:
+    application/x-yaml:
+      schema: &id001
+        $ref: models/definitions.yml#/agent_manifest
+    application/yaml:
+      schema: *id001
+    text/yaml:
+      schema: *id001
+    text/x-yaml:
+      schema: *id001
+  description: The same customer agents.yaml Agent manifest you would submit to CreateSession; only spec.sandbox.template
+    / spec.runtime.adapter (to resolve the agent) and spec.permissions are used.
+responses:
+  '200':
+    description: 'Per-rule verdicts for the agent the manifest resolves to. A 200 with `ok: false` still
+      means the policy would be rejected at CreateSession.'
+    headers: &id002
+      ratelimit-limit:
+        $ref: ../../shared/headers.yml#/ratelimit-limit
+      ratelimit-remaining:
+        $ref: ../../shared/headers.yml#/ratelimit-remaining
+      ratelimit-reset:
+        $ref: ../../shared/headers.yml#/ratelimit-reset
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/validation_result
+  '400':
+    description: Malformed manifest or invalid spec.permissions.
+    headers: *id002
+    content:
+      application/json:
+        schema:
+          $ref: models/definitions.yml#/error
+  '401':
+    $ref: ../../shared/responses/unauthorized.yml
+  '500':
+    $ref: ../../shared/responses/server_error.yml
+  '404':
+    $ref: ../../shared/responses/not_found.yml
+  '429':
+    $ref: ../../shared/responses/too_many_requests.yml
+  default:
+    $ref: ../../shared/responses/unexpected_error.yml
+x-codeSamples:
+- $ref: examples/curl/agents_validate_session_policy.yml
+security:
+- bearer_auth:
+  - agents:create

--- a/specification/resources/agents/examples/curl/agents_cancel_session_workspace_transfer.yml
+++ b/specification/resources/agents/examples/curl/agents_cancel_session_workspace_transfer.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X POST \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}/workspace/transfers/{transfer_id}/cancel\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_commit_session_workspace_transfer.yml
+++ b/specification/resources/agents/examples/curl/agents_commit_session_workspace_transfer.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X POST \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}/workspace/transfers/{transfer_id}/commit\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_create_config.yml
+++ b/specification/resources/agents/examples/curl/agents_create_config.yml
@@ -1,0 +1,5 @@
+lang: bash
+source: "curl -X POST \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  -d '{\"name\":\"support-agent\",\"manifest_yaml\":\"apiVersion: agents.digitalocean.com/v1alpha1\\nkind:\
+  \ Agent\\nspec:\\n  runtime:\\n    adapter: opencode\\n\"}' \\\n  \"https://api.digitalocean.com/v2/agents/configs\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_create_session.yml
+++ b/specification/resources/agents/examples/curl/agents_create_session.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X POST \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_create_session_input.yml
+++ b/specification/resources/agents/examples/curl/agents_create_session_input.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X POST \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}/input\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_create_session_workspace_part_upload_urls.yml
+++ b/specification/resources/agents/examples/curl/agents_create_session_workspace_part_upload_urls.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X POST \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}/workspace/transfers/{transfer_id}/part-upload-urls\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_create_session_workspace_transfer.yml
+++ b/specification/resources/agents/examples/curl/agents_create_session_workspace_transfer.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X POST \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}/workspace/transfers\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_create_session_workspace_upload.yml
+++ b/specification/resources/agents/examples/curl/agents_create_session_workspace_upload.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X POST \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}/workspace/upload\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_delete_config.yml
+++ b/specification/resources/agents/examples/curl/agents_delete_config.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X DELETE \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/configs/019fb39c-14d9-7080-933e-b9b90e25acda\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_delete_session.yml
+++ b/specification/resources/agents/examples/curl/agents_delete_session.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X DELETE \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\"\
+  \ \\\n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_get_config.yml
+++ b/specification/resources/agents/examples/curl/agents_get_config.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X GET \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/configs/019fb39c-14d9-7080-933e-b9b90e25acda\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_get_session.yml
+++ b/specification/resources/agents/examples/curl/agents_get_session.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X GET \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_get_session_stream.yml
+++ b/specification/resources/agents/examples/curl/agents_get_session_stream.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X GET \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}/stream\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_get_session_workspace_download.yml
+++ b/specification/resources/agents/examples/curl/agents_get_session_workspace_download.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X GET \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}/workspace/download\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_get_session_workspace_transfer.yml
+++ b/specification/resources/agents/examples/curl/agents_get_session_workspace_transfer.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X GET \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}/workspace/transfers/{transfer_id}\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_list_config_sessions.yml
+++ b/specification/resources/agents/examples/curl/agents_list_config_sessions.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X GET \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/configs/019fb39c-14d9-7080-933e-b9b90e25acda/sessions\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_list_configs.yml
+++ b/specification/resources/agents/examples/curl/agents_list_configs.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X GET \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/configs\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_list_session_sandbox_sizes.yml
+++ b/specification/resources/agents/examples/curl/agents_list_session_sandbox_sizes.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X GET \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/sandbox/sizes\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_list_sessions.yml
+++ b/specification/resources/agents/examples/curl/agents_list_sessions.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X GET \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_post_session_hitl.yml
+++ b/specification/resources/agents/examples/curl/agents_post_session_hitl.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X POST \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}/hitl/{request_id}\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_post_session_pause.yml
+++ b/specification/resources/agents/examples/curl/agents_post_session_pause.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X POST \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}/pause\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_post_session_resume.yml
+++ b/specification/resources/agents/examples/curl/agents_post_session_resume.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X POST \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}/resume\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_post_session_sandbox_exec.yml
+++ b/specification/resources/agents/examples/curl/agents_post_session_sandbox_exec.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X POST \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/{session_id}/sandbox/exec\""
+label: cURL

--- a/specification/resources/agents/examples/curl/agents_validate_session_policy.yml
+++ b/specification/resources/agents/examples/curl/agents_validate_session_policy.yml
@@ -1,0 +1,4 @@
+lang: bash
+source: "curl -X POST \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $DIGITALOCEAN_TOKEN\" \\\
+  \n  \"https://api.digitalocean.com/v2/agents/sessions/policy/validate\""
+label: cURL

--- a/specification/resources/agents/models/definitions.yml
+++ b/specification/resources/agents/models/definitions.yml
@@ -1,0 +1,1076 @@
+agent_kind:
+  type: string
+  enum:
+  - AGENT_KIND_UNSPECIFIED
+  - AGENT_KIND_CLAUDE_CODE
+  - AGENT_KIND_OPENCODE
+  - AGENT_KIND_CODEX_CLI
+  - AGENT_KIND_CURSOR_CLI
+  - AGENT_KIND_NONE
+  - AGENT_KIND_CUSTOM
+  default: AGENT_KIND_UNSPECIFIED
+  description: AgentKind identifies what runs inside the session sandbox. CreateSession accepts CLAUDE_CODE,
+    OPENCODE, and CODEX_CLI (the supported set is overridable via HARNESS_SUPPORTED_AGENT_KINDS); other
+    values are rejected with 400.
+  example: AGENT_KIND_UNSPECIFIED
+agent_manifest:
+  type: object
+  description: 'Customer-authored agents.yaml Agent manifest (see internal/agentspec and contracts/agent.v1alpha1.schema.json
+    — the authoritative published schema), sent as the CreateSession request body with a YAML Content-Type.
+    Untrusted input: every value is a request that is validated and clamped server-side. Decoding is strict:
+    unknown or misspelled fields are rejected with HTTP 400.'
+  required:
+  - apiVersion
+  - kind
+  - spec
+  properties:
+    apiVersion:
+      type: string
+      description: Must be "agents.digitalocean.com/v1alpha1".
+      enum:
+      - agents.digitalocean.com/v1alpha1
+      example: agents.digitalocean.com/v1alpha1
+    kind:
+      type: string
+      description: Must be "Agent".
+      enum:
+      - Agent
+      example: Agent
+    metadata:
+      type: object
+      properties:
+        name:
+          type: string
+          description: 'Optional team-unique session name: 1-64 chars of letters, digits, ''-'', ''.'',
+            ''_'', starting and ending alphanumeric; case-insensitive; must not be UUID-shaped. Omit to
+            have the control plane generate one ("session-<agent-type>-<date-time>"). Unique among the
+            team''s ACTIVE (non-terminal) sessions; destroying a session frees its name for reuse.'
+          example: example
+        description:
+          type: string
+          description: Free-form description (max 1024 chars), stored and echoed back for Console / catalog
+            surfaces.
+          example: example
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+          properties: {}
+    spec:
+      type: object
+      required:
+      - runtime
+      properties:
+        permissions:
+          $ref: '#/permissions'
+        mode:
+          type: string
+          description: Explicit lifecycle discriminator. Defaults to "interactive" (spec.serving forbidden);
+            "served" requires spec.serving.
+          enum:
+          - interactive
+          - served
+          example: interactive
+        runtime:
+          type: object
+          description: 'Canonical adapter ids: claude-code | opencode | codex | cursor | custom. codex-cli
+            and cursor-cli are deprecated aliases (accepted with a create-time warning). The framework
+            adapters (openai-agents, claude-agent-sdk, crewai, langgraph) are declared but not yet supported;
+            CreateSession rejects them. adapter: custom requires the custom block.'
+          required:
+          - adapter
+          properties:
+            adapter:
+              type: string
+              enum:
+              - claude-code
+              - opencode
+              - codex
+              - cursor
+              - custom
+              - codex-cli
+              - cursor-cli
+              - openai-agents
+              - claude-agent-sdk
+              - crewai
+              - langgraph
+              example: claude-code
+            custom:
+              type: object
+              description: 'BYO container; requires adapter: custom. image is required and should be digest-pinned.'
+              required:
+              - image
+              properties:
+                image:
+                  type: string
+                  example: example
+                entrypoint:
+                  type: array
+                  items:
+                    type: string
+                    example: example
+                  example:
+                  - example
+        workspace:
+          type: object
+          description: Repositories the session works against.
+          properties:
+            repos:
+              type: array
+              description: GitHub OWNER/REPO entries, unique. The first entry becomes the session's repo_hint;
+                the full list is the forward shape for multi-repo sessions.
+              items:
+                type: string
+                example: example
+              example:
+              - example
+        sandbox:
+          type: object
+          properties:
+            template:
+              type: string
+              description: 'Optional sandbox template. Empty (or the legacy placeholder "coding") means
+                "no preference": the template derives from the adapter.'
+              example: example
+            persistentWorkspace:
+              type: boolean
+              example: true
+            idleTimeoutSeconds:
+              type: integer
+              format: int64
+              description: Inactivity suspend timeout. 0 means tenant policy default.
+              example: 1
+            maxLifetimeSeconds:
+              type: integer
+              format: int64
+              description: Hard wall-clock ceiling for the whole session, independent of activity. Accepted,
+                not yet enforced (returns a warning).
+              example: 1
+            sizeSlug:
+              type: string
+              description: 'Requested sandbox size (catalog: GET /v2/agents/sessions/sandbox/sizes). Empty
+                means the service default.'
+              example: example
+            egress:
+              type: object
+              description: 'Requested egress allowlist. A request only: the server intersects it with
+                tenant + platform policy and can only narrow it.'
+              properties:
+                allow:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                    - host
+                    properties:
+                      host:
+                        type: string
+                        example: example
+        model:
+          type: object
+          description: Accepted, not yet enforced (returns a warning). Model routing (Plano); catalog-validated
+            when enforcement lands.
+          properties:
+            default:
+              type: string
+              example: example
+            routing:
+              type: string
+              example: example
+            profile:
+              type: string
+              example: example
+        tools:
+          type: object
+          description: Accepted, not yet enforced (returns a warning). Exactly one of mcpServers or bundle.
+          properties:
+            mcpServers:
+              type: array
+              items:
+                type: object
+                required:
+                - ref
+                properties:
+                  ref:
+                    type: string
+                    example: example
+            bundle:
+              type: string
+              example: example
+        env:
+          type: object
+          description: Non-secret guest env (debug-readable — never put secrets here; use spec.secrets).
+            Reserved platform keys (TEAM_ID, SESSION_ID, SANDBOX_ID, CONTROL_PLANE_CALLBACK_URL, SANDBOX_TEMPLATE,
+            SANDBOX_AGENT_WORKDIR, SIZE_SLUG, SANDBOX_IMAGE_ID, SANDBOX_OCI_REF, PLANO_PERMISSION_*) are
+            rejected. Credential-looking values (dop_v1_..., sk-..., ghp_...) trigger a create-time warning.
+          additionalProperties:
+            type: string
+          properties: {}
+        memory:
+          type: object
+          description: Accepted, not yet enforced (returns a warning).
+          required:
+          - backend
+          properties:
+            backend:
+              type: string
+              example: example
+            scope:
+              type: string
+              enum:
+              - tenant
+              - user
+              - agent
+              - session
+              example: tenant
+        secrets:
+          type: array
+          description: Accepted, not yet enforced (returns a warning). Brokered (non-plaintext) credential
+            requests resolved by the IAM / OAuth broker / credential vault; never carried inline in the
+            manifest. source oauth requires provider; source tenantSecret requires ref.
+          items:
+            type: object
+            required:
+            - name
+            - source
+            properties:
+              name:
+                type: string
+                example: example
+              source:
+                type: string
+                enum:
+                - oauth
+                - tenantSecret
+                example: oauth
+              provider:
+                type: string
+                example: example
+              ref:
+                type: string
+                example: example
+        defaults:
+          type: object
+          properties:
+            budget:
+              type: object
+              description: Accepted, not yet enforced (returns a warning). Advisory per-run ceilings,
+                clamped server-side to tenant policy.
+              properties:
+                maxCostUSD:
+                  type: number
+                  example: 1.0
+                maxSteps:
+                  type: integer
+                  example: 1
+                maxWallClockSeconds:
+                  type: integer
+                  format: int64
+                  example: 1
+                onBreach:
+                  type: string
+                  enum:
+                  - pause
+                  - humanInput
+                  - fail
+                  example: pause
+        serving:
+          type: object
+          description: Present only when spec.mode is "served" (autoscaled fleet).
+          properties:
+            minReplicas:
+              type: integer
+              example: 1
+            maxReplicas:
+              type: integer
+              example: 1
+            targetConcurrency:
+              type: integer
+              example: 1
+            scaleToZero:
+              type: object
+              properties:
+                idleSeconds:
+                  type: integer
+                  format: int64
+                  example: 1
+create_session_definition_request:
+  type: object
+  additionalProperties: false
+  required:
+  - name
+  - definition_id
+  properties:
+    name:
+      type: string
+      minLength: 1
+      maxLength: 64
+      description: Session name, independent of the definition name. Must satisfy the existing agents.yaml
+        metadata.name rules and must not be UUID-shaped.
+      example: demo-agent
+    definition_id:
+      type: string
+      format: uuid
+      example: 11111111-2222-3333-4444-555555555555
+    revision_id:
+      type: string
+      format: uuid
+      description: Public immutable revision UUID. Omit to pin the definition's current revision.
+      example: 11111111-2222-3333-4444-555555555555
+    credential_binding_set_id:
+      type: string
+      format: uuid
+      description: Required exactly when the selected revision declares logical credential slots.
+      example: 11111111-2222-3333-4444-555555555555
+    origin:
+      $ref: '#/session_origin_request'
+  description: Strict application/json CreateSession form. The HTTP body is capped at 16 KiB and cannot
+    carry team identity, inline manifests, or credential values.
+create_session_response:
+  type: object
+  properties:
+    session:
+      $ref: '#/session'
+error:
+  type: object
+  description: Standard JSON error envelope written by the API on non-2xx responses.
+  properties:
+    error:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+          description: Echoes the HTTP status code.
+          example: 1
+        message:
+          type: string
+          description: Client-safe error message.
+          example: example
+get_session_response:
+  type: object
+  properties:
+    session:
+      $ref: '#/session'
+hitl_outcome:
+  type: string
+  enum:
+  - HITL_OUTCOME_UNSPECIFIED
+  - HITL_OUTCOME_APPROVE
+  - HITL_OUTCOME_REJECT
+  - HITL_OUTCOME_DEFER
+  default: HITL_OUTCOME_UNSPECIFIED
+  description: HITLOutcome is the user's decision on a HITL request. DEFER backs off this attempt without
+    treating it as a rejection.
+  example: HITL_OUTCOME_UNSPECIFIED
+list_sessions_response:
+  type: object
+  properties:
+    sessions:
+      type: array
+      items:
+        $ref: '#/session'
+    next_page_token:
+      type: string
+      description: Opaque cursor for the next page. Empty when there are no further pages.
+      example: example
+permission_filesystem:
+  type: object
+  description: Filesystem boundary, enforced by the microVM (read-only root + bind-mounted writable roots)
+    for every agent.
+  properties:
+    mode:
+      type: string
+      enum:
+      - read-only
+      - workspace-write
+      example: read-only
+    allowWrite:
+      type: array
+      description: Additional writable paths beyond the workspace. Values must not contain shell-style
+        ${VAR}/$VAR expansions.
+      items:
+        type: string
+        example: example
+      example:
+      - example
+permission_network:
+  type: object
+  description: Network boundary. Narrows (subtract-only) spec.sandbox.egress; link-local/internal addresses
+    stay blocked by the broader egress policy.
+  properties:
+    default:
+      type: string
+      enum:
+      - allow
+      - deny
+      example: allow
+    allow:
+      type: array
+      items:
+        type: string
+        example: example
+      example:
+      - example
+permission_rule:
+  type: object
+  required:
+  - tool
+  - action
+  properties:
+    tool:
+      type: string
+      description: Tool taxonomy this rule matches (e.g. bash, file.read, file.write, web.fetch, git.*,
+        mcp).
+      example: example
+    match:
+      type: object
+      description: 'Optional keys narrowing the rule (e.g. {"command": "npm run deploy"} for bash). Values
+        are globs and must not contain shell-style ${VAR}/$VAR expansions.'
+      additionalProperties:
+        type: string
+      properties: {}
+    action:
+      type: string
+      enum:
+      - allow
+      - ask
+      - deny
+      example: allow
+    enforcement:
+      type: string
+      description: What happens when the agent cannot enforce the rule exactly. "strict" rejects the session;
+        "best-effort" degrades to the closest more-restrictive form and warns (never widens). Defaults
+        to strict for deny rules, best-effort otherwise.
+      enum:
+      - strict
+      - best-effort
+      example: strict
+permissions:
+  type: object
+  description: 'Customer-declared tool-execution permission policy (spec.permissions). REQUEST only: the
+    policy engine resolves it (∩ tenant ∩ platform) into the canonical policy and validates it against
+    the (agent, version) capability descriptor. Absent or empty means the agent keeps its built-in default
+    gating — no policy is shipped to the sandbox.'
+  properties:
+    defaultAction:
+      type: string
+      description: Disposition for tool calls that match no rule. Defaults to "ask" when omitted.
+      enum:
+      - allow
+      - ask
+      - deny
+      example: allow
+    rules:
+      type: array
+      description: 'Ordered match→action rules. Declared order is authoritative: the LAST matching rule
+        wins (author-order last-match).'
+      items:
+        $ref: '#/permission_rule'
+    filesystem:
+      $ref: '#/permission_filesystem'
+    network:
+      $ref: '#/permission_network'
+resolution_source:
+  type: string
+  enum:
+  - RESOLUTION_SOURCE_UNSPECIFIED
+  - RESOLUTION_SOURCE_INLINE_KEYSTROKE
+  - RESOLUTION_SOURCE_OUT_OF_BAND
+  default: RESOLUTION_SOURCE_UNSPECIFIED
+  description: How a HITL resolution was triggered. Defaults to RESOLUTION_SOURCE_OUT_OF_BAND when omitted.
+  example: RESOLUTION_SOURCE_UNSPECIFIED
+resolve_hitl_request:
+  type: object
+  properties:
+    outcome:
+      $ref: '#/hitl_outcome'
+    reason:
+      type: string
+      description: Optional free-text reason. Captured in the audit trail; not interpreted.
+      example: example
+    source:
+      $ref: '#/resolution_source'
+  required:
+  - outcome
+resolved_rule:
+  type: object
+  description: A rule after resolution (∩ tenant ∩ platform), carrying a stable id for audit correlation.
+  properties:
+    id:
+      type: string
+      description: Stable rule id assigned during resolution; correlates with the PolicyDenied event's
+        matched rule.
+      example: example
+    tool:
+      type: string
+      example: example
+    match:
+      type: object
+      additionalProperties:
+        type: string
+      properties: {}
+    action:
+      type: string
+      enum:
+      - allow
+      - ask
+      - deny
+      example: allow
+    enforcement:
+      type: string
+      enum:
+      - strict
+      - best-effort
+      example: strict
+rule_verdict:
+  type: object
+  description: Validation outcome for one resolved rule.
+  properties:
+    rule:
+      $ref: '#/resolved_rule'
+    verdict:
+      type: string
+      description: exact — enforced precisely as written; degraded — renderable only in a more-restrictive
+        form (deny→ask), warned; unsupported — cannot be enforced (strict ⇒ session reject); unverified
+        — no descriptor available, rendered conservatively but unproven.
+      enum:
+      - exact
+      - degraded
+      - unsupported
+      - unverified
+      example: exact
+    rendered:
+      type: string
+      description: 'The disposition the agent will actually enforce: the requested action when exact/unverified,
+        the more-restrictive target when degraded, omitted when unsupported (cannot render).'
+      enum:
+      - allow
+      - ask
+      - deny
+      example: allow
+    reason:
+      type: string
+      description: Human-readable explanation of the verdict.
+      example: example
+    suggestion:
+      type: string
+      description: 'Optional actionable hint (e.g. "set enforcement: best-effort, or target a capable
+        agent").'
+      example: example
+sandbox_size:
+  type: object
+  description: A customer-selectable sandbox (microVM) size.
+  properties:
+    slug:
+      type: string
+      description: DO size slug; submit as spec.sandbox.sizeSlug on CreateSession. e.g. "mv-2vcpu-4gb".
+      example: example
+    vcpus:
+      type: integer
+      format: int64
+      description: vCPU count (for display).
+      example: 1
+    memory_mb:
+      type: integer
+      format: int64
+      description: Memory in MB (for display).
+      example: 1
+sandbox_sizes_response:
+  type: object
+  description: Response for ListSandboxSizes.
+  properties:
+    sizes:
+      type: array
+      description: Selectable sizes, ordered smallest-to-largest.
+      items:
+        $ref: '#/sandbox_size'
+send_input_request:
+  type: object
+  properties:
+    text:
+      type: string
+      description: The user message to deliver into the session. Required and non-empty.
+      example: example
+  required:
+  - text
+send_input_response:
+  type: object
+  properties:
+    run_id:
+      type: string
+      description: The run id the input was attributed to. Clients can correlate against the run.started
+        event on the stream. May be empty if OHR returned no run id.
+      example: example
+session:
+  type: object
+  description: Session is the user-facing record of a managed agent + sandbox pair.
+  properties:
+    session_id:
+      type: string
+      example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    name:
+      type: string
+      description: User-assignable display name, unique per team among non-terminal sessions. Usable in
+        place of session_id by clients (doctl / Console resolve it to the id via the ListSessions ?name=
+        filter; the {session_id} path stays UUID-only). Supplied via the agents.yaml metadata.name, or
+        auto-generated ("session-<agent-type>-<date-time>") when omitted.
+      example: demo-agent
+    team_id:
+      type: integer
+      format: int64
+      description: DO Team ID (unsigned 64-bit; serialized as a JSON number).
+      example: 123456
+    agent_kind:
+      $ref: '#/agent_kind'
+    status:
+      $ref: '#/session_status'
+    sandbox_id:
+      type: string
+      description: Sandbox identity for support / debugging. Informational; omitted until a sandbox is
+        allocated.
+      example: sbx_abc123
+    created_at:
+      type: string
+      format: date-time
+      example: '2026-07-27T12:00:00Z'
+    last_event_at:
+      type: string
+      format: date-time
+      description: Timestamp of the most recent event in this session's canonical stream. Drives the inactivity
+        policy that destroys idle sessions.
+      example: '2026-07-27T12:00:00Z'
+    repo_hint:
+      type: string
+      description: Optional repository hint supplied at session creation (first spec.workspace.repos entry
+        of the manifest). Not authoritative; the agent may change repos in-session.
+      example: github.com/digitalocean/example
+    warnings:
+      type: array
+      items:
+        type: string
+        example: example
+      description: 'Non-fatal advisories computed from the manifest at create time: one entry per populated
+        accepted-but-not-yet-enforced section (spec.secrets, spec.model, spec.tools, spec.memory, spec.defaults.budget,
+        spec.sandbox.maxLifetimeSeconds), a deprecation entry when an adapter alias (codex-cli, cursor-cli)
+        is used, and a heuristic entry per credential-looking spec.env value. Populated on the CreateSession
+        response only.'
+      example:
+      - example
+    definition_id:
+      type: string
+      format: uuid
+      description: Durable Agent Definition UUID. Absent for inline-manifest sessions.
+      example: 11111111-2222-3333-4444-555555555555
+    revision_id:
+      type: string
+      format: uuid
+      description: Immutable revision UUID selected for this execution.
+      example: 11111111-2222-3333-4444-555555555555
+    credential_binding_set_id:
+      type: string
+      format: uuid
+      description: Binding-set UUID used for this execution. Secret-manager metadata and OAuth assignment
+        UUIDs are never returned.
+      example: 11111111-2222-3333-4444-555555555555
+    origin:
+      $ref: '#/session_origin'
+session_origin:
+  type: object
+  additionalProperties: false
+  description: Server-returned product workflow provenance.
+  required:
+  - product
+  properties:
+    product:
+      type: string
+      enum:
+      - direct
+      - simulation
+      - evaluation
+      example: direct
+    resource_id:
+      type: string
+      minLength: 1
+      maxLength: 255
+      pattern: ^[A-Za-z0-9][A-Za-z0-9._:/-]{0,254}$
+      description: Opaque product-owned correlation identifier (external_id).
+      example: sim-run-123
+    verified:
+      type: boolean
+      readOnly: true
+      description: True only when OHS established this claim through a trusted product adapter.
+      example: true
+session_origin_request:
+  type: object
+  additionalProperties: false
+  description: Product workflow provenance. Omission creates a verified direct session. Simulation and
+    evaluation require resource_id; direct forbids it.
+  required:
+  - product
+  properties:
+    product:
+      type: string
+      enum:
+      - direct
+      - simulation
+      - evaluation
+      description: Workflow that created the session.
+      example: direct
+    resource_id:
+      type: string
+      minLength: 1
+      maxLength: 255
+      pattern: ^[A-Za-z0-9][A-Za-z0-9._:/-]{0,254}$
+      description: Opaque product-owned correlation identifier (external_id). Required for simulation/evaluation
+        and forbidden for direct.
+      example: sim-run-123
+session_status:
+  type: string
+  enum:
+  - SESSION_STATUS_UNSPECIFIED
+  - SESSION_STATUS_PROVISIONING
+  - SESSION_STATUS_READY
+  - SESSION_STATUS_DETACHED
+  - SESSION_STATUS_DESTROYING
+  - SESSION_STATUS_DESTROYED
+  - SESSION_STATUS_FAILED
+  - SESSION_STATUS_PAUSED
+  default: SESSION_STATUS_UNSPECIFIED
+  description: SessionStatus is the lifecycle state of the sandbox + agent pair.
+  example: SESSION_STATUS_UNSPECIFIED
+stream_event:
+  type: object
+  description: The JSON payload carried in each SSE event's `data:` field (canonical SPI event envelope).
+    The SSE `event:` field repeats `type`, and the `id:` field repeats `event_id`.
+  properties:
+    event_id:
+      type: string
+      example: example
+    run_id:
+      type: string
+      example: example
+    tenant_id:
+      type: string
+      description: DO Team ID rendered as a decimal string.
+      example: example
+    session_id:
+      type: string
+      example: example
+    trace_parent:
+      type: string
+      example: example
+    timestamp:
+      type: string
+      format: date-time
+      example: '2026-07-27T12:00:00Z'
+    seq:
+      type: integer
+      format: int64
+      description: Producer-supplied sequence number; nonzero values increase monotonically within an
+        ingress stream.
+      example: 1
+    source_event_id:
+      type: string
+      example: example
+    source_event_type:
+      type: string
+      example: example
+    source_tenant_id:
+      type: string
+      description: Optional runtime-native tenant identifier; distinct from authoritative tenant_id.
+      example: example
+    producer:
+      type: string
+      description: Server-assigned component that submitted the event.
+      enum:
+      - agent
+      - ohr
+      - ohp
+      - ohs
+      example: agent
+    definition_id:
+      type: string
+      example: example
+    revision_id:
+      type: string
+      example: example
+    credential_binding_set_id:
+      type: string
+      example: example
+    type:
+      type: string
+      description: Canonical SPI event type. The SSE `event:` field carries the same value.
+      enum:
+      - run.started
+      - run.token_delta
+      - run.tool_call_started
+      - run.tool_call_completed
+      - run.human_input_requested
+      - run.human_input_received
+      - run.completed
+      - run.failed
+      - run.paused
+      - run.resumed
+      - session.updated
+      - run.state_checkpointed
+      - run.handoff
+      - run.usage_recorded
+      - run.sandbox_allocated
+      - run.sandbox_released
+      - run.cost_accrued
+      - run.log
+      - policy.denied
+      example: run.started
+    data:
+      type: object
+      description: 'Type-specific payload, discriminated by `type` (canonical SPI shapes; numeric fields
+        are JSON numbers):
+
+        - run.started: {agent}
+
+        - run.token_delta: {text}
+
+        - run.tool_call_started: {tool_call_id, name, input}
+
+        - run.tool_call_completed: {tool_call_id, ok, duration_ms, summary}
+
+        - run.human_input_requested: {hitl_id, payload}
+
+        - run.human_input_received: {hitl_id, outcome, actor, reason}
+
+        - run.completed: {total_tokens_in, total_tokens_out, run_cost_micros}
+
+        - run.failed: {code, message}
+
+        - run.paused: {reason}
+
+        - run.resumed: {}
+
+        - session.updated: {}
+
+        - run.state_checkpointed: {checkpoint_id, digest}
+
+        - run.handoff: {from, to, description}
+
+        - run.usage_recorded: {step_id, model_id, usage: {input_tokens, output_tokens, cached_input_tokens,
+        reasoning_tokens, tool_seconds}}
+
+        - run.sandbox_allocated: {sandbox_id, kind, template}
+
+        - run.sandbox_released: {sandbox_id, exit_code, duration_ms}
+
+        - run.cost_accrued: {running_total_micros, delta_micros}
+
+        - run.log: {level, message, fields}'
+      properties: {}
+validation_result:
+  type: object
+  description: 'Response of POST /v2/agents/sessions/policy/validate: per-rule verdicts for the (agent,
+    version). The same shape is persisted per session in session_policies.verdicts.'
+  properties:
+    agent:
+      type: string
+      example: example
+    version:
+      type: string
+      example: example
+    ok:
+      type: boolean
+      description: False when any strict rule is unsupported or unverified — i.e. CreateSession would
+        reject this policy for this (agent, version).
+      example: true
+    defaultAction:
+      type: string
+      description: Catch-all disposition AS SHIPPED (after unverified allow→ask downgrade). When defaultActionVerdict
+        is degraded, this remains the shipped value; see defaultActionRendered for what the agent will
+        actually enforce.
+      enum:
+      - allow
+      - ask
+      - deny
+      example: allow
+    defaultActionVerdict:
+      type: string
+      description: exact — agent can enforce the catch-all as written; degraded — agent cannot enforce
+        the requested defaultAction (warn-only; shipped value unchanged); omitted when no descriptor was
+        available to classify against.
+      enum:
+      - exact
+      - degraded
+      - unsupported
+      - unverified
+      example: exact
+    defaultActionRendered:
+      type: string
+      description: 'Disposition the agent will actually enforce as the catch-all: equals defaultAction
+        when exact; the more-restrictive degrade target (usually ask) when degraded.'
+      enum:
+      - allow
+      - ask
+      - deny
+      example: allow
+    defaultActionReason:
+      type: string
+      description: Human-readable explanation when defaultActionVerdict is degraded.
+      example: example
+    verdicts:
+      type: array
+      items:
+        $ref: '#/rule_verdict'
+workspace_part_upload_url:
+  type: object
+  properties:
+    part_number:
+      type: integer
+      format: int32
+      example: 1
+    upload_url:
+      type: string
+      description: Presigned PUT URL for this part. PUT the part bytes here directly.
+      example: example
+workspace_transfer_cancelled:
+  type: object
+  properties:
+    transfer_id:
+      type: string
+      example: example
+    aborted:
+      type: boolean
+      description: True if this call transitioned an active transfer to terminal; false if it was already
+        terminal.
+      example: true
+    status:
+      type: string
+      enum:
+      - pending
+      - in_progress
+      - completed
+      - failed
+      example: pending
+workspace_transfer_created:
+  type: object
+  description: Response to CreateWorkspaceTransfer. Upload responses carry `upload_id`, `part_size`, and
+    `expires_at`; download responses carry only `transfer_id`, `direction`, and `status`.
+  properties:
+    transfer_id:
+      type: string
+      description: Opaque id used on all subsequent calls.
+      example: example
+    direction:
+      type: string
+      enum:
+      - upload
+      - download
+      example: upload
+    status:
+      type: string
+      enum:
+      - pending
+      - in_progress
+      - completed
+      - failed
+      example: pending
+    upload_id:
+      type: string
+      description: Upload only. Multipart upload id (informational).
+      example: example
+    part_size:
+      type: integer
+      format: int64
+      description: Upload only. Split the payload into parts of this size; the last part may be smaller.
+      example: 1
+    expires_at:
+      type: string
+      format: date-time
+      description: Transfer credential window.
+      example: '2026-07-27T12:00:00Z'
+workspace_transfer_status:
+  type: object
+  properties:
+    transfer_id:
+      type: string
+      example: example
+    direction:
+      type: string
+      enum:
+      - upload
+      - download
+      example: upload
+    status:
+      type: string
+      enum:
+      - pending
+      - in_progress
+      - completed
+      - failed
+      example: pending
+    bytes_written:
+      type: integer
+      format: int64
+      example: 1
+    sha256:
+      type: string
+      description: Lowercase hex SHA-256 of the payload, when known. Verify the downloaded object against
+        this.
+      example: example
+    download_url:
+      type: string
+      description: Download + completed only. Presigned GET URL; fetch the object directly.
+      example: example
+    expires_at:
+      type: string
+      format: date-time
+      description: Expiry of download_url when present.
+      example: '2026-07-27T12:00:00Z'
+    error_message:
+      type: string
+      description: Populated when status is failed.
+      example: example
+workspace_upload_committed:
+  type: object
+  properties:
+    transfer_id:
+      type: string
+      example: example
+    status:
+      type: string
+      enum:
+      - pending
+      - in_progress
+      - completed
+      - failed
+      example: pending
+    size_bytes:
+      type: integer
+      format: int64
+      description: Size of the completed staging object, when known.
+      example: 1
+workspace_upload_response:
+  type: object
+  properties:
+    path:
+      type: string
+      description: Absolute guest path the payload was written to.
+      example: example
+    bytes_written:
+      type: integer
+      format: int64
+      description: Number of bytes committed to the workspace.
+      example: 1
+workspace_part_upload_urls:
+  type: object
+  properties:
+    transfer_id:
+      type: string
+      example: example
+    part_urls:
+      type: array
+      items:
+        $ref: '#/workspace_part_upload_url'
+      description: One presigned PUT URL per requested part number, in request order.
+    expires_at:
+      type: string
+      format: date-time
+      description: Shared expiry for all URLs in this batch.
+      example: '2026-07-27T12:00:00Z'

--- a/specification/resources/agents/models/definitions.yml
+++ b/specification/resources/agents/models/definitions.yml
@@ -1119,7 +1119,6 @@ agent_config_credential_slot:
   type: object
   required:
   - name
-  - configured
   properties:
     name:
       type: string
@@ -1133,9 +1132,6 @@ agent_config_credential_slot:
     provider:
       type: string
       example: openai
-    configured:
-      type: boolean
-      example: true
 agent_config:
   type: object
   description: Immutable team-scoped Agent Config: one sanitized manifest per config. There is no update;
@@ -1184,7 +1180,7 @@ agent_config:
       example: '2026-08-01T12:00:00Z'
     credentials:
       type: array
-      description: Redacted credential slot metadata (name/source/configured). Secret values are never
+      description: Redacted credential slot metadata (name/source/provider). Secret values are never
         included.
       items:
         $ref: '#/agent_config_credential_slot'

--- a/specification/resources/agents/models/definitions.yml
+++ b/specification/resources/agents/models/definitions.yml
@@ -1074,3 +1074,175 @@ workspace_part_upload_urls:
       format: date-time
       description: Shared expiry for all URLs in this batch.
       example: '2026-07-27T12:00:00Z'
+agent_config_summary:
+  type: object
+  description: Lightweight list representation; the manifest is available from config reads, not list
+    responses.
+  required:
+  - id
+  - name
+  - agentspec_schema_version
+  - content_hash
+  - created_by
+  - created_at
+  - updated_at
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: 019fb39c-14d9-7080-933e-b9b90e25acda
+    name:
+      type: string
+      example: support-agent
+    agentspec_schema_version:
+      type: string
+      description: Validated agentspec apiVersion, currently agents.digitalocean.com/v1alpha1.
+      example: agents.digitalocean.com/v1alpha1
+    content_hash:
+      type: string
+      pattern: ^[0-9a-f]{64}$
+      description: Lowercase SHA-256 hex digest of the canonical sanitized manifest JSON.
+      example: 75803fef24dc731824ecd4a1853c76153c7d8503534092b94da3ca3f31a882f4
+    created_by:
+      type: string
+      description: Authenticated user identity that created the config.
+      example: user-1
+    created_at:
+      type: string
+      format: date-time
+      example: '2026-08-01T12:00:00Z'
+    updated_at:
+      type: string
+      format: date-time
+      example: '2026-08-01T12:00:00Z'
+agent_config_credential_slot:
+  type: object
+  required:
+  - name
+  - configured
+  properties:
+    name:
+      type: string
+      example: OPENAI_API_KEY
+    source:
+      type: string
+      enum:
+      - tenantSecret
+      - oauth
+      example: tenantSecret
+    provider:
+      type: string
+      example: openai
+    configured:
+      type: boolean
+      example: true
+agent_config:
+  type: object
+  description: Immutable team-scoped Agent Config: one sanitized manifest per config. There is no update;
+    clone to a new config to change content.
+  required:
+  - id
+  - name
+  - agentspec_schema_version
+  - manifest
+  - content_hash
+  - created_by
+  - created_at
+  - updated_at
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: 019fb39c-14d9-7080-933e-b9b90e25acda
+    name:
+      type: string
+      example: support-agent
+    agentspec_schema_version:
+      type: string
+      description: Validated agentspec apiVersion, currently agents.digitalocean.com/v1alpha1.
+      example: agents.digitalocean.com/v1alpha1
+    manifest:
+      type: object
+      additionalProperties: true
+      description: Canonical runnable Agent manifest JSON, immutable after create.
+    content_hash:
+      type: string
+      pattern: ^[0-9a-f]{64}$
+      description: Lowercase SHA-256 hex digest of the canonical sanitized manifest JSON.
+      example: 75803fef24dc731824ecd4a1853c76153c7d8503534092b94da3ca3f31a882f4
+    created_by:
+      type: string
+      description: Authenticated user identity that created the config.
+      example: user-1
+    created_at:
+      type: string
+      format: date-time
+      example: '2026-08-01T12:00:00Z'
+    updated_at:
+      type: string
+      format: date-time
+      example: '2026-08-01T12:00:00Z'
+    credentials:
+      type: array
+      description: Redacted credential slot metadata (name/source/configured). Secret values are never
+        included.
+      items:
+        $ref: '#/agent_config_credential_slot'
+agent_config_response:
+  type: object
+  properties:
+    config:
+      $ref: '#/agent_config'
+list_agent_configs_response:
+  type: object
+  properties:
+    configs:
+      type: array
+      items:
+        $ref: '#/agent_config_summary'
+    next_page_token:
+      type: string
+      example: ''
+agent_config_create_request:
+  type: object
+  additionalProperties: false
+  description: Unified Agent Config create body. secrets/oauth_assignments are write-only and never returned.
+  required:
+  - name
+  - manifest_yaml
+  properties:
+    name:
+      type: string
+      minLength: 1
+      maxLength: 64
+      pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]{0,62}[A-Za-z0-9])?$
+      description: Config name, case-insensitively unique among the team's active configs.
+      example: support-agent
+    manifest_yaml:
+      type: string
+      maxLength: 524288
+      description: Customer agents.yaml text. The HTTP JSON body is capped at 1 MiB and this field is capped
+        at 512 KiB.
+      example: |
+        apiVersion: agents.digitalocean.com/v1alpha1
+        kind: Agent
+        spec:
+          runtime:
+            adapter: opencode
+    secrets:
+      type: object
+      maxProperties: 32
+      description: Write-only map from tenantSecret logical slot to plaintext. Stored in Secrets Manager;
+        never returned.
+      additionalProperties:
+        type: string
+        minLength: 1
+        maxLength: 32768
+    oauth_assignments:
+      type: object
+      maxProperties: 32
+      description: Write-only map from oauth logical slot to an OAuth assignment UUID. Never returned.
+      additionalProperties:
+        type: string
+        format: uuid
+


### PR DESCRIPTION
## Summary
- Add `/v2/agents/configs` list/create, `/v2/agents/configs/{config_id}` get/delete, and `/v2/agents/configs/{config_id}/sessions`
- Models + curl samples mirror harness-api `harness.swagger.json` Agent Configs surface
- Stacks on Hosted Agents sessions Origin OpenAPI (MARSOHS-551)

## Test plan
- [ ] Spec CI / spectral as configured for this repo
- [x] Paths mirror live harness swagger used by local `:8080` stack

## Notes
- Clone endpoint deferred until harness PR 739
- List search deferred to MARSOHS-774
- pydo regen depends on this PR landing (or local `SPEC_FILE=... make generate`)


Made with [Cursor](https://cursor.com)