### PR TITLE
Fix list backups response description key (ADVMY-10)

### DIFF
--- a/specification/resources/databases/responses/database_backups.yml
+++ b/specification/resources/databases/responses/database_backups.yml
@@ -1,4 +1,4 @@
-description: A JSON object with a key of `database_backups`.
+description: A JSON object with a key of `backups`.
 
 headers:
   ratelimit-limit:


### PR DESCRIPTION
## Summary
- Corrects the OpenAPI response description for `GET /v2/databases/{id}/backups` to say the JSON key is `backups` (schema, examples, and godo already use `backups`).
- Addresses the docs mismatch called out in ADVMY-10; no API/schema rename.

## Test plan
- [x] `make bundle` regenerates with description `A JSON object with a key of \`backups\`.`
- [x] `make lint` — 0 errors (pre-existing warnings only)
- [x] Confirmed `required: [backups]` and example unchanged