### PR TITLE
Fix required scope names on twelve endpoints

### DIFF
--- a/specification/resources/byoip_prefixes/byoip_prefixes_update.yml
+++ b/specification/resources/byoip_prefixes/byoip_prefixes_update.yml
@@ -51,4 +51,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-      - "byoip_prefix:write"
+      - "byoip_prefix:update"

--- a/specification/resources/databases/databases_update_kafka_schema_config.yml
+++ b/specification/resources/databases/databases_update_kafka_schema_config.yml
@@ -56,4 +56,4 @@ responses:
 
 security:
   - bearer_auth:
-      - "database:write"
+      - "database:update"

--- a/specification/resources/databases/databases_update_kafka_schema_subject_config.yml
+++ b/specification/resources/databases/databases_update_kafka_schema_subject_config.yml
@@ -57,4 +57,4 @@ responses:
 
 security:
   - bearer_auth:
-      - "database:write"
+      - "database:update"

--- a/specification/resources/dedicated_inferences/dedicated_inferences_tokens_create.yml
+++ b/specification/resources/dedicated_inferences/dedicated_inferences_tokens_create.yml
@@ -39,4 +39,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'dedicated_inference_tokens:create'
+    - 'dedicated_inference_token:create'

--- a/specification/resources/dedicated_inferences/dedicated_inferences_tokens_delete.yml
+++ b/specification/resources/dedicated_inferences/dedicated_inferences_tokens_delete.yml
@@ -39,4 +39,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'dedicated_inference_tokens:delete'
+    - 'dedicated_inference_token:delete'

--- a/specification/resources/dedicated_inferences/dedicated_inferences_tokens_list.yml
+++ b/specification/resources/dedicated_inferences/dedicated_inferences_tokens_list.yml
@@ -34,4 +34,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'dedicated_inference_tokens:read'
+    - 'dedicated_inference_token:read'

--- a/specification/resources/gen-ai/genai_update_custom_model_metadata.yml
+++ b/specification/resources/gen-ai/genai_update_custom_model_metadata.yml
@@ -39,7 +39,7 @@ responses:
     $ref: ../../shared/responses/unexpected_error.yml
 security:
 - bearer_auth:
-  - genai:default
+  - genai:update
 summary: Update Custom Model Metadata
 tags:
 - GradientAI Platform

--- a/specification/resources/nfs/nfs_access_point_list.yml
+++ b/specification/resources/nfs/nfs_access_point_list.yml
@@ -56,4 +56,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-      - "nfs:list"
+      - "nfs:read"

--- a/specification/resources/nfs/nfs_list.yml
+++ b/specification/resources/nfs/nfs_list.yml
@@ -37,4 +37,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-      - "nfs:list"
+      - "nfs:read"

--- a/specification/resources/nfs/nfs_snapshot_list.yml
+++ b/specification/resources/nfs/nfs_snapshot_list.yml
@@ -40,4 +40,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-      - "nfs:list"
+      - "nfs:read"

--- a/specification/resources/organizations/organizations_list_teams.yml
+++ b/specification/resources/organizations/organizations_list_teams.yml
@@ -38,4 +38,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'organization:read'
+    - 'organization_membership:read_teams'

--- a/specification/resources/partner_network_connect/partner_attachment_service_key_create.yml
+++ b/specification/resources/partner_network_connect/partner_attachment_service_key_create.yml
@@ -39,4 +39,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-      - partner_network_connect:write
+      - partner_network_connect:update


### PR DESCRIPTION
## Human summary

These inconsistencies were found while working on product docs updates for doctl command permission scopes (PDOCS-4599). An agent facilitated the permissions consistency search and verification.

## Summary

Twelve API operations declare `security` scopes that do not exist in the IAM permissions catalog. Anyone following the API reference to build a custom-scoped token for these endpoints ends up with a name they cannot select. This PR replaces each one with the correct scope.

| File | Was | Now |
|---|---|---|
| `nfs/nfs_list.yml`, `nfs_snapshot_list.yml`, `nfs_access_point_list.yml` | `nfs:list` | `nfs:read` |
| `databases/databases_update_kafka_schema_config.yml`, `..._subject_config.yml` | `database:write` | `database:update` |
| `gen-ai/genai_update_custom_model_metadata.yml` | `genai:default` | `genai:update` |
| `byoip_prefixes/byoip_prefixes_update.yml` | `byoip_prefix:write` | `byoip_prefix:update` |
| `partner_network_connect/partner_attachment_service_key_create.yml` | `partner_network_connect:write` | `partner_network_connect:update` |
| `dedicated_inferences/dedicated_inferences_tokens_{list,create,delete}.yml` | `dedicated_inference_tokens:*` | `dedicated_inference_token:*` |
| `organizations/organizations_list_teams.yml` | `organization:read` | `organization_membership:read_teams` |

## How the new values were verified

Each endpoint was called against production with custom-scoped personal access tokens:

- With a token holding only `account:read`, all twelve endpoints returned 403.
- With a token holding the scopes above,  all twelve endpoints were authorized.
- The partner network connect service names the missing scope in its 403 body (`you are missing the required permission partner_network_connect:update`), which is how that one was pinned down.
- `GET /v2/organizations/teams` returned 200 with a token holding only `organization_membership:read_teams`. That scope is only offered to Organization Admin, Owner, and Biller roles.

